### PR TITLE
Remove virtual calls in dtors

### DIFF
--- a/hipfile/src/amd_detail/buffer.cpp
+++ b/hipfile/src/amd_detail/buffer.cpp
@@ -6,6 +6,7 @@
 #include "buffer.h"
 #include "context.h"
 #include "hip.h"
+#include "sys.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -13,6 +14,7 @@
 #include <hip/hip_runtime_api.h>
 #include <iterator>
 #include <stdexcept>
+#include <syslog.h>
 #include <utility>
 #include <vector>
 
@@ -158,26 +160,13 @@ BufferMap::clear()
 
 BufferMap::~BufferMap()
 {
-    try {
-        // Create a list of registered buffers without causing the use_count to increase
-        vector<const void *> buffer_ptrs;
-        buffer_ptrs.reserve(from_ptr.size());
-        transform(from_ptr.begin(), from_ptr.end(), std::back_inserter(buffer_ptrs),
-                  [](const auto &pair) { return pair.first; });
-
-        for (const auto &ptr : buffer_ptrs) {
-            // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
-            deregisterBuffer(ptr);
+    // Complain in the logs if we're shutting down a BufferMap
+    // with buffers that are still in use.
+    for (const auto &p : from_ptr) {
+        if (p.second.use_count() > 1) {
+            Context<Sys>::get()->syslog(LOG_CRIT, "BufferMap state is being destructed with in-use buffers.");
+            return;
         }
-    }
-    catch (...) {
-#ifndef NDEBUG
-        // TODO: Consider logging here and/or changing this behaviour
-        //       before launch. It's not a great idea to call exit()
-        //       from inside libraries, but this will at least alert
-        //       us to badness while we develop.
-        std::exit(EXIT_FAILURE);
-#endif
     }
 }
 

--- a/hipfile/src/amd_detail/buffer.cpp
+++ b/hipfile/src/amd_detail/buffer.cpp
@@ -162,11 +162,15 @@ BufferMap::~BufferMap()
 {
     // Complain in the logs if we're shutting down a BufferMap
     // with buffers that are still in use.
+    int count = 0;
     for (const auto &p : from_ptr) {
         if (p.second.use_count() > 1) {
-            Context<Sys>::get()->syslog(LOG_CRIT, "BufferMap state is being destructed with in-use buffers.");
-            return;
+            count++;
         }
+    }
+
+    if (count > 0) {
+        Context<Sys>::get()->syslog(LOG_CRIT, "BufferMap state is being destructed with in-use buffers");
     }
 }
 

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -151,7 +151,7 @@ FileMap::~FileMap()
     // Complain in the logs if we're shutting down a FileMap
     // with files that are still in use.
     for (const auto &p : from_fh) {
-        if (p.second.use_count() > 1) {
+        if (p.second.use_count() > 2) {
             Context<Sys>::get()->syslog(LOG_CRIT, "FileMap state is being destructed with in-use files.");
             return;
         }

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -150,11 +150,15 @@ FileMap::~FileMap()
 {
     // Complain in the logs if we're shutting down a FileMap
     // with files that are still in use.
+    int count = 0;
     for (const auto &p : from_fh) {
         if (p.second.use_count() > 2) {
-            Context<Sys>::get()->syslog(LOG_CRIT, "FileMap state is being destructed with in-use files.");
-            return;
+            count++;
         }
+    }
+
+    if (count > 0) {
+        Context<Sys>::get()->syslog(LOG_CRIT, "FileMap state is being destructed with in-use files");
     }
 }
 

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -14,6 +14,7 @@
 #include <iterator>
 #include <utility>
 #include <sys/sysmacros.h>
+#include <syslog.h>
 #include <vector>
 
 using std::optional;
@@ -147,26 +148,13 @@ FileMap::clear()
 
 FileMap::~FileMap()
 {
-    try {
-        // Create a list of registered files without causing the use_count to increase
-        vector<hipFileHandle_t> file_handles;
-        file_handles.reserve(from_fh.size());
-        transform(from_fh.begin(), from_fh.end(), std::back_inserter(file_handles),
-                  [](const auto &pair) { return pair.first; });
-
-        for (const auto &fh : file_handles) {
-            // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
-            deregisterFile(fh);
+    // Complain in the logs if we're shutting down a FileMap
+    // with files that are still in use.
+    for (const auto &p : from_fh) {
+        if (p.second.use_count() > 1) {
+            Context<Sys>::get()->syslog(LOG_CRIT, "FileMap state is being destructed with in-use files.");
+            return;
         }
-    }
-    catch (...) {
-#ifndef NDEBUG
-        // TODO: Consider logging here and/or changing this behaviour
-        //       before launch. It's not a great idea to call exit()
-        //       from inside libraries, but this will at least alert
-        //       us to badness while we develop.
-        std::exit(EXIT_FAILURE);
-#endif
     }
 }
 

--- a/hipfile/src/amd_detail/stream.cpp
+++ b/hipfile/src/amd_detail/stream.cpp
@@ -88,13 +88,17 @@ StreamMap::getStream(hipStream_t hip_stream)
 
 StreamMap::~StreamMap()
 {
-    for (const auto &[hip_stream, stream] : from_ptr) {
-        (void)hip_stream;
-        if (stream.use_count() > 1) {
-            Context<Sys>::get()->syslog(LOG_CRIT,
-                                        "Stream state is being destructed while operations are outstanding.");
-            return;
+    // Complain in the logs if we're shutting down a Stream
+    // with outstanding operations.
+    int count = 0;
+    for (const auto &p : from_ptr) {
+        if (p.second.use_count() > 1) {
+            count++;
         }
+    }
+
+    if (count > 0) {
+        Context<Sys>::get()->syslog(LOG_CRIT, "Stream state is being destructed with outstanding operations");
     }
 }
 


### PR DESCRIPTION
clang-tidy complains about using virtual calls in the FileMap and BufferMap destructors. The virtual calls in question attempt to shut down the map objects, which is unnecessary, as the maps contain shared pointers that will be cleaned when they go out of scope.

The functionality that we retained is complaining about any in-use File or Buffer objects when the associated maps are shut down. Previously, this would result in exit() being called in debug builds and silently ignoring the problem in release builds. The new behavior is to create syslog messages in all builds (like our Stream class).

Fixes #99 