### PR TITLE
Updated the change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,8 @@
 ### Changed
 
 ### Removed
+* The hipify patch was removed. You can get hipify with hipFile support at https://github.com/derobins/HIPIFY/tree/hipFile.
 
 ### Known issues
+* The batch API calls are not supported
+* The async API calls are not supported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Removed
 * The hipify patch was removed. You can get hipify with hipFile support at https://github.com/derobins/HIPIFY/tree/hipFile.
 
-### Known issues
+### Limitations
 * The batch API calls are not supported w/ a rocFile backend
 * The async API calls are not supported w/ a rocFile backend
+
+### Known issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,5 @@
 * The hipify patch was removed. You can get hipify with hipFile support at https://github.com/derobins/HIPIFY/tree/hipFile.
 
 ### Known issues
-* The batch API calls are not supported
-* The async API calls are not supported
+* The batch API calls are not supported w/ a rocFile backend
+* The async API calls are not supported w/ a rocFile backend


### PR DESCRIPTION
* Note that the hipify patch has been removed and points to derobins/HIPIFY repo
* Note that batch & async API calls are unsupported