### PR TITLE
Enable clang-tidy warnings as errors

### DIFF
--- a/cmake/AISClangTidy.cmake
+++ b/cmake/AISClangTidy.cmake
@@ -11,5 +11,5 @@ option(AIS_USE_CLANG_TIDY "Run clang-tidy when compiling" OFF)
 
 if(AIS_USE_CLANG_TIDY)
     find_program(CLANG_TIDY_EXE NAMES clang-tidy REQUIRED)
-    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE})
+    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE};-warnings-as-errors=*)
 endif()

--- a/hipfile/src/amd_detail/buffer.cpp
+++ b/hipfile/src/amd_detail/buffer.cpp
@@ -166,6 +166,7 @@ BufferMap::~BufferMap()
                   [](const auto &pair) { return pair.first; });
 
         for (const auto &ptr : buffer_ptrs) {
+            // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
             deregisterBuffer(ptr);
         }
     }

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -155,6 +155,7 @@ FileMap::~FileMap()
                   [](const auto &pair) { return pair.first; });
 
         for (const auto &fh : file_handles) {
+            // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
             deregisterFile(fh);
         }
     }


### PR DESCRIPTION
* Adds -warnings-as-errors=* to clang-tidy in CMake
* Adds warning suppression comments to virtual destructor issues