### PR TITLE
Remove Buffer and File class friends

### DIFF
--- a/hipfile/src/amd_detail/buffer.cpp
+++ b/hipfile/src/amd_detail/buffer.cpp
@@ -6,6 +6,7 @@
 #include "buffer.h"
 #include "context.h"
 #include "hip.h"
+#include "passkey.h"
 #include "sys.h"
 
 #include <algorithm>
@@ -46,7 +47,7 @@ isValidBufferRegion(void *ptr, size_t length)
     return true;
 }
 
-Buffer::Buffer(const void *_buffer, size_t _length, int _flags, Key<BufferMap>)
+Buffer::Buffer(const void *_buffer, size_t _length, int _flags, PassKey<BufferMap>)
     : buffer{const_cast<void *>(_buffer)}, length{_length}, flags{_flags}
 {
     if (!buffer) {
@@ -102,7 +103,7 @@ BufferMap::registerBuffer(const void *buf, size_t length, int flags)
         throw BufferAlreadyRegistered();
     }
 
-    auto buffer   = std::shared_ptr<IBuffer>(new Buffer(buf, length, flags, Key<BufferMap>{}));
+    auto buffer   = std::shared_ptr<IBuffer>(new Buffer(buf, length, flags, PassKey<BufferMap>{}));
     from_ptr[buf] = buffer;
 }
 
@@ -140,7 +141,7 @@ BufferMap::getBuffer(const void *buf, size_t length, int flags)
     if (from_ptr.end() == itr) {
         // If the buffer hasn't been registered, use an unregistered
         // temporary Buffer object
-        return std::shared_ptr<IBuffer>(new Buffer(buf, length, flags, Key<BufferMap>{}));
+        return std::shared_ptr<IBuffer>(new Buffer(buf, length, flags, PassKey<BufferMap>{}));
     }
     else {
         // If we found a registered buffer, it's an error if the

--- a/hipfile/src/amd_detail/buffer.cpp
+++ b/hipfile/src/amd_detail/buffer.cpp
@@ -47,7 +47,7 @@ isValidBufferRegion(void *ptr, size_t length)
     return true;
 }
 
