### PR TITLE
Use default dtors for BufferMap and FileMap

### DIFF
--- a/hipfile/src/amd_detail/buffer.cpp
+++ b/hipfile/src/amd_detail/buffer.cpp
@@ -156,29 +156,4 @@ BufferMap::clear()
     from_ptr.clear();
 }
 
-BufferMap::~BufferMap()
-{
-    try {
-        // Create a list of registered buffers without causing the use_count to increase
-        vector<const void *> buffer_ptrs;
-        buffer_ptrs.reserve(from_ptr.size());
-        transform(from_ptr.begin(), from_ptr.end(), std::back_inserter(buffer_ptrs),
-                  [](const auto &pair) { return pair.first; });
-
-        for (const auto &ptr : buffer_ptrs) {
-            // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
-            deregisterBuffer(ptr);
-        }
-    }
-    catch (...) {
-#ifndef NDEBUG
-        // TODO: Consider logging here and/or changing this behaviour
-        //       before launch. It's not a great idea to call exit()
-        //       from inside libraries, but this will at least alert
-        //       us to badness while we develop.
-        std::exit(EXIT_FAILURE);
-#endif
-    }
-}
-
 }

--- a/hipfile/src/amd_detail/buffer.h
+++ b/hipfile/src/amd_detail/buffer.h
@@ -105,7 +105,7 @@ private:
 
 class BufferMap {
 public:
-    virtual ~BufferMap();
+    virtual ~BufferMap() = default;
 
     /// @brief Creates and registers a buffer
     /// @attention A unique_lock on HipFileMutex must be held

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -145,29 +145,4 @@ FileMap::clear()
     from_fh.clear();
 }
 
-FileMap::~FileMap()
-{
-    try {
-        // Create a list of registered files without causing the use_count to increase
-        vector<hipFileHandle_t> file_handles;
-        file_handles.reserve(from_fh.size());
-        transform(from_fh.begin(), from_fh.end(), std::back_inserter(file_handles),
-                  [](const auto &pair) { return pair.first; });
-
-        for (const auto &fh : file_handles) {
-            // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
-            deregisterFile(fh);
-        }
-    }
-    catch (...) {
-#ifndef NDEBUG
-        // TODO: Consider logging here and/or changing this behaviour
-        //       before launch. It's not a great idea to call exit()
-        //       from inside libraries, but this will at least alert
-        //       us to badness while we develop.
-        std::exit(EXIT_FAILURE);
-#endif
-    }
-}
-
 }

--- a/hipfile/src/amd_detail/file.h
+++ b/hipfile/src/amd_detail/file.h
@@ -129,7 +129,7 @@ private:
 
 class FileMap {
 public:
-    virtual ~FileMap();
+    virtual ~FileMap() = default;
 
     /// @brief Registers a file. Files must be registered before they can be used with hipFile IO APIs
     /// @attention A unique_lock on HipFileMutex must be held


### PR DESCRIPTION
Making virtual calls in destructors is a bad idea in C++ and clang-tidy complains about this. There's really no reason to walk the maps to free elements, as the elements are all shared pointers and will be cleaned up automatically as the reference counts drop to zero.

This PR replaces the explicit destructors with default destructors.
