### PR TITLE
rocfile/test: Split HipMemoryTypes into supported and unsupported

### DIFF
--- a/rocfile/test/buffer.cpp
+++ b/rocfile/test/buffer.cpp
@@ -47,43 +47,43 @@ struct RocFileBuffer : public RocFileOpened {
     void *nonnull_ptr;
 };
 
-TEST_F(RocFileBuffer, register_internal_device_memory)
+TEST_F(RocFileBuffer, register_internal_supported_hip_memory)
 {
-    StrictMock<MHip> mhip;
-    expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
-}
-
-TEST_F(RocFileBuffer, register_device_memory)
-{
-    StrictMock<MHip> mhip;
-    expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    ASSERT_EQ(rocFileBufRegister(nonnull_ptr, 0, 0), ROCFILE_SUCCESS);
-}
-
-TEST_F(RocFileBuffer, register_internal_not_device_memory)
-{
-    for (const auto memoryType : HipMemoryTypes) {
-        if (memoryType != hipMemoryTypeDevice) {
-            StrictMock<MHip>      mhip;
-            hipPointerAttribute_t attrs;
-            attrs.type = memoryType;
-            EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
-            ASSERT_THROW(Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0), InvalidMemoryType);
-        }
+    for (const auto memoryType : SupportedHipMemoryTypes) {
+        StrictMock<MHip> mhip;
+        expect_buffer_registration(mhip, memoryType);
+        Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
     }
 }
 
-TEST_F(RocFileBuffer, register_not_device_memory)
+TEST_F(RocFileBuffer, register_supported_hip_memory)
 {
-    for (const auto memoryType : HipMemoryTypes) {
-        if (memoryType != hipMemoryTypeDevice) {
-            StrictMock<MHip>      mhip;
-            hipPointerAttribute_t attrs;
-            attrs.type = memoryType;
-            EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
-            ASSERT_EQ(rocFileBufRegister(nonnull_ptr, 0, 0), RocFileOpError(rocFileHipMemoryTypeInvalid));
-        }
+    for (const auto memoryType : SupportedHipMemoryTypes) {
+        StrictMock<MHip> mhip;
+        expect_buffer_registration(mhip, memoryType);
+        ASSERT_EQ(rocFileBufRegister(nonnull_ptr, 0, 0), ROCFILE_SUCCESS);
+    }
+}
+
+TEST_F(RocFileBuffer, register_internal_unsupported_hip_memory)
+{
+    for (const auto memoryType : UnsupportedHipMemoryTypes) {
+        StrictMock<MHip>      mhip;
+        hipPointerAttribute_t attrs;
+        attrs.type = memoryType;
+        EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
+        ASSERT_THROW(Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0), InvalidMemoryType);
+    }
+}
+
+TEST_F(RocFileBuffer, register_unsupported_hip_memory)
+{
+    for (const auto memoryType : UnsupportedHipMemoryTypes) {
+        StrictMock<MHip>      mhip;
+        hipPointerAttribute_t attrs;
+        attrs.type = memoryType;
+        EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
+        ASSERT_EQ(rocFileBufRegister(nonnull_ptr, 0, 0), RocFileOpError(rocFileHipMemoryTypeInvalid));
     }
 }
 

--- a/rocfile/test/io.cpp
+++ b/rocfile/test/io.cpp
@@ -154,19 +154,17 @@ TEST(RocFileFallbackBackend, FallbackBackendIsBarelyWillingToHandleDeviceMemory)
     ASSERT_EQ(Fallback().score(mfile, mbuffer, io_size, file_offset, buffer_offset), 0);
 }
 
-TEST(RocFileFallbackBackend, FallbackBackendRejectsNonDeviceMemory)
+TEST(RocFileFallbackBackend, FallbackBackendRejectsUnsupportedHipMemoryTypes)
 {
     auto   mfile{std::make_shared<StrictMock<MFile>>()};
     size_t io_size{2048};
     hoff_t file_offset{4096};
     hoff_t buffer_offset{1024};
 
-    for (const auto memoryType : HipMemoryTypes) {
-        if (memoryType != hipMemoryTypeDevice) {
-            auto mbuffer = std::make_shared<StrictMock<MBuffer>>();
-            EXPECT_CALL(*mbuffer, getType).WillOnce(Return(memoryType));
-            ASSERT_EQ(Fallback().score(mfile, mbuffer, io_size, file_offset, buffer_offset), -1);
-        }
+    for (const auto memoryType : UnsupportedHipMemoryTypes) {
+        auto mbuffer = std::make_shared<StrictMock<MBuffer>>();
+        EXPECT_CALL(*mbuffer, getType).WillOnce(Return(memoryType));
+        ASSERT_EQ(Fallback().score(mfile, mbuffer, io_size, file_offset, buffer_offset), -1);
     }
 }
 
@@ -372,21 +370,18 @@ TEST_F(RocFileWrite, write_handles_pointer_get_attributes_error)
     ASSERT_EQ(rocFileWrite(fh, nonnull_ptr, 0, 0, 0), -static_cast<ssize_t>(hipErrorUnknown));
 }
 