-Buffer::Buffer(const void *_buffer, size_t _length, int _flags, PassKey<BufferMap>)
+Buffer::Buffer(const void *_buffer, size_t _length, int _flags, const PassKey<BufferMap> &)
     : buffer{const_cast<void *>(_buffer)}, length{_length}, flags{_flags}
 {
     if (!buffer) {

--- a/hipfile/src/amd_detail/buffer.cpp
+++ b/hipfile/src/amd_detail/buffer.cpp
@@ -46,7 +46,7 @@ isValidBufferRegion(void *ptr, size_t length)
     return true;
 }
 
-Buffer::Buffer(const void *_buffer, size_t _length, int _flags)
+Buffer::Buffer(const void *_buffer, size_t _length, int _flags, Key<BufferMap>)
     : buffer{const_cast<void *>(_buffer)}, length{_length}, flags{_flags}
 {
     if (!buffer) {
@@ -102,7 +102,7 @@ BufferMap::registerBuffer(const void *buf, size_t length, int flags)
         throw BufferAlreadyRegistered();
     }
 
-    auto buffer   = std::shared_ptr<IBuffer>(new Buffer(buf, length, flags));
+    auto buffer   = std::shared_ptr<IBuffer>(new Buffer(buf, length, flags, Key<BufferMap>{}));
     from_ptr[buf] = buffer;
 }
 
@@ -140,7 +140,7 @@ BufferMap::getBuffer(const void *buf, size_t length, int flags)
     if (from_ptr.end() == itr) {
         // If the buffer hasn't been registered, use an unregistered
         // temporary Buffer object
-        return std::shared_ptr<IBuffer>(new Buffer(buf, length, flags));
+        return std::shared_ptr<IBuffer>(new Buffer(buf, length, flags, Key<BufferMap>{}));
     }
     else {
         // If we found a registered buffer, it's an error if the

--- a/hipfile/src/amd_detail/buffer.h
+++ b/hipfile/src/amd_detail/buffer.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "key.h"
+#include "passkey.h"
 
 #include <cstddef>
 #include <hip/hip_runtime_api.h>
@@ -87,7 +87,7 @@ public:
     /// @param length Buffer length
     /// @param flags Buffer flags (unused)
     /// @param k  Key class instance (see key.h)
-    Buffer(const void *buf, size_t length, int flags, Key<BufferMap> k);
+    Buffer(const void *buf, size_t length, int flags, PassKey<BufferMap> k);
 
 private:
     /// @brief Pointer to a hip allocated buffer

--- a/hipfile/src/amd_detail/buffer.h
+++ b/hipfile/src/amd_detail/buffer.h
@@ -87,7 +87,7 @@ public:
     /// @param length Buffer length
     /// @param flags Buffer flags (unused)
     /// @param k  Key class instance (see passkey.h)
-    Buffer(const void *buf, size_t length, int flags, PassKey<BufferMap> k);
+    Buffer(const void *buf, size_t length, int flags, const PassKey<BufferMap> &k);
 
 private:
     /// @brief Pointer to a hip allocated buffer

--- a/hipfile/src/amd_detail/buffer.h
+++ b/hipfile/src/amd_detail/buffer.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "key.h"
+
 #include <cstddef>
 #include <hip/hip_runtime_api.h>
 #include <memory>
@@ -59,6 +61,8 @@ public:
     virtual int           getGpuId() const  = 0;
 };
 
+class BufferMap;
+
 class Buffer : public IBuffer {
 
 public:
@@ -82,7 +86,7 @@ public:
     /// @param buf Buffer pointer
     /// @param length Buffer length
     /// @param flags Buffer flags (unused)
-    Buffer(const void *buf, size_t length, int flags);
+    Buffer(const void *buf, size_t length, int flags, Key<BufferMap>);
 
 private:
     /// @brief Pointer to a hip allocated buffer

--- a/hipfile/src/amd_detail/buffer.h
+++ b/hipfile/src/amd_detail/buffer.h
@@ -86,7 +86,8 @@ public:
     /// @param buf Buffer pointer
     /// @param length Buffer length
     /// @param flags Buffer flags (unused)
-    Buffer(const void *buf, size_t length, int flags, Key<BufferMap>);
+    /// @param k  Key class instance (see key.h)
+    Buffer(const void *buf, size_t length, int flags, Key<BufferMap> k);
 
 private:
     /// @brief Pointer to a hip allocated buffer

--- a/hipfile/src/amd_detail/buffer.h
+++ b/hipfile/src/amd_detail/buffer.h
@@ -86,7 +86,7 @@ public:
     /// @param buf Buffer pointer
     /// @param length Buffer length
     /// @param flags Buffer flags (unused)
-    /// @param k  Key class instance (see key.h)
+    /// @param k  Key class instance (see passkey.h)
     Buffer(const void *buf, size_t length, int flags, PassKey<BufferMap> k);
 
 private:

--- a/hipfile/src/amd_detail/buffer.h
+++ b/hipfile/src/amd_detail/buffer.h
@@ -78,13 +78,13 @@ public:
     virtual hipMemoryType getType() const override;
     virtual int           getGpuId() const override;
 
-private:
     /// @brief Creates a buffer.
     /// @param buf Buffer pointer
     /// @param length Buffer length
     /// @param flags Buffer flags (unused)
     Buffer(const void *buf, size_t length, int flags);
 
+private:
     /// @brief Pointer to a hip allocated buffer
     void *buffer;
 
@@ -99,8 +99,6 @@ private:
 
     /// @brief Gpu ID
     int gpu_id;
-
-    friend class BufferMap;
 };
 
 class BufferMap {

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -6,6 +6,7 @@
 #include "context.h"
 #include "file.h"
 #include "mountinfo.h"
+#include "passkey.h"
 #include "sys.h"
 
 #include <algorithm>
@@ -68,7 +69,7 @@ IFile::getHandle() const
     return reinterpret_cast<hipFileHandle_t>(const_cast<IFile *>(this));
 }
 
-File::File(const UnregisteredFile &uf, Key<FileMap>)
+File::File(const UnregisteredFile &uf, PassKey<FileMap>)
     : fd{uf.getFd()}, stx{uf.getStatx()}, status_flags{uf.getFlags()}, mountinfo{uf.getMountInfo()}
 {
 }
@@ -115,7 +116,7 @@ FileMap::registerFile(const UnregisteredFile &uf)
         throw FileAlreadyRegistered();
     }
 
