### PR TITLE
Add 'no execute' linker flag

### DIFF
--- a/cmake/AISAddLibraries.cmake
+++ b/cmake/AISAddLibraries.cmake
@@ -108,6 +108,10 @@ function(ais_add_libraries)
         endif()
         target_link_libraries(${target} PRIVATE hip::host)
 
+        # Add link options (mainly for hardening)
+        # Assumes a linker that understands ld flags
+        target_link_options(${target} PRIVATE "-Wl,-z,noexecstack")
+
         # Add the common include path
         target_include_directories(${target} PRIVATE "${CMAKE_SOURCE_DIR}/shared")
 

--- a/cmake/AISAddLibraries.cmake
+++ b/cmake/AISAddLibraries.cmake
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 include(AISCompilerOptions)
+include(CheckLinkerFlag)
 
 # Add static and shared libraries using AIS build conventions
 #
@@ -109,8 +110,10 @@ function(ais_add_libraries)
         target_link_libraries(${target} PRIVATE hip::host)
 
         # Add link options (mainly for hardening)
-        # Assumes a linker that understands ld flags
-        target_link_options(${target} PRIVATE "-Wl,-z,noexecstack")
+        check_linker_flag(CXX "-Wl,-z,noexecstack" LINKER_SUPPORTS_NOEXECSTACK)
+        if(LINKER_SUPPORTS_NOEXECSTACK)
+            target_link_options(${target} PRIVATE "-Wl,-z,noexecstack")
+        endif()
 
         # Add the common include path
         target_include_directories(${target} PRIVATE "${CMAKE_SOURCE_DIR}/shared")


### PR DESCRIPTION
Marks the stack as non-executable

Only useful with ld-compatible linkers (which is most of the Linux ones)