### PR TITLE
Fix cmake-lint problems

### DIFF
--- a/.cmakelintrc
+++ b/.cmakelintrc
@@ -1,0 +1,3 @@
+# CMake lint file for hipFile
+# https://cmake-format.readthedocs.io/en/latest/cmake-lint.html
+filter=-linelength

--- a/cmake/AISCompilerOptions.cmake
+++ b/cmake/AISCompilerOptions.cmake
@@ -7,7 +7,7 @@
 include(AISClangCompilerOptions)
 include(AISGNUCompilerOptions)
 
-function (ais_set_compiler_flags target)
+function(ais_set_compiler_flags target)
     get_target_property(sources ${target} SOURCES)
     foreach(source IN LISTS sources)
         get_source_file_property(language ${source} LANGUAGE)

--- a/cmake/AISGNUCompilerOptions.cmake
+++ b/cmake/AISGNUCompilerOptions.cmake
@@ -9,7 +9,7 @@
 function(get_ais_gnu_warning_flags outvar compiler_version)
 
     # Warning flags for g++ 9 and earlier
-    set(flags 
+    set(flags
         # Basic "high" warning levels
         -Wall
         -Wextra

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -28,7 +28,7 @@ if(BUILD_ROCFILE OR BUILD_HIPFILE)
         )
     endif()
     if(BUILD_HIPFILE)
-       rocm_install(
+        rocm_install(
             DIRECTORY ${CMAKE_SOURCE_DIR}/hipfile/include/
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )

--- a/cmake/AISSanitizers.cmake
+++ b/cmake/AISSanitizers.cmake
@@ -9,7 +9,7 @@ if(AIS_BUILD_THREAD_SANITIZERS)
     message(WARNING "TSAN has known problems with higher levels of entropy, try using `sudo sysctl vm.mmap_rnd_bits=28` if you encounter errors concerning unexpected memory mappings.")
 endif()
 
-function (ais_add_sanitizers target)
+function(ais_add_sanitizers target)
     if(AIS_BUILD_SANITIZERS AND AIS_BUILD_THREAD_SANITIZERS)
         message(FATAL_ERROR "AIS_BUILD_SANITIZERS is not compatible with AIS_BUILD_THREAD_SANITIZERS")
     endif()

--- a/cmake/AISSetCoverageFile.cmake
+++ b/cmake/AISSetCoverageFile.cmake
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: MIT
 
-function (ais_set_coverage_file test_list_name directory)
+function(ais_set_coverage_file test_list_name directory)
     set(test_counter 0)
     set(test_list "${${test_list_name}}")
     foreach(test IN LISTS test_list)
         set_tests_properties(
             ${test}
             PROPERTIES ENVIRONMENT_MODIFICATION "LLVM_PROFILE_FILE=set:${directory}/${test_list_name}.${test_counter}.profraw")
-        MATH(EXPR test_counter "${test_counter}+1")
+        math(EXPR test_counter "${test_counter}+1")
     endforeach()
 endfunction()

--- a/cmake/AISUseGTest.cmake
+++ b/cmake/AISUseGTest.cmake
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 include(FetchContent)
+
+# lint_cmake: -readability/wonkycase
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
@@ -13,7 +15,9 @@ FetchContent_Declare(
 
 set(INSTALL_GTEST OFF CACHE BOOL "Don't install gtest.")
 set(GTEST_HAS_ABSL OFF CACHE BOOL "Don't use abseil for GTest.")
+
 FetchContent_MakeAvailable(googletest)
+# lint_cmake: +readability/wonkycase
 
 if(rocm-cmake_SOURCE_DIR)
     message(STATUS "Using fetched googletest.")

--- a/cmake/AISUseGTest.cmake
+++ b/cmake/AISUseGTest.cmake
@@ -23,7 +23,7 @@ endif()
 
 include(GoogleTest)
 
-function (ais_gtest_discover_tests target)
+function(ais_gtest_discover_tests target)
     cmake_language(CALL gtest_discover_tests ${ARGV})
 
     if(BUILD_CODE_COVERAGE)

--- a/cmake/AISUseROCmCMake.cmake
+++ b/cmake/AISUseROCmCMake.cmake
@@ -4,6 +4,7 @@
 
 include(FetchContent)
 
+# lint_cmake: -readability/wonkycase
 FetchContent_Declare(
     rocm-cmake
     URL https://github.com/ROCm/rocm-cmake/archive/refs/tags/rocm-6.4.3.tar.gz
@@ -13,6 +14,7 @@ FetchContent_Declare(
     FIND_PACKAGE_ARGS NAMES ROCmCMakeBuildTools
 )
 FetchContent_MakeAvailable(rocm-cmake)
+# lint_cmake: +readability/wonkycase
 
 if(rocm-cmake_SOURCE_DIR)
     message(STATUS "Using fetched rocm-cmake.")

--- a/rocfile/src/CMakeLists.txt
+++ b/rocfile/src/CMakeLists.txt
@@ -26,6 +26,6 @@ ais_add_libraries(
     DETAIL   amd
     SRCS     ${ROCFILE_SOURCES}
     LIBINCL  ${ROCFILE_INCLUDE_PATH}
-    SYSINCLS ${ROCFILE_SOURCE_PATH} 
+    SYSINCLS ${ROCFILE_SOURCE_PATH}
     LIBS     mount
 )


### PR DESCRIPTION
* Add an rc file for running cmake-lint
    * Currently just suppresses line length warnings
* Fix identified issues
* Add suppression comments for FetchContent format issues