-    auto file                  = std::shared_ptr<IFile>(new File(uf, Key<FileMap>{}));
+    auto file                  = std::shared_ptr<IFile>(new File(uf, PassKey<FileMap>{}));
     from_fd[file->getFd()]     = file;
     from_fh[file->getHandle()] = file;
 

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -68,7 +68,7 @@ IFile::getHandle() const
     return reinterpret_cast<hipFileHandle_t>(const_cast<IFile *>(this));
 }
 
-File::File(const UnregisteredFile &uf)
+File::File(const UnregisteredFile &uf, Key<FileMap>)
     : fd{uf.getFd()}, stx{uf.getStatx()}, status_flags{uf.getFlags()}, mountinfo{uf.getMountInfo()}
 {
 }
@@ -115,7 +115,7 @@ FileMap::registerFile(const UnregisteredFile &uf)
         throw FileAlreadyRegistered();
     }
 
-    auto file                  = std::shared_ptr<IFile>(new File(uf));
+    auto file                  = std::shared_ptr<IFile>(new File(uf, Key<FileMap>{}));
     from_fd[file->getFd()]     = file;
     from_fh[file->getHandle()] = file;
 

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -69,7 +69,7 @@ IFile::getHandle() const
     return reinterpret_cast<hipFileHandle_t>(const_cast<IFile *>(this));
 }
 
-File::File(const UnregisteredFile &uf, PassKey<FileMap>)
+File::File(const UnregisteredFile &uf, const PassKey<FileMap> &)
     : fd{uf.getFd()}, stx{uf.getStatx()}, status_flags{uf.getFlags()}, mountinfo{uf.getMountInfo()}
 {
 }

--- a/hipfile/src/amd_detail/file.h
+++ b/hipfile/src/amd_detail/file.h
@@ -110,7 +110,8 @@ public:
 
     /// @brief Construct a registered file
     /// @param uf An unregistered file
-    File(const UnregisteredFile &uf, Key<FileMap>);
+    /// @param k  Key class instance (see key.h)
+    File(const UnregisteredFile &uf, Key<FileMap> k);
 
 private:
     /// @brief The file descriptor

--- a/hipfile/src/amd_detail/file.h
+++ b/hipfile/src/amd_detail/file.h
@@ -105,11 +105,11 @@ public:
     virtual int                      getStatusFlags() const override;
     virtual std::optional<MountInfo> getMountInfo() const override;
 
-private:
     /// @brief Construct a registered file
     /// @param uf An unregistered file
     File(const UnregisteredFile &uf);
 
+private:
     /// @brief The file descriptor
     int fd;
 
@@ -123,8 +123,6 @@ private:
 
     /// @brief Mount information for the filesystem backing fd
     std::optional<MountInfo> mountinfo;
-
-    friend class FileMap;
 };
 
 class FileMap {

--- a/hipfile/src/amd_detail/file.h
+++ b/hipfile/src/amd_detail/file.h
@@ -111,7 +111,7 @@ public:
     /// @brief Construct a registered file
     /// @param uf An unregistered file
     /// @param k  Key class instance (see passkey.h)
-    File(const UnregisteredFile &uf, PassKey<FileMap> k);
+    File(const UnregisteredFile &uf, const PassKey<FileMap> &k);
 
 private:
     /// @brief The file descriptor

--- a/hipfile/src/amd_detail/file.h
+++ b/hipfile/src/amd_detail/file.h
@@ -110,7 +110,7 @@ public:
 
     /// @brief Construct a registered file
     /// @param uf An unregistered file
-    /// @param k  Key class instance (see key.h)
+    /// @param k  Key class instance (see passkey.h)
     File(const UnregisteredFile &uf, PassKey<FileMap> k);
 
 private:

--- a/hipfile/src/amd_detail/file.h
+++ b/hipfile/src/amd_detail/file.h
@@ -6,8 +6,8 @@
 #pragma once
 
 #include "hipfile.h"
-#include "key.h"
 #include "mountinfo.h"
+#include "passkey.h"
 
 #include <linux/stat.h>
 #include <memory>
@@ -111,7 +111,7 @@ public:
     /// @brief Construct a registered file
     /// @param uf An unregistered file
     /// @param k  Key class instance (see key.h)
-    File(const UnregisteredFile &uf, Key<FileMap> k);
+    File(const UnregisteredFile &uf, PassKey<FileMap> k);
 
 private:
     /// @brief The file descriptor

--- a/hipfile/src/amd_detail/file.h
+++ b/hipfile/src/amd_detail/file.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "hipfile.h"
+#include "key.h"
 #include "mountinfo.h"
 
 #include <linux/stat.h>
@@ -87,6 +88,8 @@ public:
     virtual std::optional<MountInfo> getMountInfo() const      = 0;
 };
 
