### PR TITLE
Restrict shellcheck CI to .sh changes

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,7 +1,10 @@
 # Run ShellCheck (https://www.shellcheck.net/) over all shell scripts
 # in the repository
 name: ShellCheck
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '**.sh'
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
All our current shell scripts have a .sh extension