### PR TITLE
CI: Add a concurrency tag when updating the image.

### DIFF
--- a/.github/workflows/update-ais-ci-image.yml
+++ b/.github/workflows/update-ais-ci-image.yml
@@ -8,7 +8,9 @@ on:
       - develop
   workflow_dispatch:
     # Requires write access to trigger.
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
If multiple commits are merged rapidly, there is not much point in continuing to build & push an old image (not to mention the race condition that occurs).

Only keep the image from the last commit.