+class FileMap;
+
 class File : public IFile {
 
 public:
@@ -107,7 +110,7 @@ public:
 
     /// @brief Construct a registered file
     /// @param uf An unregistered file
-    File(const UnregisteredFile &uf);
+    File(const UnregisteredFile &uf, Key<FileMap>);
 
 private:
     /// @brief The file descriptor

--- a/hipfile/src/amd_detail/key.h
+++ b/hipfile/src/amd_detail/key.h
@@ -1,0 +1,17 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+template <typename T> class Key {
+    friend T;
+
+    Key()
+    {
+    }
+    Key(Key const &)
+    {
+    }
+};

--- a/hipfile/src/amd_detail/key.h
+++ b/hipfile/src/amd_detail/key.h
@@ -5,8 +5,22 @@
 
 #pragma once
 
+/// @brief Key class for implementing the PassKey idiom
+///
+/// If you make this a parameter of a function, that function will be
+/// private to every class aside from the one specified in the template
+/// type. This allows friend semantics for a limited number of functions
+/// instead of the entire class.
+///
+/// This is used in hipFile to make the constructors in File, Buffer,
+/// etc. private to everyone aside from their associated container classes,
+/// which makes it impossible to instantiate an unregistered object.
+///
+/// @tparam T The "friend" class
 template <typename T> class Key {
     friend T;
+
+    // Note: Changing these constructors can break encapsulation.
 
     Key()
     {

--- a/hipfile/src/amd_detail/key.h
+++ b/hipfile/src/amd_detail/key.h
@@ -20,11 +20,13 @@
 template <typename T> class Key {
     friend T;
 
+private:
     // Note: Changing these constructors can break encapsulation.
 
     Key()
     {
     }
+
     Key(Key const &)
     {
     }

--- a/hipfile/src/amd_detail/passkey.h
+++ b/hipfile/src/amd_detail/passkey.h
@@ -17,17 +17,17 @@
 /// which makes it impossible to instantiate an unregistered object.
 ///
 /// @tparam T The "friend" class
-template <typename T> class Key {
+template <typename T> class PassKey {
     friend T;
 
 private:
     // Note: Changing these constructors can break encapsulation.
 
-    Key()
+    PassKey()
     {
     }
 
-    Key(Key const &)
+    PassKey(PassKey const &)
     {
     }
 };

--- a/hipfile/src/amd_detail/stream.cpp
+++ b/hipfile/src/amd_detail/stream.cpp
@@ -16,7 +16,7 @@
 
 namespace hipFile {
 
-Stream::Stream(const hipStream_t _hip_stream, uint32_t flags, PassKey<StreamMap>)
+Stream::Stream(const hipStream_t _hip_stream, uint32_t flags, const PassKey<StreamMap> &)
     : hip_stream{_hip_stream}, fixed_buf_offset{(flags & HIPFILE_STREAM_FIXED_BUF_OFFSET) != 0},
       fixed_file_offset{(flags & HIPFILE_STREAM_FIXED_FILE_OFFSET) != 0},
       fixed_io_size{(flags & HIPFILE_STREAM_FIXED_FILE_SIZE) != 0},

--- a/hipfile/src/amd_detail/stream.cpp
+++ b/hipfile/src/amd_detail/stream.cpp
@@ -4,6 +4,7 @@
  */
 #include "context.h"
 #include "hipfile.h"
+#include "passkey.h"
 #include "stream.h"
 #include "sys.h"
 
@@ -15,7 +16,7 @@
 
 namespace hipFile {
 
-Stream::Stream(const hipStream_t _hip_stream, uint32_t flags)
+Stream::Stream(const hipStream_t _hip_stream, uint32_t flags, PassKey<StreamMap>)
     : hip_stream{_hip_stream}, fixed_buf_offset{(flags & HIPFILE_STREAM_FIXED_BUF_OFFSET) != 0},
       fixed_file_offset{(flags & HIPFILE_STREAM_FIXED_FILE_OFFSET) != 0},
       fixed_io_size{(flags & HIPFILE_STREAM_FIXED_FILE_SIZE) != 0},
@@ -60,7 +61,7 @@ StreamMap::registerStream(hipStream_t hip_stream, uint32_t flags)
         throw std::invalid_argument("Stream is already registered");
     }
 
-    auto stream                     = std::shared_ptr<Stream>(new Stream(hip_stream, flags));
+    auto stream = std::shared_ptr<Stream>(new Stream(hip_stream, flags, PassKey<StreamMap>{}));
     StreamMap::from_ptr[hip_stream] = stream;
 }
 
@@ -80,7 +81,7 @@ StreamMap::getStream(hipStream_t hip_stream)
 {
     auto itr = StreamMap::from_ptr.find(hip_stream);
     if (StreamMap::from_ptr.end() == itr) {
-        return std::shared_ptr<Stream>(new Stream(hip_stream, 0));
+        return std::shared_ptr<Stream>(new Stream(hip_stream, 0, PassKey<StreamMap>{}));
     }
 
     return itr->second;

--- a/hipfile/src/amd_detail/stream.h
+++ b/hipfile/src/amd_detail/stream.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include "passkey.h"
+
 #include <cstdint>
 #include <hip/hip_runtime_api.h>
 #include <memory>
@@ -22,6 +24,8 @@ public:
     virtual bool        pageAligned() const       = 0;
 };
 
+class StreamMap;
+
 class Stream : public IStream {
 public:
     virtual ~Stream() override = default;
@@ -32,9 +36,9 @@ public:
     virtual bool        fixedIOSize() const override;
     virtual bool        pageAligned() const override;
 
-private:
-    Stream(const hipStream_t hip_stream, uint32_t flags);
+    Stream(const hipStream_t hip_stream, uint32_t flags, PassKey<StreamMap> k);
 
+private:
     Stream(const Stream &)             = delete;
     Stream &operator=(const Stream &)  = delete;
     Stream(const Stream &&)            = delete;
@@ -45,12 +49,12 @@ private:
     bool        fixed_file_offset;
     bool        fixed_io_size;
     bool        page_aligned;
-
-    friend struct StreamMap;
 };
 
-struct StreamMap {
+class StreamMap {
+public:
     ~StreamMap();
+
     /// @brief Registers a stream to use for async operations
     /// @param hip_stream A HIP stream
     /// @param flags Stream flags
@@ -64,7 +68,7 @@ struct StreamMap {
     /// @param hip_stream A HIP stream
     std::shared_ptr<IStream> getStream(hipStream_t hip_stream);
 
-protected:
+private:
     std::unordered_map<hipStream_t, std::shared_ptr<IStream>> from_ptr;
 };
 

--- a/hipfile/src/amd_detail/stream.h
+++ b/hipfile/src/amd_detail/stream.h
@@ -36,7 +36,7 @@ public:
     virtual bool        fixedIOSize() const override;
     virtual bool        pageAligned() const override;
 
-    Stream(const hipStream_t hip_stream, uint32_t flags, PassKey<StreamMap> k);
+    Stream(const hipStream_t hip_stream, uint32_t flags, const PassKey<StreamMap> &k);
 
 private:
     Stream(const Stream &)             = delete;


### PR DESCRIPTION
I don't recall the reason for making the ctors private, requiring friend classes to instantiate them. I'm personally not a fan of breaking encapsulation with friend classes.