### PR TITLE
rocFile: Use platform-independent hoff_t

### DIFF
--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -36,6 +36,12 @@ if(BUILD_ROCFILE OR BUILD_HIPFILE)
         )
     endif()
 
+    # Always install the hipfile-types.h file
+    rocm_install(
+        FILES ${CMAKE_SOURCE_DIR}/shared/hipfile-types.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+
     # rocm_package_add_dependencies() line should go here
     # when we have dependencies
 

--- a/hipfile/include/hipfile.h
+++ b/hipfile/include/hipfile.h
@@ -14,6 +14,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <hipfile-types.h>
+
 #if defined(__GNUC__)
 #define HIPFILE_API __attribute__((visibility("default")))
 #else
@@ -84,20 +86,6 @@ extern "C" {
  * @ingroup core
  */
 #define HIPFILE_VERSION_PATCH 0
-
-// ***********************************************************************
-//  PLATFORM-INDEPENDENT TYPES
-// ***********************************************************************
-
-/*!
- * @brief Platform-independent offset type
- * @ingroup core
- */
-#ifndef _WIN32
-typedef off_t hoff_t;
-#else
-typedef __int64 hoff_t;
-#endif
 
 // ***********************************************************************
 //  ERROR HANDLING

--- a/rocfile/include/rocfile.h
+++ b/rocfile/include/rocfile.h
@@ -14,6 +14,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <hipfile-types.h>
+
 #if defined(__GNUC__)
 #define ROCFILE_API __attribute__((visibility("default")))
 #else
@@ -405,15 +407,15 @@ typedef struct rocFileFSOps {
     /*!
      * Get the assigned priority of a RDMA device. If -1, there is no preference.
      */
-    int (*getRDMADevicePriority)(void *handle, char *, size_t, off_t, struct sockaddr *hostaddr);
+    int (*getRDMADevicePriority)(void *handle, char *, size_t, hoff_t, struct sockaddr *hostaddr);
     /*!
      * Read from the remote filesystem. If NULL, use the Linux VFS.
      */
-    ssize_t (*read)(void *handle, char *, size_t, off_t, rocFileRDMAInfo_t *);
+    ssize_t (*read)(void *handle, char *, size_t, hoff_t, rocFileRDMAInfo_t *);
     /*!
      * Write to the remote filesystem. If NULL, use the Linux VFS.
      */
-    ssize_t (*write)(void *handle, const char *, size_t, off_t, rocFileRDMAInfo_t *);
+    ssize_t (*write)(void *handle, const char *, size_t, hoff_t, rocFileRDMAInfo_t *);
 } rocFileFSOps_t;
 
 /*!
@@ -521,8 +523,8 @@ rocFileError_t rocFileBufDeregister(const void *buffer_base);
  * @return else:    Negative value of the related rocFileOpError_t
  */
 ROCFILE_API
-ssize_t rocFileRead(rocFileHandle_t fh, void *buffer_base, size_t size, off_t file_offset,
-                    off_t buffer_offset);
+ssize_t rocFileRead(rocFileHandle_t fh, void *buffer_base, size_t size, hoff_t file_offset,
+                    hoff_t buffer_offset);
 
 /*!
  * @brief Synchronously write data from a GPU buffer to a file
@@ -539,8 +541,8 @@ ssize_t rocFileRead(rocFileHandle_t fh, void *buffer_base, size_t size, off_t fi
  * @return else:    Negative value of the related rocFileOpError_t
  */
 ROCFILE_API
-ssize_t rocFileWrite(rocFileHandle_t fh, const void *buffer_base, size_t size, off_t file_offset,
-                     off_t buffer_offset);
+ssize_t rocFileWrite(rocFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
+                     hoff_t buffer_offset);
 
 // ***********************************************************************
 //  GPU IO DRIVER API
@@ -832,8 +834,8 @@ rocFileError_t rocFileBatchIODestroy(rocFileBatchHandle_t batch_idp);
  * @return A rocFile error
  */
 ROCFILE_API
-rocFileError_t rocFileReadAsync(rocFileHandle_t fh, void *buffer_base, size_t *size_p, off_t *file_offset_p,
-                                off_t *buffer_offset_p, ssize_t *bytes_read_p, hipStream_t stream);
+rocFileError_t rocFileReadAsync(rocFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *file_offset_p,
+                                hoff_t *buffer_offset_p, ssize_t *bytes_read_p, hipStream_t stream);
 
 /*!
  * @brief Perform an asynchronous write to a stream
@@ -851,8 +853,8 @@ rocFileError_t rocFileReadAsync(rocFileHandle_t fh, void *buffer_base, size_t *s
  * @return A rocFile error
  */
 ROCFILE_API
-rocFileError_t rocFileWriteAsync(rocFileHandle_t fh, void *buffer_base, size_t *size_p, off_t *file_offset_p,
-                                 off_t *buffer_offset_p, ssize_t *bytes_written_p, hipStream_t stream);
+rocFileError_t rocFileWriteAsync(rocFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *file_offset_p,
+                                 hoff_t *buffer_offset_p, ssize_t *bytes_written_p, hipStream_t stream);
 
 /*!
  * @brief Register a stream to be used by for asynchronous GPU IO

--- a/rocfile/src/async.cpp
+++ b/rocfile/src/async.cpp
@@ -78,8 +78,8 @@ AsyncMonitor::completion_thread()
 }
 
 AsyncOp::AsyncOp(IoType _io_type, std::shared_ptr<IFile> _file, std::shared_ptr<IBuffer> _buffer,
-                 std::shared_ptr<IStream> _stream, size_t *_size, hoff_t *_file_offset, hoff_t *_buffer_offset,
-                 ssize_t *_bytes_transferred)
+                 std::shared_ptr<IStream> _stream, size_t *_size, hoff_t *_file_offset,
+                 hoff_t *_buffer_offset, ssize_t *_bytes_transferred)
     : io_type{_io_type}, file{_file}, buffer{_buffer}, stream{_stream},
 
       size{stream->fixedIOSize() ? std::variant<size_t, size_t *>{*_size}

--- a/rocfile/src/async.cpp
+++ b/rocfile/src/async.cpp
@@ -78,16 +78,16 @@ AsyncMonitor::completion_thread()
 }
 
 AsyncOp::AsyncOp(IoType _io_type, std::shared_ptr<IFile> _file, std::shared_ptr<IBuffer> _buffer,
-                 std::shared_ptr<IStream> _stream, size_t *_size, off_t *_file_offset, off_t *_buffer_offset,
+                 std::shared_ptr<IStream> _stream, size_t *_size, hoff_t *_file_offset, hoff_t *_buffer_offset,
                  ssize_t *_bytes_transferred)
     : io_type{_io_type}, file{_file}, buffer{_buffer}, stream{_stream},
 
       size{stream->fixedIOSize() ? std::variant<size_t, size_t *>{*_size}
                                  : std::variant<size_t, size_t *>{_size}},
-      file_offset{stream->fixedFileOffset() ? std::variant<const off_t, off_t *>{*_file_offset}
-                                            : std::variant<const off_t, off_t *>{_file_offset}},
-      buffer_offset{stream->fixedBufferOffset() ? std::variant<const off_t, off_t *>{*_buffer_offset}
-                                                : std::variant<const off_t, off_t *>{_buffer_offset}},
+      file_offset{stream->fixedFileOffset() ? std::variant<const hoff_t, hoff_t *>{*_file_offset}
+                                            : std::variant<const hoff_t, hoff_t *>{_file_offset}},
+      buffer_offset{stream->fixedBufferOffset() ? std::variant<const hoff_t, hoff_t *>{*_buffer_offset}
+                                                : std::variant<const hoff_t, hoff_t *>{_buffer_offset}},
       bytes_transferred{_bytes_transferred}
 {
 }

--- a/rocfile/src/async.h
+++ b/rocfile/src/async.h
@@ -22,14 +22,14 @@ namespace rocFile {
 
 class AsyncOp {
 public:
-    const IoType                       io_type;
-    std::shared_ptr<IFile>             file;
-    std::shared_ptr<IBuffer>           buffer;
-    std::shared_ptr<IStream>           stream;
-    std::variant<size_t, size_t *>     size;
-    std::variant<const off_t, off_t *> file_offset;
-    std::variant<const off_t, off_t *> buffer_offset;
-    ssize_t *const                     bytes_transferred;
+    const IoType                         io_type;
+    std::shared_ptr<IFile>               file;
+    std::shared_ptr<IBuffer>             buffer;
+    std::shared_ptr<IStream>             stream;
+    std::variant<size_t, size_t *>       size;
+    std::variant<const hoff_t, hoff_t *> file_offset;
+    std::variant<const hoff_t, hoff_t *> buffer_offset;
+    ssize_t *const                       bytes_transferred;
 
     AsyncOp(const AsyncOp &)            = delete;
     AsyncOp &operator=(const AsyncOp &) = delete;
@@ -38,7 +38,7 @@ public:
     virtual ~AsyncOp();
 
     AsyncOp(IoType ioType, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
-            std::shared_ptr<IStream> stream, size_t *size, off_t *file_offset, off_t *buffer_offset,
+            std::shared_ptr<IStream> stream, size_t *size, hoff_t *file_offset, hoff_t *buffer_offset,
             ssize_t *bytes_transferred);
 };
 

--- a/rocfile/src/backend.h
+++ b/rocfile/src/backend.h
@@ -40,7 +40,7 @@ struct Backend {
     /// @param buffer_offset  Offset from the start of the buffer
     /// @return
     virtual int score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
-                      off_t file_offset, off_t buffer_offset) const = 0;
+                      hoff_t file_offset, hoff_t buffer_offset) const = 0;
 
     /// @brief Perform a read or write operation
     ///
@@ -55,7 +55,7 @@ struct Backend {
     ///
     /// @throws Hip::RuntimeError Sys::RuntimeError
     virtual ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
-                       off_t file_offset, off_t buffer_offset) = 0;
+                       hoff_t file_offset, hoff_t buffer_offset) = 0;
 };
 
 }

--- a/rocfile/src/backend/asyncop-fallback.cpp
+++ b/rocfile/src/backend/asyncop-fallback.cpp
@@ -25,7 +25,7 @@ hipHostDeleter(void *buffer)
 
 AsyncOpFallback::AsyncOpFallback(IoType _io_type, std::shared_ptr<IFile> _file,
                                  std::shared_ptr<IBuffer> _buffer, std::shared_ptr<IStream> _stream,
-                                 size_t *_size, off_t *_file_offset, off_t *_buffer_offset,
+                                 size_t *_size, hoff_t *_file_offset, hoff_t *_buffer_offset,
                                  ssize_t *_bytes_transferred)
     : AsyncOp{_io_type, _file, _buffer, _stream, _size, _file_offset, _buffer_offset, _bytes_transferred},
       bytes_transferred_internal{0}, gpu_buffer{buffer->getBuffer()}, bounce_buffer_dev_ptr{nullptr},

--- a/rocfile/src/backend/asyncop-fallback.h
+++ b/rocfile/src/backend/asyncop-fallback.h
@@ -18,7 +18,7 @@ private:
 
 public:
     AsyncOpFallback(IoType ioType, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
-                    std::shared_ptr<IStream> stream, size_t *size, off_t *fileOffset, off_t *bufferOffset,
+                    std::shared_ptr<IStream> stream, size_t *size, hoff_t *fileOffset, hoff_t *bufferOffset,
                     ssize_t *bytesTransferred);
 
     void *bounceBufferHostPtr();

--- a/rocfile/src/backend/fallback.cpp
+++ b/rocfile/src/backend/fallback.cpp
@@ -19,8 +19,13 @@ using std::unique_ptr;
 static const size_t DefaultChunkSize = 16 * 1024 * 1024;
 
 int
+<<<<<<< HEAD
 Fallback::score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, off_t file_offset,
                 off_t buffer_offset) const
+=======
+Fallback::score(std::shared_ptr<file::IFile> file, std::shared_ptr<buffer::IBuffer> buffer, size_t size,
+                hoff_t file_offset, hoff_t buffer_offset) const
+>>>>>>> 1ff39d2 (rocFile: Use platform-independent hoff_t)
 {
     (void)buffer_offset;
     (void)file;
@@ -31,14 +36,14 @@ Fallback::score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, si
 
 ssize_t
 Fallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
-             off_t file_offset, off_t buffer_offset)
+             hoff_t file_offset, hoff_t buffer_offset)
 {
     return io(type, file, buffer, size, file_offset, buffer_offset, DefaultChunkSize);
 }
 
 ssize_t
 Fallback::io(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
-             off_t file_offset, off_t buffer_offset, size_t chunk_size)
+             hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size)
 {
     size = min(size, rocFile::MAX_RW_COUNT);
 

--- a/rocfile/src/backend/fallback.cpp
+++ b/rocfile/src/backend/fallback.cpp
@@ -19,13 +19,8 @@ using std::unique_ptr;
 static const size_t DefaultChunkSize = 16 * 1024 * 1024;
 
 int
-<<<<<<< HEAD
-Fallback::score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, off_t file_offset,
-                off_t buffer_offset) const
-=======
-Fallback::score(std::shared_ptr<file::IFile> file, std::shared_ptr<buffer::IBuffer> buffer, size_t size,
-                hoff_t file_offset, hoff_t buffer_offset) const
->>>>>>> 1ff39d2 (rocFile: Use platform-independent hoff_t)
+Fallback::score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
+                hoff_t buffer_offset) const
 {
     (void)buffer_offset;
     (void)file;

--- a/rocfile/src/backend/fallback.h
+++ b/rocfile/src/backend/fallback.h
@@ -14,17 +14,18 @@ namespace rocFile {
 struct Fallback : public Backend {
     virtual ~Fallback() override = default;
 
-    int score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, off_t file_offset,
-              off_t buffer_offset) const override;
+    int score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
+              hoff_t buffer_offset) const override;
 
     ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
-               off_t file_offset, off_t buffer_offset) override;
+               hoff_t file_offset, hoff_t buffer_offset) override;
 
     // Once we can import gtest.h and make test suites or test friends everything
     // below here should be made protected.
     // protected:
 
     ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
-               off_t file_offset, off_t buffer_offset, size_t chunk_size);
+               hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size);
 };
+
 }

--- a/rocfile/src/rocfile-private.h
+++ b/rocfile/src/rocfile-private.h
@@ -18,4 +18,4 @@ ROCFILE_API
 void rocFileEnsureDriverInitPrivate();
 
 ssize_t rocFileIo(rocFile::IoType type, rocFileHandle_t fh, const void *buffer_base, size_t size,
-                  off_t file_offset, off_t buffer_offset);
+                  hoff_t file_offset, hoff_t buffer_offset);

--- a/rocfile/src/rocfile.cpp
+++ b/rocfile/src/rocfile.cpp
@@ -225,8 +225,8 @@ catch (...) {
 }
 
 ssize_t
-rocFileIo(IoType type, rocFileHandle_t fh, const void *buffer_base, size_t size, off_t file_offset,
-          off_t buffer_offset)
+rocFileIo(IoType type, rocFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
+          hoff_t buffer_offset)
 try {
     HIPFILE_WARN_NO_EXIT_DTOR_OFF
     static const auto backends{Context<DriverState>::get()->getBackends()};
@@ -282,13 +282,14 @@ catch (...) {
 }
 
 ssize_t
-rocFileRead(rocFileHandle_t fh, void *buffer_base, size_t size, off_t file_offset, off_t buffer_offset)
+rocFileRead(rocFileHandle_t fh, void *buffer_base, size_t size, hoff_t file_offset, hoff_t buffer_offset)
 {
     return rocFileIo(IoType::Read, fh, buffer_base, size, file_offset, buffer_offset);
 }
 
 ssize_t
-rocFileWrite(rocFileHandle_t fh, const void *buffer_base, size_t size, off_t file_offset, off_t buffer_offset)
+rocFileWrite(rocFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
+             hoff_t buffer_offset)
 {
     return rocFileIo(IoType::Write, fh, buffer_base, size, file_offset, buffer_offset);
 }
@@ -458,8 +459,8 @@ catch (...) {
 }
 
 rocFileError_t
-rocFileReadAsync(rocFileHandle_t fh, void *buffer_base, size_t *size_p, off_t *file_offset_p,
-                 off_t *buffer_offset_p, ssize_t *bytes_read_p, hipStream_t stream)
+rocFileReadAsync(rocFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *file_offset_p,
+                 hoff_t *buffer_offset_p, ssize_t *bytes_read_p, hipStream_t stream)
 try {
     if (Context<DriverState>::get()->getRefCount() == 0) {
         return {rocFileDriverNotInitialized, hipSuccess};
@@ -480,8 +481,8 @@ catch (...) {
 }
 
 rocFileError_t
-rocFileWriteAsync(rocFileHandle_t fh, void *buffer_base, size_t *size_p, off_t *file_offset_p,
-                  off_t *buffer_offset_p, ssize_t *bytes_written_p, hipStream_t stream)
+rocFileWriteAsync(rocFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *file_offset_p,
+                  hoff_t *buffer_offset_p, ssize_t *bytes_written_p, hipStream_t stream)
 try {
     if (Context<DriverState>::get()->getRefCount() == 0) {
         return {rocFileDriverNotInitialized, hipSuccess};

--- a/rocfile/test/async.cpp
+++ b/rocfile/test/async.cpp
@@ -98,24 +98,31 @@ struct RocFileAsyncOpStreamParams
 TEST_P(RocFileAsyncOpStreamParams, asyncOp_construction_has_correct_variants)
 {
     size_t size              = 100;
+<<<<<<< HEAD
     off_t  file_offset       = 0;
     off_t  buffer_offset     = 0;
     off_t  bytes_transferred = 0;
     auto   op = std::make_shared<AsyncOp>(IoType::Read, file, buffer, stream, &size, &file_offset,
+=======
+    hoff_t file_offset       = 0;
+    hoff_t buffer_offset     = 0;
+    hoff_t bytes_transferred = 0;
+    auto   op = std::make_shared<AsyncOp>(io::IoType::Read, file, buffer, stream, &size, &file_offset,
+>>>>>>> 1ff39d2 (rocFile: Use platform-independent hoff_t)
                                           &buffer_offset, &bytes_transferred);
 
     // Unfixed flags will be pointers
     if (flags & ROCFILE_STREAM_FIXED_BUF_OFFSET) {
-        EXPECT_NO_THROW(std::get<const off_t>(op->buffer_offset));
+        EXPECT_NO_THROW(std::get<const hoff_t>(op->buffer_offset));
     }
     else {
-        EXPECT_NO_THROW(std::get<off_t *>(op->buffer_offset));
+        EXPECT_NO_THROW(std::get<hoff_t *>(op->buffer_offset));
     }
     if (flags & ROCFILE_STREAM_FIXED_FILE_OFFSET) {
-        EXPECT_NO_THROW(std::get<const off_t>(op->file_offset));
+        EXPECT_NO_THROW(std::get<const hoff_t>(op->file_offset));
     }
     else {
-        EXPECT_NO_THROW(std::get<off_t *>(op->file_offset));
+        EXPECT_NO_THROW(std::get<hoff_t *>(op->file_offset));
     }
     if (flags & ROCFILE_STREAM_FIXED_FILE_SIZE) {
         EXPECT_NO_THROW(std::get<size_t>(op->size));
@@ -129,9 +136,9 @@ INSTANTIATE_TEST_SUITE_P(StreamSuite, RocFileAsyncOpStreamParams, rocfileFlagsPo
 TEST_F(RocFileAsyncOp, AsyncOpFallback_new_uses_pinned_host_memory)
 {
     size_t size              = 100;
-    off_t  file_offset       = 0;
-    off_t  buffer_offset     = 0;
-    off_t  bytes_transferred = 0;
+    hoff_t file_offset       = 0;
+    hoff_t buffer_offset     = 0;
+    hoff_t bytes_transferred = 0;
     auto   op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
     auto   bounce_buffer     = std::shared_ptr<void>(new uint8_t[size]);
     EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
@@ -145,9 +152,9 @@ TEST_F(RocFileAsyncOp, AsyncOpFallback_new_uses_pinned_host_memory)
 TEST_F(RocFileAsyncOp, AsyncOpFallback_new_failure_throws_bad_alloc)
 {
     size_t size              = 100;
-    off_t  file_offset       = 0;
-    off_t  buffer_offset     = 0;
-    off_t  bytes_transferred = 0;
+    hoff_t file_offset       = 0;
+    hoff_t buffer_offset     = 0;
+    hoff_t bytes_transferred = 0;
     auto   op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
     EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Throw(Hip::RuntimeError(hipErrorOutOfMemory)));
     EXPECT_THROW(std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{IoType::Read, file, buffer, stream,
@@ -159,9 +166,9 @@ TEST_F(RocFileAsyncOp, AsyncOpFallback_new_failure_throws_bad_alloc)
 TEST_F(RocFileAsyncOp, AsyncOpFallback_bounce_alloc_failure_throws)
 {
     size_t size              = 100;
-    off_t  file_offset       = 0;
-    off_t  buffer_offset     = 0;
-    off_t  bytes_transferred = 0;
+    hoff_t file_offset       = 0;
+    hoff_t buffer_offset     = 0;
+    hoff_t bytes_transferred = 0;
     auto   op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
     EXPECT_CALL(mhip, hipHostMalloc)
         .WillOnce(Return(op_data.get()))
@@ -176,9 +183,9 @@ TEST_F(RocFileAsyncOp, AsyncOpFallback_bounce_alloc_failure_throws)
 TEST_F(RocFileAsyncOp, AsyncOpFallback_bounce_buffer_deleter_failure_calls_syslog)
 {
     size_t size              = 100;
-    off_t  file_offset       = 0;
-    off_t  buffer_offset     = 0;
-    off_t  bytes_transferred = 0;
+    hoff_t file_offset       = 0;
+    hoff_t buffer_offset     = 0;
+    hoff_t bytes_transferred = 0;
     auto   op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
     auto   bounce_buffer     = std::shared_ptr<void>(new uint8_t[size]);
     EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
@@ -194,9 +201,9 @@ TEST_F(RocFileAsyncOp, AsyncOpFallback_bounce_buffer_deleter_failure_calls_syslo
 TEST_F(RocFileAsyncOp, AsyncOpFallback_delete_failure_calls_syslog)
 {
     size_t size              = 100;
-    off_t  file_offset       = 0;
-    off_t  buffer_offset     = 0;
-    off_t  bytes_transferred = 0;
+    hoff_t file_offset       = 0;
+    hoff_t buffer_offset     = 0;
+    hoff_t bytes_transferred = 0;
     auto   op_data           = std::shared_ptr<void>(new uint8_t[sizeof(AsyncOpFallback)]);
     auto   bounce_buffer     = std::shared_ptr<void>(new uint8_t[size]);
     EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
@@ -225,9 +232,9 @@ struct RocFileAsyncOpFallbackFunctions : public RocFileAsyncOp {
     }
     void                            *bounce_buffer_dev_ptr = reinterpret_cast<void *>(0xDECDECDE);
     size_t                           size                  = 100;
-    off_t                            file_offset           = 0;
-    off_t                            buffer_offset         = 0;
-    off_t                            bytes_transferred     = 0;
+    hoff_t                           file_offset           = 0;
+    hoff_t                           buffer_offset         = 0;
+    hoff_t                           bytes_transferred     = 0;
     std::shared_ptr<void>            bounce_buffer;
     std::shared_ptr<AsyncOpFallback> op;
 };
@@ -247,9 +254,9 @@ TEST_F(RocFileAsyncOpFallbackFunctions, devPtr_calls_hipHostGetDevicePointer)
 TEST_F(RocFileAsyncMonitor, addOp_and_completeOp_with_valid_params_works)
 {
     size_t size              = 100;
-    off_t  file_offset       = 0;
-    off_t  buffer_offset     = 0;
-    off_t  bytes_transferred = 0;
+    hoff_t file_offset       = 0;
+    hoff_t buffer_offset     = 0;
+    hoff_t bytes_transferred = 0;
     auto   op = std::make_shared<AsyncOp>(IoType::Read, file, buffer, stream, &size, &file_offset,
                                           &buffer_offset, &bytes_transferred);
 
@@ -265,9 +272,9 @@ TEST_F(RocFileAsyncMonitor, completeOp_with_invalid_op_throws)
 TEST_F(RocFileAsyncMonitor, addOp_without_completeOp_prints_error_on_AsyncMonitor_destruction)
 {
     size_t size              = 100;
-    off_t  file_offset       = 0;
-    off_t  buffer_offset     = 0;
-    off_t  bytes_transferred = 0;
+    hoff_t file_offset       = 0;
+    hoff_t buffer_offset     = 0;
+    hoff_t bytes_transferred = 0;
     auto   op = std::make_unique<AsyncOp>(IoType::Read, file, buffer, stream, &size, &file_offset,
                                           &buffer_offset, &bytes_transferred);
     monitor.addOp(std::move(op));

--- a/rocfile/test/async.cpp
+++ b/rocfile/test/async.cpp
@@ -98,17 +98,10 @@ struct RocFileAsyncOpStreamParams
 TEST_P(RocFileAsyncOpStreamParams, asyncOp_construction_has_correct_variants)
 {
     size_t size              = 100;
-<<<<<<< HEAD
-    off_t  file_offset       = 0;
-    off_t  buffer_offset     = 0;
-    off_t  bytes_transferred = 0;
-    auto   op = std::make_shared<AsyncOp>(IoType::Read, file, buffer, stream, &size, &file_offset,
-=======
     hoff_t file_offset       = 0;
     hoff_t buffer_offset     = 0;
     hoff_t bytes_transferred = 0;
-    auto   op = std::make_shared<AsyncOp>(io::IoType::Read, file, buffer, stream, &size, &file_offset,
->>>>>>> 1ff39d2 (rocFile: Use platform-independent hoff_t)
+    auto   op = std::make_shared<AsyncOp>(IoType::Read, file, buffer, stream, &size, &file_offset,
                                           &buffer_offset, &bytes_transferred);
 
     // Unfixed flags will be pointers

--- a/rocfile/test/io.cpp
+++ b/rocfile/test/io.cpp
@@ -76,8 +76,8 @@ rand_fill(std::vector<uint8_t> &v)
 // bytes in expected starting at expected offset. Also ensure that all other
 // bytes in buffer are zero.
 static bool
-contains_expected_data(std::vector<uint8_t> &buffer, off_t buffer_offset, std::vector<uint8_t> &expected,
-                       off_t expected_offset, size_t count)
+contains_expected_data(std::vector<uint8_t> &buffer, hoff_t buffer_offset, std::vector<uint8_t> &expected,
+                       hoff_t expected_offset, size_t count)
 {
     if (buffer_offset < 0 || buffer.size() < static_cast<size_t>(buffer_offset) + count) {
         throw std::invalid_argument("out of bounds: buffer");
@@ -87,7 +87,7 @@ contains_expected_data(std::vector<uint8_t> &buffer, off_t buffer_offset, std::v
         throw std::invalid_argument("out of bounds: expected");
     }
 
-    for (off_t i = 0; i < buffer_offset; i++) {
+    for (hoff_t i = 0; i < buffer_offset; i++) {
         if (buffer.data()[i] != 0) {
             return false;
         }
@@ -146,8 +146,8 @@ TEST(RocFileFallbackBackend, FallbackBackendIsBarelyWillingToHandleDeviceMemory)
     auto   mfile{std::make_shared<StrictMock<MFile>>()};
     auto   mbuffer{std::make_shared<StrictMock<MBuffer>>()};
     size_t io_size{2048};
-    off_t  file_offset{4096};
-    off_t  buffer_offset{1024};
+    hoff_t file_offset{4096};
+    hoff_t buffer_offset{1024};
 
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(hipMemoryTypeDevice));
 
@@ -158,8 +158,8 @@ TEST(RocFileFallbackBackend, FallbackBackendRejectsNonDeviceMemory)
 {
     auto   mfile{std::make_shared<StrictMock<MFile>>()};
     size_t io_size{2048};
-    off_t  file_offset{4096};
-    off_t  buffer_offset{1024};
+    hoff_t file_offset{4096};
+    hoff_t buffer_offset{1024};
 
     for (const auto memoryType : HipMemoryTypes) {
         if (memoryType != hipMemoryTypeDevice) {
@@ -224,7 +224,7 @@ TEST_P(RocFileFallbackValidation, fallback_io_throws_if_buffer_offset_is_out_of_
 {
     StrictMock<MHip> mhip;
     StrictMock<MSys> msys;
-    off_t            buffer_offset = static_cast<off_t>(buffer->getLength());
+    hoff_t           buffer_offset = static_cast<hoff_t>(buffer->getLength());
     ASSERT_THROW(Fallback().io(io_type, file, buffer, 0, 0, buffer_offset, 4096), std::invalid_argument);
 }
 
@@ -233,7 +233,7 @@ TEST_P(RocFileFallbackValidation, fallback_io_throws_if_op_could_overrun_buffer)
     StrictMock<MHip> mhip;
     StrictMock<MSys> msys;
     size_t           size          = 10;
-    off_t            buffer_offset = static_cast<off_t>(buffer->getLength()) - 9;
+    hoff_t           buffer_offset = static_cast<hoff_t>(buffer->getLength()) - 9;
     ASSERT_THROW(Fallback().io(io_type, file, buffer, size, 0, buffer_offset, 4096), std::invalid_argument);
 }
 
@@ -258,16 +258,18 @@ TEST_P(RocFileFallbackValidation, fallback_io_truncates_size_to_MAX_RW_COUNT)
     switch (io_type) {
         case IoType::Read:
             EXPECT_CALL(msys, pread)
-                .WillRepeatedly(testing::Invoke(
-                    [](int, void *, size_t count, off_t) -> ssize_t { return static_cast<ssize_t>(count); }));
+                .WillRepeatedly(testing::Invoke([](int, void *, size_t count, hoff_t) -> ssize_t {
+                    return static_cast<ssize_t>(count);
+                }));
             EXPECT_CALL(mhip, hipMemcpy).WillRepeatedly(testing::Return());
             break;
         case IoType::Write:
             EXPECT_CALL(mhip, hipMemcpy).WillRepeatedly(testing::Return());
             EXPECT_CALL(mhip, hipStreamSynchronize).WillRepeatedly(testing::Return());
             EXPECT_CALL(msys, pwrite)
-                .WillRepeatedly(testing::Invoke(
-                    [](int, void *, size_t count, off_t) -> ssize_t { return static_cast<ssize_t>(count); }));
+                .WillRepeatedly(testing::Invoke([](int, void *, size_t count, hoff_t) -> ssize_t {
+                    return static_cast<ssize_t>(count);
+                }));
             break;
         default:
             FAIL();
@@ -314,7 +316,7 @@ INSTANTIATE_TEST_SUITE_P(FallbackValidationTests, RocFileFallbackValidation,
 
 struct RocFileWrite : public RocFileIO {
 
-    ssize_t fake_pwrite(int fd, void *buf, size_t count, off_t offset)
+    ssize_t fake_pwrite(int fd, void *buf, size_t count, hoff_t offset)
     {
         (void)fd;
 
@@ -346,7 +348,7 @@ struct RocFileWrite : public RocFileIO {
     }
 
     // Test if the file contains the correct data
-    bool file_contains_expected_data(off_t file_offset, off_t buffer_offset, size_t count)
+    bool file_contains_expected_data(hoff_t file_offset, hoff_t buffer_offset, size_t count)
     {
         return contains_expected_data(file_data, file_offset, buffer_data, buffer_offset, count);
     }
@@ -542,7 +544,7 @@ TEST_F(RocFileWrite, fallback_write_to_empty_file_at_file_offset)
 
     size_t size        = 64 * 1024;
     size_t chunk_size  = 4096;
-    off_t  file_offset = 1024;
+    hoff_t file_offset = 1024;
 
     randomize_device_buffer();
     expect_fallback_write(mhip, msys);
@@ -558,7 +560,7 @@ TEST_F(RocFileWrite, fallback_write_to_empty_file_at_buffer_offset)
 
     size_t size          = 64 * 1024;
     size_t chunk_size    = 4096;
-    off_t  buffer_offset = 1024;
+    hoff_t buffer_offset = 1024;
 
     randomize_device_buffer();
     expect_fallback_write(mhip, msys);
@@ -574,8 +576,8 @@ TEST_F(RocFileWrite, fallback_write_to_empty_file_at_buffer_offset_file_offset)
 
     size_t size          = 64 * 1024;
     size_t chunk_size    = 4096;
-    off_t  buffer_offset = 1024;
-    off_t  file_offset   = 512;
+    hoff_t buffer_offset = 1024;
+    hoff_t file_offset   = 512;
 
     randomize_device_buffer();
     expect_fallback_write(mhip, msys);
@@ -603,7 +605,7 @@ TEST_F(RocFileWrite, fallback_write_to_file_subregion)
     StrictMock<MSys> msys;
 
     size_t file_length = buffer->getLength() * 2;
-    off_t  file_offset = buffer->getLength() / 2;
+    hoff_t file_offset = buffer->getLength() / 2;
     file_data.resize(file_length);
     randomize_device_buffer();
     expect_fallback_write(mhip, msys);
@@ -620,7 +622,7 @@ TEST_F(RocFileWrite, fallback_write_append_non_empty_small_file)
 
     file_data.resize(64);
     size_t size        = 64 * 1024;
-    off_t  file_offset = 64;
+    hoff_t file_offset = 64;
 
     randomize_device_buffer();
     expect_fallback_write(mhip, msys);
@@ -643,7 +645,7 @@ struct RocFileRead : public RocFileIO {
         rand_fill(file_data);
     }
 
-    ssize_t fake_pread(int fd, void *buf, size_t count, off_t offset)
+    ssize_t fake_pread(int fd, void *buf, size_t count, hoff_t offset)
     {
         (void)fd;
 
@@ -670,7 +672,7 @@ struct RocFileRead : public RocFileIO {
         return static_cast<ssize_t>(count);
     }
 
-    bool device_buffer_contains_expected_data(off_t file_offset, off_t buffer_offset, size_t count)
+    bool device_buffer_contains_expected_data(hoff_t file_offset, hoff_t buffer_offset, size_t count)
     {
         return contains_expected_data(buffer_data, buffer_offset, file_data, file_offset, count);
     }
@@ -806,8 +808,8 @@ TEST_F(RocFileRead, read_with_fallback_backend)
     init_file(file_length);
 
     size_t size          = buffer->getLength() / 2;
-    off_t  buffer_offset = buffer->getLength() / 4;
-    off_t  file_offset   = static_cast<off_t>(buffer->getLength());
+    hoff_t buffer_offset = buffer->getLength() / 4;
+    hoff_t file_offset   = static_cast<hoff_t>(buffer->getLength());
 
     expect_fallback_read(mhip, msys);
     ASSERT_EQ(rocFileRead(file->getHandle(), buffer->getBuffer(), size, file_offset, buffer_offset), size);
@@ -864,10 +866,10 @@ TEST_F(RocFileRead, fallback_read_handles_short_preads)
 
     EXPECT_CALL(msys, mmap).WillOnce(testing::Invoke(::mmap));
     EXPECT_CALL(msys, pread)
-        .WillOnce(testing::Invoke([this](int fd, void *buf, size_t count, off_t offset) -> ssize_t {
+        .WillOnce(testing::Invoke([this](int fd, void *buf, size_t count, hoff_t offset) -> ssize_t {
             return this->fake_pread(fd, buf, count / 2, offset);
         }))
-        .WillRepeatedly(testing::Invoke([this](int fd, void *buf, size_t count, off_t offset) -> ssize_t {
+        .WillRepeatedly(testing::Invoke([this](int fd, void *buf, size_t count, hoff_t offset) -> ssize_t {
             return this->fake_pread(fd, buf, count, offset);
         }));
     EXPECT_CALL(mhip, hipMemcpy).WillRepeatedly(testing::Invoke(this, &RocFileRead::fake_hipMemcpy));
@@ -887,7 +889,7 @@ TEST_F(RocFileRead, fallback_read_handles_interrupted_pread)
     EXPECT_CALL(msys, mmap).WillOnce(testing::Invoke(::mmap));
     EXPECT_CALL(msys, pread)
         .WillOnce(testing::Throw(Sys::RuntimeError(EINTR)))
-        .WillRepeatedly(testing::Invoke([this](int fd, void *buf, size_t count, off_t offset) -> ssize_t {
+        .WillRepeatedly(testing::Invoke([this](int fd, void *buf, size_t count, hoff_t offset) -> ssize_t {
             return this->fake_pread(fd, buf, count, offset);
         }));
     EXPECT_CALL(mhip, hipMemcpy).WillRepeatedly(testing::Invoke(this, &RocFileRead::fake_hipMemcpy));
@@ -970,7 +972,7 @@ TEST_F(RocFileRead, fallback_read_with_non_zero_file_offset)
 
     size_t file_length = buffer->getLength() * 3;
     init_file(file_length);
-    off_t file_offset = static_cast<off_t>(buffer->getLength());
+    hoff_t file_offset = static_cast<hoff_t>(buffer->getLength());
 
     expect_fallback_read(mhip, msys);
     ASSERT_EQ(buffer->getLength(),
@@ -985,7 +987,7 @@ TEST_F(RocFileRead, fallback_read_to_eof_with_non_zero_file_offset)
 
     size_t file_length = buffer->getLength() * 2;
     init_file(file_length);
-    off_t file_offset = static_cast<off_t>(buffer->getLength());
+    hoff_t file_offset = static_cast<hoff_t>(buffer->getLength());
 
     expect_fallback_read(mhip, msys);
     ASSERT_EQ(buffer->getLength(),
@@ -1000,7 +1002,7 @@ TEST_F(RocFileRead, fallback_read_past_eof_with_non_zero_file_offset)
 
     size_t file_length = buffer->getLength() * 2;
     init_file(file_length);
-    off_t file_offset = static_cast<off_t>(buffer->getLength()) + 1;
+    hoff_t file_offset = static_cast<hoff_t>(buffer->getLength()) + 1;
 
     expect_fallback_read(mhip, msys);
     ASSERT_EQ(buffer->getLength() - 1,
@@ -1015,7 +1017,7 @@ TEST_F(RocFileRead, fallback_read_can_read_single_byte_at_end_of_file)
 
     size_t file_length = buffer->getLength();
     init_file(file_length);
-    off_t file_offset = static_cast<off_t>(file_length) - 1;
+    hoff_t file_offset = static_cast<hoff_t>(file_length) - 1;
 
     expect_fallback_read(mhip, msys);
     ASSERT_EQ(1, Fallback().io(IoType::Read, file, buffer, buffer->getLength(), file_offset, 0));
@@ -1029,7 +1031,7 @@ TEST_F(RocFileRead, fallback_read_emtpy_file_with_non_zero_file_offset)
 
     size_t file_length = 0;
     init_file(file_length);
-    off_t file_offset = static_cast<off_t>(buffer->getLength());
+    hoff_t file_offset = static_cast<hoff_t>(buffer->getLength());
 
     expect_fallback_read(mhip, msys);
     ASSERT_EQ(0, Fallback().io(IoType::Read, file, buffer, buffer->getLength(), file_offset, 0));
@@ -1043,7 +1045,7 @@ TEST_F(RocFileRead, fallback_read_with_non_zero_buffer_offset)
 
     size_t file_length = buffer->getLength() * 2;
     init_file(file_length);
-    off_t buffer_offset = static_cast<off_t>(1);
+    hoff_t buffer_offset = static_cast<hoff_t>(1);
 
     expect_fallback_read(mhip, msys);
     ASSERT_EQ(buffer->getLength() - 1,
@@ -1058,7 +1060,7 @@ TEST_F(RocFileRead, fallback_read_can_read_into_last_byte_of_buffer)
 
     size_t file_length = buffer->getLength();
     init_file(file_length);
-    off_t buffer_offset = static_cast<off_t>(buffer->getLength() - 1);
+    hoff_t buffer_offset = static_cast<hoff_t>(buffer->getLength() - 1);
 
     expect_fallback_read(mhip, msys);
     ASSERT_EQ(1, Fallback().io(IoType::Read, file, buffer, 1, 0, buffer_offset));
@@ -1072,8 +1074,8 @@ TEST_F(RocFileRead, fallback_read_with_non_zero_buffer_offset_and_file_offset)
 
     size_t file_length = buffer->getLength();
     init_file(file_length);
-    off_t  file_offset   = 74;
-    off_t  buffer_offset = 97;
+    hoff_t file_offset   = 74;
+    hoff_t buffer_offset = 97;
     size_t read_size     = buffer->getLength() / 2;
 
     expect_fallback_read(mhip, msys);
@@ -1087,8 +1089,8 @@ struct RocFileIoBackendSelectionParam : public ::testing::TestWithParam<IoType> 
     rocFileHandle_t                       handle;
     void                                 *buffer;
     size_t                                io_size;
-    off_t                                 file_offset;
-    off_t                                 buffer_offset;
+    hoff_t                                file_offset;
+    hoff_t                                buffer_offset;
     int                                   flags;
     std::shared_ptr<StrictMock<MFile>>    mfile;
     std::shared_ptr<StrictMock<MBuffer>>  mbuffer;

--- a/rocfile/test/mbackend.h
+++ b/rocfile/test/mbackend.h
@@ -16,7 +16,8 @@ struct MBackend : Backend {
                 (const override));
     MOCK_METHOD(ssize_t, io,
                 (rocFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
-                 hoff_t), (override));
+                 hoff_t),
+                (override));
 };
 
 }

--- a/rocfile/test/mbackend.h
+++ b/rocfile/test/mbackend.h
@@ -12,12 +12,11 @@
 namespace rocFile {
 
 struct MBackend : Backend {
-    MOCK_METHOD(int, score, (std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, off_t, off_t),
+    MOCK_METHOD(int, score, (std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t, hoff_t),
                 (const override));
     MOCK_METHOD(ssize_t, io,
-                (rocFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, off_t,
-                 off_t),
-                (override));
+                (rocFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
+                 hoff_t), (override));
 };
 
 }

--- a/shared/hipfile-types.h
+++ b/shared/hipfile-types.h
@@ -1,0 +1,19 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+// ***********************************************************************
+//  PLATFORM-INDEPENDENT TYPES
+// ***********************************************************************
+
+/*!
+ * @brief Platform-independent offset type
+ * @ingroup core
+ */
+#ifndef _WIN32
+typedef off_t hoff_t;
+#else
+typedef __int64 hoff_t;
+#endif


### PR DESCRIPTION
* Move hoff_t definition to a new shared/hipfile-types.h file
* Use hoff_t everywhere in rocFile (except sys equivalents)
* Add hipfile-types.h to the list of installed files
