### PR TITLE
Remove BUILD_HIPFILE/ROCFILE

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -325,8 +325,6 @@ jobs:
               cmake \
                 -DCMAKE_CXX_COMPILER=${{ matrix.supported_compilers }} \
                 -DCMAKE_CXX_FLAGS="-Werror" \
-                -DBUILD_ROCFILE=OFF \
-                -DBUILD_HIPFILE=ON \
                 -DCMAKE_HIP_PLATFORM=nvidia \
                 -DBUILD_AIS_DOCS=ON \
                 ..

--- a/.github/workflows/hipfile-nvidia.yml.disabled
+++ b/.github/workflows/hipfile-nvidia.yml.disabled
@@ -73,8 +73,6 @@ jobs:
               cmake \
                 -DCMAKE_CXX_COMPILER=g++ \
                 -DCMAKE_CXX_FLAGS="-Werror" \
-                -DBUILD_ROCFILE=OFF \
-                -DBUILD_HIPFILE=ON \
                 -DCMAKE_HIP_PLATFORM=nvidia \
                 -DBUILD_AIS_DOCS=ON \
                 -DAIS_CAPABLE_DIR=\"${ROCTMPDIR}\" \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,21 +156,19 @@ include(AISIWYU)
 #-------------------
 include(AISSanitizers)
 
-#----------------------------------
-# rocfile (default OFF for NVIDIA)
-#----------------------------------
+#-------------------
+# Platform defaults
+#-------------------
 if(CMAKE_HIP_PLATFORM STREQUAL "nvidia")
-    set(BUILD_ROCFILE_DEFAULT OFF)
+    set(BUILD_ROCFILE OFF)
 else()
-    set(BUILD_ROCFILE_DEFAULT ON)
+    set(BUILD_ROCFILE ON)
 endif()
-option(BUILD_ROCFILE "Build rocfile library (AMD only)" ${BUILD_ROCFILE_DEFAULT})
 
-#---------
-# hipfile
-#---------
-option(BUILD_HIPFILE "Build hipfile library" ON)
-cmake_dependent_option(BUILD_AISCP "Build aiscp example program" ON "BUILD_HIPFILE" OFF)
+#-----------------------
+# aiscp example program
+#-----------------------
+option(BUILD_AISCP "Build aiscp example program" ON)
 
 #------
 # docs
@@ -221,12 +219,10 @@ endif()
 #-----------------------------------------------------------------------------
 # Subdirectories to configure/build
 #-----------------------------------------------------------------------------
-if(BUILD_ROCFILE AND CMAKE_HIP_PLATFORM STREQUAL "amd")
+if(BUILD_ROCFILE)
     add_subdirectory(rocfile)
 endif()
-if(BUILD_HIPFILE)
-    add_subdirectory(hipfile)
-endif()
+add_subdirectory(hipfile)
 if(BUILD_AIS_DOCS)
     add_subdirectory(docs)
 endif()

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,10 +38,8 @@ Options
 |AIS\_USE\_CLANG\_TIDY|OFF|Run the `clang-tidy` tool|
 |AIS\_USE\_IWYU|OFF|Run the `include-what-you-use` tool|
 |BUILD\_AIS\_DOCS|OFF|Build API documentation (requires Doxygen)|
-|BUILD\_AISCP|ON|Build `aiscp` example program (OFF if no hipFile)|
+|BUILD\_AISCP|ON|Build `aiscp` example program|
 |BUILD\_CODE\_COVERAGE|OFF|Generate code coverage information when tests are run|
-|BUILD\_HIPFILE|ON|Build the hipFile library|
-|BUILD\_ROCFILE|ON|Build the rocFile library (AMD only, OFF for NVIDIA)|
 |BUILD\_TESTING|ON|Build the test suite|
 
 Sanitizer options

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -8,62 +8,54 @@
 include(ROCMInstallTargets)
 include(ROCMCreatePackage)
 
-if(BUILD_ROCFILE OR BUILD_HIPFILE)
 
