### PR TITLE
CI: Add image caching to when we update the CI image.

### DIFF
--- a/.github/workflows/build-ais-ci-image.yml
+++ b/.github/workflows/build-ais-ci-image.yml
@@ -24,10 +24,6 @@ jobs:
     container: docker:28.5
     outputs:
       new_ci_image: ${{ steps.ci-image.outputs.AIS_CI_IMAGE }}
-      image_tag: ${{ steps.ci-image.outputs.AIS_CI_IMAGE_TAG }}
-      # image_tag is a bit hacky. GitHub does not support separating outputs
-      # from a workflow run in a matrix. The last workflow to run will set the
-      # output value. `image_tag` is constant across matrix jobs so this is fine.
     steps:
       - name: Set CI environment variables
         run: |

--- a/.github/workflows/build-ais-ci-image.yml
+++ b/.github/workflows/build-ais-ci-image.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           echo "AIS_CI_IMAGE=${{ env.AIS_DOCKER_REGISTRY }}/${{ env.AIS_CI_IMAGE_NAME}}:${AIS_CI_IMAGE_TAG}" \
             >> "${GITHUB_OUTPUT}"
+          echo "AIS_CI_LATEST_CACHE=${{ env.AIS_DOCKER_REGISTRY }}/${{ env.AIS_CI_IMAGE_NAME}}:latest-cache" \
+            >> "${GITHUB_OUTPUT}"
       - name: Fetching code repository...
         uses: actions/checkout@v5
       - name: Authenticating to GitHub Container Registry.
@@ -62,6 +64,7 @@ jobs:
               PR URL: ${{ env.AIS_PR_BASE_URL }}/${AIS_PR_NUMBER}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from=type=registry,ref=${{ steps.ci-image.outputs.AIS_CI_IMAGE }} \
+            --cache-from=type=registry,ref=${{ steps.ci-image.outcome.AIS_CI_LATEST_CACHE }} \
             --push \
             -t ${{ steps.ci-image.outputs.AIS_CI_IMAGE }} \
             ${GITHUB_WORKSPACE}

--- a/.github/workflows/update-ais-ci-image.yml
+++ b/.github/workflows/update-ais-ci-image.yml
@@ -8,6 +8,12 @@ on:
       - develop
   workflow_dispatch:
     # Requires write access to trigger.
+    inputs:
+      pull_from_cache:
+        description: Build image with 'latest' cache
+        required: false
+        default: true
+        type: boolean
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -42,20 +48,33 @@ jobs:
         run: |
           echo "AIS_CI_IMAGE=${{ env.AIS_DOCKER_REGISTRY }}/${{ env.AIS_CI_IMAGE_NAME}}:latest" \
             >> "${GITHUB_OUTPUT}"
+      - name: Set Docker Cache Instruction
+        id: use-cache
+        # If triggered by a pull_request, pull_from_cache will be null. Note
+        # however `false == null` resolves to `true`. Use empty string to check
+        # for 'null'.
+        # See: https://docs.github.com/en/actions/reference/workflows-and-actions/expressions
+        # for how null gets converted when compared to non-null, and converted into a string.
+        run: >-
+          echo "CACHE_FROM_CMD=${{
+            ( format('{0}', inputs.pull_from_cache) == '' || inputs.pull_from_cache ) &&
+            format('--cache-from=type=registry,ref=\"{0}-cache\"', steps.ci-image.outputs.AIS_CI_IMAGE) ||
+            ''
+          }}" >> "${GITHUB_OUTPUT}"
       - name: Setup Docker Builder
         uses: docker/setup-buildx-action@v3.11.1
         with:
           name: ais-builder
           driver: docker-container
           cache-binary: false # True uses the GHA Cache Backend.
-      # We won't use the cache from the previous image.
-      # This lets us semi-regularly pull in package updates automatically.
       - name: Build & Push latest image for AIS CI
         run: |
           docker buildx build \
             -f ${GITHUB_WORKSPACE}/util/docker/DOCKERFILE.${{ env.AIS_CI_IMAGE_NAME }} \
             --label "org.opencontainers.image.description= \
               Latest AIS CI Image for ${{ matrix.supported_platforms }}." \
+            --cache-to=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE }}-cache" \
+            ${{ steps.use-cache.outputs.CACHE_FROM_CMD }} \
             --push \
             -t ${{ steps.ci-image.outputs.AIS_CI_IMAGE }} \
             ${GITHUB_WORKSPACE}

--- a/.github/workflows/update-ais-ci-image.yml
+++ b/.github/workflows/update-ais-ci-image.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       AIS_DOCKER_REGISTRY: ghcr.io/rocm/hipfile
       AIS_CI_IMAGE_NAME: ais_ci_${{ matrix.supported_platforms }}
-    if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
     runs-on: [ubuntu-24.04]
     container: docker:28.5
     strategy:


### PR DESCRIPTION
Re-introduce caching when building & updating the latest CI image. This will help reduce how quickly the local docker image registry fills up with dangling image layers.

A future enhancement could be adding another --cache-from instruction that caches from the PR that was just merged. If the Dockerfile was changed, it can re-use the image layers from the pre-checkin workflow runs. Else, there is a cache-miss but otherwise does not stop the build from taking place.

Also fixes an issue with the gate when triggering this workflow manually. Before this change, the workflow could be manually triggered but would immediately be "skipped" due to failing the `if:` condition on the job.

Workflow run after PR merge that invalidates the cache (e.g. modify DOCKERFILE): https://github.com/riley-dixon/hipFile-test/actions/runs/19553569023
Workflow run after PR merge without invalidating the cache: https://github.com/riley-dixon/hipFile-test/actions/runs/19553743491
Manual run with caching from enabled: https://github.com/riley-dixon/hipFile-test/actions/runs/19553782405
Manual run with caching from disabled: https://github.com/riley-dixon/hipFile-test/actions/runs/19553796414
