### PR TITLE
Quiet clang-tidy about invalid enum values

### DIFF
--- a/shared/invalid-enum.h
+++ b/shared/invalid-enum.h
@@ -9,5 +9,5 @@ template <typename Enum>
 constexpr Enum
 invalidEnum(int value)
 {
-    return static_cast<Enum>(value); // NOLINT
+    return static_cast<Enum>(value); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
 }

--- a/shared/invalid-enum.h
+++ b/shared/invalid-enum.h
@@ -9,5 +9,5 @@ template <typename Enum>
 constexpr Enum
 invalidEnum(int value)
 {
-    return static_cast<Enum>(value);
+    return static_cast<Enum>(value); // NOLINT
 }


### PR DESCRIPTION
Only in test code