-    # Install the package
-    if(BUILD_ROCFILE)
-        rocm_install(TARGETS rocfile_static)
-        rocm_install(TARGETS rocfile_shared)
-    endif()
-    if(BUILD_HIPFILE)
-        rocm_install(TARGETS hipfile_static)
-        rocm_install(TARGETS hipfile_shared)
-    endif()
+# Install the package
+if(BUILD_ROCFILE)
+    rocm_install(TARGETS rocfile_static)
+    rocm_install(TARGETS rocfile_shared)
+endif()
+rocm_install(TARGETS hipfile_static)
+rocm_install(TARGETS hipfile_shared)
 
-    # Install the headers
-    if(BUILD_ROCFILE)
-        rocm_install(
-            DIRECTORY ${CMAKE_SOURCE_DIR}/rocfile/include/
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        )
-    endif()
-    if(BUILD_HIPFILE)
-        rocm_install(
-            DIRECTORY ${CMAKE_SOURCE_DIR}/hipfile/include/
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        )
-    endif()
-
-    # Always install the hipfile-types.h file
+# Install the headers
+if(BUILD_ROCFILE)
     rocm_install(
-        FILES ${CMAKE_SOURCE_DIR}/shared/hipfile-types.h
+        DIRECTORY ${CMAKE_SOURCE_DIR}/rocfile/include/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
-
-    # rocm_package_add_dependencies() line should go here
-    # when we have dependencies
-
-    # Export the targets
-    if(BUILD_ROCFILE)
-        set(target_list ${target_list} roc::rocfile_shared roc::rocfile_static)
-    endif()
-    if(BUILD_HIPFILE)
-        set(target_list ${target_list} roc::hipfile_shared roc::hipfile_static)
-    endif()
-
-    rocm_export_targets(
-        TARGETS ${target_list}
-        NAMESPACE roc::
-    )
-
-    # CPack license setup
-    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.md")
-    set(CPACK_RPM_PACKAGE_LICENSE "MIT")
-
-    # Create the package
-    rocm_create_package(
-        NAME "hipFile"
-        DESCRIPTION "The hipFile (and rocFile w/ AMD) libraries"
-        MAINTAINER "ais-eap <ais-eap@amd.com>"
-    )
 endif()
+rocm_install(
+    DIRECTORY ${CMAKE_SOURCE_DIR}/hipfile/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Always install the hipfile-types.h file
+rocm_install(
+    FILES ${CMAKE_SOURCE_DIR}/shared/hipfile-types.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# rocm_package_add_dependencies() line should go here
+# when we have dependencies
+
+# Export the targets
+if(BUILD_ROCFILE)
+    set(target_list ${target_list} roc::rocfile_shared roc::rocfile_static)
+endif()
+set(target_list ${target_list} roc::hipfile_shared roc::hipfile_static)
+
+rocm_export_targets(
+    TARGETS ${target_list}
+    NAMESPACE roc::
+)
+
+# CPack license setup
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.md")
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+
+# Create the package
+rocm_create_package(
+    NAME "hipFile"
+    DESCRIPTION "The hipFile library"
+    MAINTAINER "ais-eap <ais-eap@amd.com>"
+)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -51,15 +51,7 @@ function(ais_add_docs_target AIS_DOC_PRETTY_NAME)
     add_dependencies(doc ${AIS_DOC_TARGET_NAME})
 endfunction()
 
-if(BUILD_HIPFILE)
-    ais_add_docs_target("hipFile")
-endif()
+ais_add_docs_target("hipFile")
 if(BUILD_ROCFILE)
-    ais_add_docs_target("rocFile")
-endif()
-# Allow building the docs when no library is selected
-# This builds ALL the API docs
-if(NOT BUILD_ROCFILE AND NOT BUILD_HIPFILE)
-    ais_add_docs_target("hipFile")
     ais_add_docs_target("rocFile")
 endif()


### PR DESCRIPTION
These CMake options will be meaningless as we consolidate hipFile and rocFile. We will now always build both libraries on AMD and only hipFile on NVIDIA.
