### PR TITLE
Turn AIS_WARN_UNSAFE_BUFFER_OPS on by default

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,7 +37,7 @@ Options
 |------|-------|-------|
 |AIS\_USE\_CLANG\_TIDY|OFF|Run the `clang-tidy` tool|
 |AIS\_USE\_IWYU|OFF|Run the `include-what-you-use` tool|
-|AIS\_WARN\_UNSAFE\_BUFFER\_OPS|ON|Scan code for unsafe buffer operations (clang only)|
+|AIS\_WARN\_UNSAFE\_BUFFER\_OPS|ON|Scan code for unsafe buffer operations (clang only, OFF for others)|
 |BUILD\_AIS\_DOCS|OFF|Build API documentation (requires Doxygen)|
 |BUILD\_AISCP|ON|Build `aiscp` example program (OFF if no hipFile)|
 |BUILD\_CODE\_COVERAGE|OFF|Generate code coverage information when tests are run|

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,6 +37,7 @@ Options
 |------|-------|-------|
 |AIS\_USE\_CLANG\_TIDY|OFF|Run the `clang-tidy` tool|
 |AIS\_USE\_IWYU|OFF|Run the `include-what-you-use` tool|
+|AIS\_WARN\_UNSAFE\_BUFFER\_OPS|ON|Scan code for unsafe buffer operations (clang only)|
 |BUILD\_AIS\_DOCS|OFF|Build API documentation (requires Doxygen)|
 |BUILD\_AISCP|ON|Build `aiscp` example program (OFF if no hipFile)|
 |BUILD\_CODE\_COVERAGE|OFF|Generate code coverage information when tests are run|

--- a/cmake/AISClangSafeBuffers.cmake
+++ b/cmake/AISClangSafeBuffers.cmake
@@ -9,7 +9,13 @@
 #
 # Fixing this cleanly requires C++20, so it's an option for now
 #-----------------------------------------------------------------------------
-option(AIS_WARN_UNSAFE_BUFFER_OPS "Warn about unsafe buffer operations (llvm C++ only)" OFF)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(USE_UBO ON)
+else()
+    set(USE_UBO OFF)
+endif()
+option(AIS_WARN_UNSAFE_BUFFER_OPS "Warn about unsafe buffer operations (llvm C++ only)" ${USE_UBO})
+
 if(AIS_WARN_UNSAFE_BUFFER_OPS)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         set(AIS_CLANG_WARNING_FLAGS
@@ -17,5 +23,7 @@ if(AIS_WARN_UNSAFE_BUFFER_OPS)
             -fsafe-buffer-usage-suggestions
             ${AIS_CLANG_WARNING_FLAGS}
         )
+    else()
+        message(FATAL_ERROR "Unsafe buffer warnings are only useful for clang/llvm")
     endif()
 endif()


### PR DESCRIPTION
This affects clang/llvm C++ only. We currently raise no warnings with this switched on. If it becomes problematic in the future, we can switch it back off, but it's useful to turn on to encourage developers to find other solutions if this raises warnings.

This is only turned on by default w/ clang. For gcc, it remains off since it's not useful. It will now emit a FATAL_ERROR if enabled with gcc.
