### PR TITLE
Use artifacts instead of registry for passing CI image to jobs

### DIFF
--- a/.github/workflows/build_ais.yml
+++ b/.github/workflows/build_ais.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Set AIS CI image environment variables
         run: |
-          echo "AIS_CI_DEV_IMAGE=${{ env.AIS_DOCKER_REGISTRY }}/${{ env.AIS_CI_IMAGE_NAME }}_dev:$(echo ${{ github.ref }} \
+          echo "AIS_CI_DEV_IMAGE=${{ env.AIS_CI_IMAGE_NAME }}_dev:$(echo ${{ github.ref }} \
             | sed 's|[^a-zA-Z0-9]|-|g')" >> "$GITHUB_ENV"
           echo "AIS_CI_LATEST_IMAGE=${{ env.AIS_DOCKER_REGISTRY }}/${{ env.AIS_CI_IMAGE_NAME }}:latest" >> "$GITHUB_ENV"
           echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
@@ -47,11 +47,18 @@ jobs:
               ${{ env.AIS_CI_IMAGE_NAME }} Development Image for AIS CI using branch \
               ${{ github.head_ref }} for PR #${AIS_PR_NUMBER}. \
               PR URL: ${{ env.AIS_PR_BASE_URL }}/${AIS_PR_NUMBER}" \
-            --cache-to=type=registry,ref="${{ env.AIS_DOCKER_REGISTRY }}/${{ env.AIS_CI_IMAGE_NAME }}_dev:cache" \
             --cache-from=type=registry,ref="${{ env.AIS_DOCKER_REGISTRY }}/${{ env.AIS_CI_IMAGE_NAME }}_dev:cache" \
-            --push \
-            -t ${AIS_CI_DEV_IMAGE} \
+            --output=type=docker,dest=${GITHUB_WORKSPACE}/${{ env.AIS_CI_IMAGE_NAME}}_dev.tar \
+            -t ${{ env.AIS_CI_IMAGE_NAME }}_dev \
             ${GITHUB_WORKSPACE}
+      - name: Upload AIS CI image as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
+          path: ${{ github.workspace }}/${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
   compile_on_AMD:
     runs-on: [ubuntu-24.04]
     needs: build_AIS_image
@@ -71,6 +78,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download AIS CI image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
+          path: ${{ github.workspace }}
+      - name: Load AIS CI image into Docker
+        run: docker load --input ${GITHUB_WORKSPACE}/${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
       # Detach the container and run separate commands to it.
       # Thus we can make separate explicit steps in the Github CI
       # as if we were able to parameterize the container image in the first place.
@@ -79,11 +93,10 @@ jobs:
           docker run \
             -dt \
             --rm \
-            --pull always \
             -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
             -v ${{ env.AIS_MOUNT_PATH }}:/mnt/ais-fs \
             --name ${AIS_CONTAINER_NAME} \
-            ${AIS_CI_DEV_IMAGE}
+            ${{ env.AIS_CI_IMAGE_NAME }}_dev
       - name: Make copy of the code repository and create build directories
         # Single quotes necessary to ensure string/command substitutions happen
         # in the container and not on the host.
@@ -181,16 +194,22 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download AIS CI image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
+          path: ${{ github.workspace }}
+      - name: Load AIS CI image into Docker
+        run: docker load --input ${GITHUB_WORKSPACE}/${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
       - name: Starting Docker Container
         run: |
           docker run \
             -dt \
             --rm \
-            --pull always \
             -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
             -v ${{ env.AIS_MOUNT_PATH }}:/mnt/ais-fs \
             --name ${AIS_CONTAINER_NAME} \
-            ${AIS_CI_DEV_IMAGE}
+            ${{ env.AIS_CI_IMAGE_NAME }}_dev
       - name: Make copy of the code repository and create build directories
         run: |
           docker exec \
@@ -246,6 +265,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download AIS CI image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
+          path: ${{ github.workspace }}
+      - name: Load AIS CI image into Docker
+        run: docker load --input ${GITHUB_WORKSPACE}/${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
       # Detach the container and run separate commands to it.
       # Thus we can make separate explicit steps in the Github CI
       # as if we were able to parameterize the container image in the first place.
@@ -257,11 +283,10 @@ jobs:
             --device=/dev/kfd \
             --device=/dev/dri \
             --security-opt seccomp=unconfined \
-            --pull always \
             -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
             -v ${{ env.AIS_MOUNT_PATH }}:/mnt/ais-fs \
             --name ${AIS_CONTAINER_NAME} \
-            ${AIS_CI_DEV_IMAGE}
+            ${{ env.AIS_CI_IMAGE_NAME }}_dev
       - name: Make copy of the code repository and create build directories
         run: |
           docker exec \
@@ -349,11 +374,10 @@ jobs:
           docker run \
             -dt \
             --rm \
-            --pull always \
             -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
             -v ${{ env.AIS_MOUNT_PATH }}:/mnt/ais-fs \
             --name ${AIS_CONTAINER_NAME} \
-            ${AIS_CI_DEV_IMAGE}
+            ${{ env.AIS_CI_IMAGE_NAME }}_dev
       - name: Make copy of the code repository and create build directories
         run: |
           docker exec \

--- a/.github/workflows/build_ais.yml
+++ b/.github/workflows/build_ais.yml
@@ -366,6 +366,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download AIS CI image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
+          path: ${{ github.workspace }}
+      - name: Load AIS CI image into Docker
+        run: docker load --input ${GITHUB_WORKSPACE}/${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
       # Detach the container and run separate commands to it.
       # Thus we can make separate explicit steps in the Github CI
       # as if we were able to parameterize the container image in the first place.

--- a/.github/workflows/hipfile-nvidia.yml
+++ b/.github/workflows/hipfile-nvidia.yml
@@ -32,6 +32,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download AIS CI image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
+          path: ${{ github.workspace }}
+      - name: Load AIS CI image into Docker
+        run: docker load --input ${GITHUB_WORKSPACE}/${{ env.AIS_CI_IMAGE_NAME }}_dev.tar
       # Detach the container and run separate commands to it.
       # Thus we can make separate explicit steps in the Github CI
       # as if we were able to parameterize the container image in the first place.
@@ -44,12 +51,11 @@ jobs:
             -e NVIDIA_GDS=enabled \
             --runtime=nvidia \
             --gpus all \
-            --pull always \
             --cap-add=CAP_SYSLOG \
             -v $(pwd):/mnt/ais:ro \
             -v ${{ env.AIS_MOUNT_PATH }}:/mnt/ais-fs \
             --name ${AIS_CONTAINER_NAME} \
-            ${AIS_CI_DEV_IMAGE}
+            ${{ env.AIS_CI_IMAGE_NAME }}_dev
       - name: Make copy of the code repository
         run: |
           docker exec \


### PR DESCRIPTION
## Motivation

To enable PRs coming in from external forks of the repo to use our CI as-is.

## Technical Details

External PR's (e.g. from a forked repo) are not allowed to push to the head repo's Docker Registry when the workflow trigger is "pull_request". This is a good protection to have. Artifacts are not published and are kept on a job by job basis - for a single day in our case. They are not intended to be consumed by non-CI. This should allow us to keep most of our existing CI by switching to this model.

An additional job after a PR has been accepted and merged will be needed if we wish to still have some concept of caching for building the docker image. No matter what we will need to push the entire Docker image for each workflow using this mechanism rather than benefiting from speed-up provided by the registry to skip uploading unchanged layers of the image.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