-TEST_F(RocFileWrite, write_handles_invalid_memory_type)
+TEST_F(RocFileWrite, write_handles_unsupported_hip_memory_type)
 {
     StrictMock<MSys> msys;
     EXPECT_CALL(msys, fstat);
     EXPECT_CALL(msys, fcntl);
     auto fh = Context<DriverState>::get()->registerFile(0xBADCAFE);
-    for (const auto memoryType : HipMemoryTypes) {
-        if (memoryType != hipMemoryTypeDevice) {
-            StrictMock<MHip>      mhip;
-            hipPointerAttribute_t attrs;
-            attrs.type = memoryType;
-            EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
-            ASSERT_EQ(rocFileWrite(fh, nonnull_ptr, 0, 0, 0),
-                      -static_cast<ssize_t>(rocFileHipMemoryTypeInvalid));
-        }
+    for (const auto memoryType : UnsupportedHipMemoryTypes) {
+        StrictMock<MHip>      mhip;
+        hipPointerAttribute_t attrs;
+        attrs.type = memoryType;
+        EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
+        ASSERT_EQ(rocFileWrite(fh, nonnull_ptr, 0, 0, 0), -static_cast<ssize_t>(rocFileHipMemoryTypeInvalid));
     }
 }
 
@@ -699,21 +694,18 @@ TEST_F(RocFileRead, read_handles_pointer_get_attributes_error)
     ASSERT_EQ(rocFileRead(fh, nonnull_ptr, 0, 0, 0), -static_cast<ssize_t>(hipErrorUnknown));
 }
 
-TEST_F(RocFileRead, read_handles_invalid_memory_type)
+TEST_F(RocFileRead, read_handles_unsupported_hip_memory_type)
 {
     StrictMock<MHip> mhip;
     StrictMock<MSys> msys;
     EXPECT_CALL(msys, fstat);
     EXPECT_CALL(msys, fcntl);
     auto fh{Context<DriverState>::get()->registerFile(0xBADCAFE)};
-    for (const auto memoryType : HipMemoryTypes) {
-        if (memoryType != hipMemoryTypeDevice) {
-            hipPointerAttribute_t attrs;
-            attrs.type = memoryType;
-            EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
-            ASSERT_EQ(rocFileRead(fh, nonnull_ptr, 0, 0, 0),
-                      -static_cast<ssize_t>(rocFileHipMemoryTypeInvalid));
-        }
+    for (const auto memoryType : UnsupportedHipMemoryTypes) {
+        hipPointerAttribute_t attrs;
+        attrs.type = memoryType;
+        EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
+        ASSERT_EQ(rocFileRead(fh, nonnull_ptr, 0, 0, 0), -static_cast<ssize_t>(rocFileHipMemoryTypeInvalid));
     }
 }
 

--- a/rocfile/test/rocfile-test.h
+++ b/rocfile/test/rocfile-test.h
@@ -113,10 +113,15 @@ struct RocFileUnopened : public ::testing::Test {
 //  BUFFER FUNCTIONALITY
 // ***********************************************************************
 
-constexpr std::array<hipMemoryType, 6> HipMemoryTypes{
-    hipMemoryTypeArray,   hipMemoryTypeDevice,  hipMemoryTypeHost,
-    hipMemoryTypeManaged, hipMemoryTypeUnified, hipMemoryTypeUnregistered,
-};
-
 /// @brief Set up mocks for buffer registration
 void expect_buffer_registration(rocFile::MHip &mhip, hipMemoryType memory_type);
+
+// ***********************************************************************
+//  ENUM VALUE HELPERS
+// ***********************************************************************
+
+constexpr std::array<hipMemoryType, 1> SupportedHipMemoryTypes{hipMemoryTypeDevice};
+constexpr std::array<hipMemoryType, 5> UnsupportedHipMemoryTypes{
+    hipMemoryTypeArray,   hipMemoryTypeHost,         hipMemoryTypeManaged,
+    hipMemoryTypeUnified, hipMemoryTypeUnregistered,
+};


### PR DESCRIPTION
## Motivation

Allow tests to be parameterized on supported/unsupported. 