### PR TITLE
CI: Update container names

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -18,9 +18,9 @@ jobs:
   compile_on_AMD:
     runs-on: [ubuntu-24.04]
     steps:
-      - name: Get PR number and store it as a environment variable
+      - name: Set early AIS CI environment variables
         run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
-      - name: Set AIS CI image environment variables
+      - name: Set AIS CI container name
         run: |
           echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}" >> "$GITHUB_ENV"
       - name: Fetching code repository...
@@ -125,11 +125,11 @@ jobs:
           - clang++
           - g++
     steps:
-      - name: Get PR number and store it as a environment variable
+      - name: Set early AIS CI environment variables
         run: |
           echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
           echo "AIS_SAFE_COMPILER_NAME=$(echo ${{ matrix.alternate_compilers}} | sed 's|[\+]|plus|g')" >> "$GITHUB_ENV"
-      - name: Set AIS CI image environment variables
+      - name: Set AIS CI container name
         run: |
           echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}_${AIS_SAFE_COMPILER_NAME}" >> "$GITHUB_ENV"
       - name: Fetching code repository...
@@ -190,9 +190,9 @@ jobs:
     runs-on: [linux, AIS]
     needs: compile_on_AMD
     steps:
-      - name: Get PR number and store it as a environment variable
+      - name: Set early AIS CI environment variables
         run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
-      - name: Set AIS CI image environment variables
+      - name: Set AIS CI container name
         run: |
           echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}" >> "$GITHUB_ENV"
       - name: Fetching code repository...
@@ -282,11 +282,11 @@ jobs:
           - g++
           - clang++
     steps:
-      - name: Get PR number and store it as a environment variable
+      - name: Set early AIS CI environment variables
         run: |
           echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
           echo "AIS_SAFE_COMPILER_NAME=$(echo ${{ matrix.supported_compilers }} | sed 's|[\+]|plus|g')" >> "$GITHUB_ENV"
-      - name: Set AIS CI image environment variables
+      - name: Set AIS CI container name
         run: |
           echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}_${AIS_SAFE_COMPILER_NAME}" >> "$GITHUB_ENV"
       - name: Fetching code repository...

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
       - name: Set AIS CI image environment variables
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{inputs.platform}}" >> "$GITHUB_ENV"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}" >> "$GITHUB_ENV"
       - name: Fetching code repository...
         uses: actions/checkout@v6
       - name: Authenticating to GitHub Container Registry
@@ -126,10 +126,12 @@ jobs:
           - g++
     steps:
       - name: Get PR number and store it as a environment variable
-        run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
+        run: |
+          echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
+          echo "AIS_SAFE_COMPILER_NAME=$(echo ${{ matrix.alternate_compilers}} | sed 's|[\+]|plus|g')" >> "$GITHUB_ENV"
       - name: Set AIS CI image environment variables
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{inputs.platform}}" >> "$GITHUB_ENV"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}_${AIS_SAFE_COMPILER_NAME}" >> "$GITHUB_ENV"
       - name: Fetching code repository...
         uses: actions/checkout@v6
       - name: Authenticating to GitHub Container Registry
@@ -192,7 +194,7 @@ jobs:
         run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
       - name: Set AIS CI image environment variables
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{inputs.platform}}_nvidia" >> "$GITHUB_ENV"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}" >> "$GITHUB_ENV"
       - name: Fetching code repository...
         uses: actions/checkout@v6
       - name: Authenticating to GitHub Container Registry
@@ -281,10 +283,12 @@ jobs:
           - clang++
     steps:
       - name: Get PR number and store it as a environment variable
-        run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
+        run: |
+          echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "$GITHUB_ENV"
+          echo "AIS_SAFE_COMPILER_NAME=$(echo ${{ matrix.supported_compilers }} | sed 's|[\+]|plus|g')" >> "$GITHUB_ENV"
       - name: Set AIS CI image environment variables
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{inputs.platform}}_nvidia" >> "$GITHUB_ENV"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}_${AIS_SAFE_COMPILER_NAME}" >> "$GITHUB_ENV"
       - name: Fetching code repository...
         uses: actions/checkout@v6
       - name: Authenticating to GitHub Container Registry


### PR DESCRIPTION
This isn't an issue on isolated runners, but on a host with multiple runners could induce a conflict in Docker with trying to start a container with the same name as an existing container. This would only occur on matrix jobs since the matrix parameter is not actually added to the `job_id`. I don't believe we ever hit this issue however since this was introduced as we switched away from self-hosted machines.
