### PR TITLE
Add AIS_BUILD_INTEGER_SANITIZERS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,6 +44,13 @@ Options
 |BUILD\_ROCFILE|ON|Build the rocFile library (AMD only, OFF for NVIDIA)|
 |BUILD\_TESTING|ON|Build the test suite|
 
+Sanitizer options
+|Option|Default|Purpose|
+|------|-------|-------|
+|AIS\_BUILD\_SANITIZERS|OFF|Build with -fsanitize=address, leak, and undefined|
+|AIS\_BUILD\_INTEGER\_SANITIZERS|OFF|Build with -fsanitize=integer (clang only)|
+|AIS\_BUILD\_THREAD\_SANITIZERS|OFF|Build with -fsanitize=thread (not compatible with AIS\_BUILD\_SANITIZERS)|
+
 ### Build
 `cmake --build .`
 

--- a/cmake/AISSanitizers.cmake
+++ b/cmake/AISSanitizers.cmake
@@ -48,7 +48,7 @@ function(ais_add_sanitizers target)
             target_compile_options(${target} PRIVATE ${integer_sanitize_flags})
             target_link_options(${target} PRIVATE ${integer_sanitize_flags})
         else()
-            message(WARNING "The integer sanitizer is only available on clang")
+            message(FATAL_ERROR "The integer sanitizer is only available on clang")
         endif()
     endif()
 

--- a/cmake/AISSanitizers.cmake
+++ b/cmake/AISSanitizers.cmake
@@ -38,8 +38,7 @@ function(ais_add_sanitizers target)
     # the process if undefined integer behaviour occurs (like
     # wrapping a signed integer).
     if(AIS_BUILD_INTEGER_SANITIZERS)
-        set(compiler_id "${CMAKE_CXX_COMPILER_ID}")
-        if(compiler_id STREQUAL "Clang")
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             set(integer_sanitize_flags
                 -fsanitize=integer
                 -fsanitize-minimal-runtime

--- a/cmake/AISSanitizers.cmake
+++ b/cmake/AISSanitizers.cmake
@@ -4,6 +4,7 @@
 
 option(AIS_BUILD_SANITIZERS "Build with -fsanitize=address, leak, and undefined" OFF)
 option(AIS_BUILD_THREAD_SANITIZERS "Build with -fsanitize=thread (not compatible with AIS_BUILD_SANITIZERS)" OFF)
+option(AIS_BUILD_INTEGER_SANITIZERS "Build with -fsanitize=integer (clang only)" OFF)
 
 if(AIS_BUILD_THREAD_SANITIZERS)
     message(WARNING "TSAN has known problems with higher levels of entropy, try using `sudo sysctl vm.mmap_rnd_bits=28` if you encounter errors concerning unexpected memory mappings.")
@@ -30,4 +31,25 @@ function(ais_add_sanitizers target)
         target_compile_options(${target} PRIVATE -fsanitize=thread)
         target_link_options(${target} PRIVATE -fsanitize=thread)
     endif()
+
+    # clang-only
+    #
+    # This has a very small runtime penalty (<1%) and will kill
+    # the process if undefined integer behaviour occurs (like
+    # wrapping a signed integer).
+    if(AIS_BUILD_INTEGER_SANITIZERS)
+        set(compiler_id "${CMAKE_CXX_COMPILER_ID}")
+        if(compiler_id STREQUAL "Clang")
+            set(integer_sanitize_flags
+                -fsanitize=integer
+                -fsanitize-minimal-runtime
+                -fno-sanitize-recover
+            )
+            target_compile_options(${target} PRIVATE ${integer_sanitize_flags})
+            target_link_options(${target} PRIVATE ${integer_sanitize_flags})
+        else()
+            message(WARNING "The integer sanitizer is only available on clang")
+        endif()
+    endif()
+
 endfunction()

--- a/cmake/AISSanitizers.cmake
+++ b/cmake/AISSanitizers.cmake
@@ -43,7 +43,7 @@ function(ais_add_sanitizers target)
             set(integer_sanitize_flags
                 -fsanitize=integer
                 -fsanitize-minimal-runtime
-                -fno-sanitize-recover
+                -fno-sanitize-recover=integer
             )
             target_compile_options(${target} PRIVATE ${integer_sanitize_flags})
             target_link_options(${target} PRIVATE ${integer_sanitize_flags})


### PR DESCRIPTION
Adds an option to build integer sanitizers (clang-only)
