### PR TITLE
A couple of code coverage fixes.

### DIFF
--- a/cmake/AISCompilerOptions.cmake
+++ b/cmake/AISCompilerOptions.cmake
@@ -34,6 +34,7 @@ function (ais_set_compiler_flags target)
         if(BUILD_CODE_COVERAGE)
             target_compile_options(${target} PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-fprofile-instr-generate -fcoverage-mapping>)
             target_link_options(${target} PRIVATE $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-fprofile-instr-generate>)
+            target_link_options(${target} PRIVATE $<$<COMPILE_LANG_AND_ID:HIP,Clang>:-fprofile-instr-generate>)
         endif()
     endforeach()
 

--- a/util/llvm-coverage.sh
+++ b/util/llvm-coverage.sh
@@ -39,12 +39,14 @@ while getopts "b:ch" o; do
     esac
 done
 
-readarray -d '' COV_FILES < <(find "$BUILD_DIR" -name "*.profraw" -print0)
-if [ ${#COV_FILES[@]} -eq 0 ]; then
+COV_FILES="$BUILD_DIR/coverage-files.txt"
+
+find "$BUILD_DIR" -name "*.profraw" >"$COV_FILES"
+if [ ! -s "$COV_FILES" ]; then
     echo "No coverage files found" >>/dev/stderr
     exit 1
 fi
 
-llvm-profdata merge -output="$BUILD_DIR"/coverage.profdata "${COV_FILES[@]}"
+llvm-profdata merge -output="$BUILD_DIR"/coverage.profdata --input-files="$COV_FILES"
 llvm-cov report "$COLOR_ARG" -instr-profile="$BUILD_DIR"/coverage.profdata -object="$BUILD_DIR"/rocfile/src/librocfile.so -object="$BUILD_DIR"/hipfile/src/amd_detail/libhipfile.so >"$BUILD_DIR"/coverage-report.txt
 llvm-cov show "$COLOR_ARG" -instr-profile="$BUILD_DIR"/coverage.profdata -object="$BUILD_DIR"/rocfile/src/librocfile.so -object="$BUILD_DIR"/hipfile/src/amd_detail/libhipfile.so >"$BUILD_DIR"/coverage-lines.txt


### PR DESCRIPTION
Pass -fprofile-instr-generate flag when linking with HIP.  The HIP linker will be used when an object file contains HIP code.

Use a file to pass the coverage files into the merge step, to avoid command-line length issues.