### PR TITLE
hipFile: Apply IWYU to NVIDIA side of hipFile

### DIFF
--- a/hipfile/include/hipfile.h
+++ b/hipfile/include/hipfile.h
@@ -10,7 +10,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/socket.h>
 #include <sys/types.h>
 
 #if defined(__GNUC__)

--- a/hipfile/src/nvidia_detail/hipfile-cufile.cpp
+++ b/hipfile/src/nvidia_detail/hipfile-cufile.cpp
@@ -6,12 +6,9 @@
 #include "hipfile-cufile.h"
 
 #include <climits>
+#include <cuda.h>
 #include <hip/hip_runtime_api.h>
 #include <stdexcept>
-
-#ifdef __HIP_PLATFORM_NVIDIA__
-#include <cuda.h>
-#endif
 
 hipFileOpError_t
 toHipFileOpError(CUfileOpError cu_status)

--- a/hipfile/src/nvidia_detail/hipfile-cufile.cpp
+++ b/hipfile/src/nvidia_detail/hipfile-cufile.cpp
@@ -6,7 +6,12 @@
 #include "hipfile-cufile.h"
 
 #include <climits>
+#include <hip/hip_runtime_api.h>
 #include <stdexcept>
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#include <cuda.h>
+#endif
 
 hipFileOpError_t
 toHipFileOpError(CUfileOpError cu_status)

--- a/hipfile/src/nvidia_detail/hipfile.cpp
+++ b/hipfile/src/nvidia_detail/hipfile.cpp
@@ -3,9 +3,19 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "hipfile.h"
 #include "hipfile-cufile.h"
+#include "hipfile-types.h"
 
+#include <hip/hip_runtime_api.h>
+#include <sys/types.h>
 #include <vector>
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#include <cuda.h>
+#include <cufile.h>
+#include <driver_types.h>
+#endif
 
 using namespace std;
 

--- a/hipfile/src/nvidia_detail/hipfile.cpp
+++ b/hipfile/src/nvidia_detail/hipfile.cpp
@@ -7,15 +7,12 @@
 #include "hipfile-cufile.h"
 #include "hipfile-types.h"
 
-#include <hip/hip_runtime_api.h>
-#include <sys/types.h>
-#include <vector>
-
-#ifdef __HIP_PLATFORM_NVIDIA__
 #include <cuda.h>
 #include <cufile.h>
 #include <driver_types.h>
-#endif
+#include <hip/hip_runtime_api.h>
+#include <sys/types.h>
+#include <vector>
 
 using namespace std;
 

--- a/hipfile/test/hipfile-cufile.cpp
+++ b/hipfile/test/hipfile-cufile.cpp
@@ -5,12 +5,19 @@
 
 #include "hipfile.h"
 #include "hipfile-cufile.h"
-#include "test-common.h"
-
 #include "hipfile-warnings.h"
 #include "invalid-enum.h"
+#include "test-common.h"
 
 #include <gtest/gtest.h>
+#include <hip/hip_runtime_api.h>
+#include <memory>
+#include <stdexcept>
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#include <cuda.h>
+#include <cufile.h>
+#endif
 
 // Put tests inside the macros to suppress the global constructor
 // warnings

--- a/hipfile/test/system/driver.cpp
+++ b/hipfile/test/system/driver.cpp
@@ -18,6 +18,10 @@
 #include <time.h>
 #include <vector>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#include <driver_types.h>
+#endif
+
 using namespace std;
 
 extern SystemTestOptions test_env;


### PR DESCRIPTION
Modest changes. Ignores gtest header confusion from iwyu and its insistence that we drop stdbool.h from hipfile.h.