### PR TITLE
cmake: Add hipfile/rocfile label on tests.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,7 +46,18 @@ Options
 `cmake --build .`
 
 ### Run tests
-`ctest .`
+
+`ctest .` will run all tests.
+
+You can filter on test labels using the `-L` option. We currently have `hipfile` and `rocfile` labels for each library and `unit`, `system`, and `stress` labels for the different test types. Multiple `-L` options form an *and*. A `|` can be used for an *or*.
+
+`ctest . -L rocfile -L unit` runs all unit tests in the rocFile library.
+`ctest . -L 'system|unit'` runs all system or unit tests.
+
+You can filter on test names using the `-R` option. This option supports wildcards.
+
+`ctest . -R RocFileBuffer.get_buffer_makes_temporary_buffer` runs the specified test.
+`ctest . -R 'RocFileBuffer*'` runs all tests that start with RocFileBuffer.
 
 ### Install and package
 The hipFile and rocFile libraries can be installed with CMake. The default

--- a/hipfile/test/CMakeLists.txt
+++ b/hipfile/test/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 
 ais_gtest_discover_tests(
     hipfile_tests
-    PROPERTIES LABELS unit
+    PROPERTIES "LABELS;unit;LABELS;hipfile"
     TEST_LIST hipfile_unit_tests
 )
 
@@ -82,7 +82,7 @@ gtest_discover_tests(
     hipfile_system_tests
     EXTRA_ARGS --ais-capable-dir ${AIS_CAPABLE_DIR}
     WORKING_DIRECTORY ${AIS_CAPABLE_DIR}
-    PROPERTIES LABELS system
+    PROPERTIES "LABELS;system;LABELS;hipfile"
 )
 
 # Temporary Test Files

--- a/rocfile/test/CMakeLists.txt
+++ b/rocfile/test/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(rocfile_tests PRIVATE GTest::gtest_main)
 
 ais_gtest_discover_tests(
     rocfile_tests
-    PROPERTIES LABELS unit
+    PROPERTIES "LABELS;unit;LABELS;rocfile"
     TEST_LIST rocfile_unit_tests
 )
 
@@ -71,7 +71,7 @@ add_test(
     NAME state_mt_test
     COMMAND gdb --batch --quiet -ex run -ex "thread apply all bt full" --return-child-result --args $<TARGET_FILE:state_mt>
 )
-set_tests_properties(state_mt_test PROPERTIES LABELS stress)
+set_tests_properties(state_mt_test PROPERTIES LABELS "stress;rocfile")
 
 ais_add_executable(
     NAME batch_mt
@@ -83,4 +83,4 @@ add_test(
     NAME batch_mt_test
     COMMAND gdb --batch --quiet -ex run -ex "thread apply all bt full" --return-child-result --args $<TARGET_FILE:batch_mt>
 )
-set_tests_properties(batch_mt_test PROPERTIES LABELS stress)
+set_tests_properties(batch_mt_test PROPERTIES LABELS "stress;rocfile")


### PR DESCRIPTION
Allows filtering on tests by library.  For example, rocfile unit tests can be run with the following command:

ctest . -L 'rocfile' -L 'unit'