### PR TITLE
hipfile: Introduce Configuration

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -285,13 +285,17 @@ jobs:
             /bin/bash -c '
               ctest -V -L "stress" --parallel
             '
-      - name: hipFile IO test using aiscp
+      - name: hipFile fallback/POSIX IO test using aiscp
         run: |
           docker exec \
             -t \
             -w /mnt/ais-fs/${AIS_CONTAINER_NAME} \
             ${AIS_CONTAINER_NAME} \
-            /bin/bash /ais/hipFile/util/ci-aiscp-test.sh /ais/hipFile/build/hipfile/examples/aiscp/aiscp
+            /bin/bash -c '
+              HIPFILE_FORCE_COMPAT_MODE=true
+                /ais/hipFile/util/ci-aiscp-test.sh \
+                /ais/hipFile/build/hipfile/examples/aiscp/aiscp
+            '
       - name: Configure fio
         run: |
           docker exec \

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -328,22 +328,7 @@ jobs:
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
               /ais/fio/build/fio \
-                --ioengine=libhipfile \
-                --rocm_io=hipfile \
-                --direct=1 \
-                --gpu_dev_ids=0 \
-                --filename=fio.dat \
-                --size=1G \
-                --bs=1M \
-                --verify=md5 \
-                --numjobs=1 \
-                --name=write \
-                --rw=write \
-                --do_verify=0 \
-                --name=read \
-                --stonewall \
-                --rw=read \
-                --do_verify=1
+              /ais/hipFile/util/fio/write-read-verify.fio
             '
       - name: Destroy hipfile IO test directory
         if: ${{ always() }}

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -320,15 +320,16 @@ jobs:
             /bin/bash -c '
               make -j
             '
-      - name: hipFile IO test using fio
+      - name: hipFile fallback/POSIX IO test using fio
         run: |
           docker exec \
             -t \
             -w /mnt/ais-fs/${AIS_CONTAINER_NAME} \
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
-              /ais/fio/build/fio \
-              /ais/hipFile/util/fio/write-read-verify.fio
+              HIPFILE_FORCE_COMPAT_MODE=true \
+                /ais/fio/build/fio \
+                /ais/hipFile/util/fio/write-read-verify.fio
             '
       - name: Destroy hipfile IO test directory
         if: ${{ always() }}

--- a/hipfile/src/amd_detail/CMakeLists.txt
+++ b/hipfile/src/amd_detail/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HIPFILE_SOURCES
     batch/batch.cpp
     buffer.cpp
     context.cpp
+    environment.cpp
     file.cpp
     hip.cpp
     hipfile.cpp

--- a/hipfile/src/amd_detail/CMakeLists.txt
+++ b/hipfile/src/amd_detail/CMakeLists.txt
@@ -12,6 +12,7 @@ set(HIPFILE_SOURCES
     backend/fastpath.cpp
     batch/batch.cpp
     buffer.cpp
+    configuration.cpp
     context.cpp
     environment.cpp
     file.cpp

--- a/hipfile/src/amd_detail/configuration.cpp
+++ b/hipfile/src/amd_detail/configuration.cpp
@@ -1,0 +1,37 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "configuration.h"
+#include "environment.h"
+#include "hip.h"
+
+using namespace hipFile;
+
+Configuration::Configuration() : m_fastpath(true), m_fallback(true)
+{
+    auto maybe_env_force_compat{Environment::force_compat_mode()};
+    if (maybe_env_force_compat && maybe_env_force_compat.value()) {
+        m_fastpath = false;
+    }
+    m_fastpath = !!getHipAmdFileReadPtr() && m_fastpath;
+    m_fastpath = !!getHipAmdFileWritePtr() && m_fastpath;
+
+    auto maybe_env_allow_compat{Environment::allow_compat_mode()};
+    if (maybe_env_allow_compat && !maybe_env_allow_compat.value()) {
+        m_fallback = false;
+    }
+}
+
+bool
+Configuration::fastpath() const noexcept
+{
+    return m_fastpath;
+}
+
+bool
+Configuration::fallback() const noexcept
+{
+    return m_fallback;
+}

--- a/hipfile/src/amd_detail/configuration.h
+++ b/hipfile/src/amd_detail/configuration.h
@@ -1,0 +1,36 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+namespace hipFile {
+
+class IConfiguration {
+public:
+    virtual ~IConfiguration()
+    {
+    }
+
+    /// @brief Checks if the fastpath backend is enabled
+    /// @return true if the fastpath backend is enabled, false otherwise
+    virtual bool fastpath() const noexcept = 0;
+
+    /// @brief Checks if the fallback backend is enabled
+    /// @return true if the fallback backend is enabled, false otherwise
+    virtual bool fallback() const noexcept = 0;
+};
+
+class Configuration : public IConfiguration {
+    bool m_fastpath;
+    bool m_fallback;
+
+public:
+    Configuration();
+
+    bool fastpath() const noexcept override;
+    bool fallback() const noexcept override;
+};
+
+}

--- a/hipfile/src/amd_detail/environment.cpp
+++ b/hipfile/src/amd_detail/environment.cpp
@@ -1,0 +1,24 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "environment.h"
+
+using namespace hipFile;
+using namespace std;
+
+template <>
+std::optional<bool>
+Environment::get<bool>(const char *key)
+{
+    const char *value{Context<Sys>::get()->getenv(key)};
+    if (value) {
+        if (!strcasecmp(value, "true")) {
+            return true;
+        }
+        if (!strcasecmp(value, "false")) {
+            return false;
+        }
+    }
+    return std::nullopt;
+}

--- a/hipfile/src/amd_detail/environment.cpp
+++ b/hipfile/src/amd_detail/environment.cpp
@@ -22,3 +22,9 @@ Environment::get<bool>(const char *key)
     }
     return std::nullopt;
 }
+
+optional<bool>
+Environment::allow_compat_mode()
+{
+    return Environment::get<bool>(Environment::ALLOW_COMPAT_MODE);
+}

--- a/hipfile/src/amd_detail/environment.cpp
+++ b/hipfile/src/amd_detail/environment.cpp
@@ -28,3 +28,9 @@ Environment::allow_compat_mode()
 {
     return Environment::get<bool>(Environment::ALLOW_COMPAT_MODE);
 }
+
+optional<bool>
+Environment::force_compat_mode()
+{
+    return Environment::get<bool>(Environment::FORCE_COMPAT_MODE);
+}

--- a/hipfile/src/amd_detail/environment.h
+++ b/hipfile/src/amd_detail/environment.h
@@ -20,6 +20,20 @@ public:
     /// @return An optional value of type T if the key was set, nullopt if the key
     /// was not set or had an invalid value for the type T
     template <typename T> static std::optional<T> get(const char *key);
+
+    /// @brief Allow I/O operations to fallback to POSIX I/O APIs
+    ///
+    /// If enabled (default), I/O operations can use the POSIX I/O path if they
+    /// cannot be completed by the AIS path.
+    /// If disabled, I/O operations that cannot be completed by the AIS path
+    /// will be rejected.
+    static constexpr const char *const ALLOW_COMPAT_MODE{"HIPFILE_ALLOW_COMPAT_MODE"};
+
+    /// @brief Get the value of HIPFILE_ALLOW_COMPAT_MODE from the environment
+    /// @return An optional boolean value if HIPFILE_ALLOW_COMPAT_MODE was set,
+    /// nullopt if HIPFILE_ALLOW_COMPAT_MODE was unset or had a value other than
+    /// true or false.
+    static std::optional<bool> allow_compat_mode();
 };
 
 }

--- a/hipfile/src/amd_detail/environment.h
+++ b/hipfile/src/amd_detail/environment.h
@@ -1,0 +1,25 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "context.h"
+#include "sys.h"
+
+#include <cstring>
+#include <optional>
+
+namespace hipFile {
+
+class Environment {
+public:
+    /// @brief Get a value from the environment
+    /// @param key The name of the variable
+    /// @return An optional value of type T if the key was set, nullopt if the key
+    /// was not set or had an invalid value for the type T
+    template <typename T> static std::optional<T> get(const char *key);
+};
+
+}

--- a/hipfile/src/amd_detail/environment.h
+++ b/hipfile/src/amd_detail/environment.h
@@ -34,6 +34,15 @@ public:
     /// nullopt if HIPFILE_ALLOW_COMPAT_MODE was unset or had a value other than
     /// true or false.
     static std::optional<bool> allow_compat_mode();
+
+    /// @brief Force I/O operations to use POSIX I/O APIs
+    ///
+    /// If enabled, I/O operations will be forced to use the POSIX I/O path.
+    /// If disabled (default), I/O operations can use the AIS path if conditions
+    /// are satisfied
+    static constexpr const char *const FORCE_COMPAT_MODE{"HIPFILE_FORCE_COMPAT_MODE"};
+
+    static std::optional<bool> force_compat_mode();
 };
 
 }

--- a/hipfile/src/amd_detail/state.cpp
+++ b/hipfile/src/amd_detail/state.cpp
@@ -7,8 +7,9 @@
 #include "backend/fastpath.h"
 #include "batch/batch.h"
 #include "buffer.h"
+#include "configuration.h"
+#include "context.h"
 #include "file.h"
-#include "hip.h"
 #include "state.h"
 #include "stream.h"
 
@@ -278,10 +279,12 @@ std::vector<std::shared_ptr<Backend>>
 DriverState::getBackends() const
 {
     static bool once = [&]() {
-        if (getHipAmdFileReadPtr() && getHipAmdFileWritePtr()) {
+        if (Context<Configuration>::get()->fastpath()) {
             backends.emplace_back(new Fastpath{});
         }
-        backends.emplace_back(new Fallback{});
+        if (Context<Configuration>::get()->fallback()) {
+            backends.emplace_back(new Fallback{});
+        }
         return true;
     }();
     (void)once;

--- a/hipfile/src/amd_detail/sys.cpp
+++ b/hipfile/src/amd_detail/sys.cpp
@@ -78,4 +78,10 @@ Sys::statx(int dirfd, const char *pathname, int flags, unsigned int mask) const
     return statxbuf;
 }
 
+char *
+Sys::getenv(const char *name) const noexcept
+{
+    return ::getenv(name);
+}
+
 }

--- a/hipfile/src/amd_detail/sys.h
+++ b/hipfile/src/amd_detail/sys.h
@@ -38,6 +38,8 @@ struct Sys {
 
     virtual int fcntl(int fd, int op, uintptr_t arg) const;
 
+    virtual char *getenv(const char *name) const noexcept;
+
     struct RuntimeError : public std::runtime_error {
         /// The value of errno when RuntimeError was thrown
         int error;

--- a/hipfile/test/amd_detail/CMakeLists.txt
+++ b/hipfile/test/amd_detail/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SHARED_SOURCE_FILES
 set(TEST_SOURCE_FILES
     async.cpp
     batch/batch.cpp
+    configuration.cpp
     context.cpp
     buffer.cpp
     driver.cpp

--- a/hipfile/test/amd_detail/CMakeLists.txt
+++ b/hipfile/test/amd_detail/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCE_FILES
     context.cpp
     buffer.cpp
     driver.cpp
+    environment.cpp
     handle.cpp
     hip.cpp
     hipfile-api.cpp

--- a/hipfile/test/amd_detail/configuration.cpp
+++ b/hipfile/test/amd_detail/configuration.cpp
@@ -1,0 +1,148 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "configuration.h"
+#include "environment.h"
+#include "hipfile-warnings.h"
+#include "mhip.h"
+#include "msys.h"
+
+#include <gtest/gtest.h>
+
+using namespace hipFile;
+using namespace testing;
+using namespace std;
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
+
+struct ConfigurationExpectation;
+
+struct ConfigurationExpectationBuilder {
+    StrictMock<MSys>           &m_msys;
+    StrictMock<MHip>           &m_mhip;
+    std::optional<const char *> m_env_force_compat_mode;
+    std::optional<const char *> m_env_allow_compat_mode;
+    void                       *m_hip_amd_file_read{reinterpret_cast<void *>(0xDEADBEEF)};
+    void                       *m_hip_amd_file_write{reinterpret_cast<void *>(0x0BADF00D)};
+
+    ConfigurationExpectationBuilder(StrictMock<MSys> &msys, StrictMock<MHip> &mhip)
+        : m_msys(msys), m_mhip(mhip)
+    {
+    }
+
+    ConfigurationExpectationBuilder &env_force_compat_mode(const char *value)
+    {
+        m_env_force_compat_mode = value;
+        return *this;
+    }
+
+    ConfigurationExpectationBuilder &env_allow_compat_mode(const char *value)
+    {
+        m_env_allow_compat_mode = value;
+        return *this;
+    }
+
+    ConfigurationExpectationBuilder &hip_amd_file_read(void *value)
+    {
+        m_hip_amd_file_read = value;
+        return *this;
+    }
+
+    ConfigurationExpectationBuilder &hip_amd_file_write(void *value)
+    {
+        m_hip_amd_file_write = value;
+        return *this;
+    }
+
+    ConfigurationExpectation build();
+};
+
+struct ConfigurationExpectation {
+    ConfigurationExpectation(const ConfigurationExpectationBuilder &builder)
+    {
+        if (builder.m_env_force_compat_mode) {
+            EXPECT_CALL(builder.m_msys, getenv(StrEq(hipFile::Environment::FORCE_COMPAT_MODE)))
+                .WillOnce(Return(const_cast<char *>(builder.m_env_force_compat_mode.value())));
+        }
+        else {
+            EXPECT_CALL(builder.m_msys, getenv(StrEq(hipFile::Environment::FORCE_COMPAT_MODE)));
+        }
+
+        if (builder.m_env_allow_compat_mode) {
+            EXPECT_CALL(builder.m_msys, getenv(StrEq(hipFile::Environment::ALLOW_COMPAT_MODE)))
+                .WillOnce(Return(const_cast<char *>(builder.m_env_allow_compat_mode.value())));
+        }
+        else {
+            EXPECT_CALL(builder.m_msys, getenv(StrEq(hipFile::Environment::ALLOW_COMPAT_MODE)));
+        }
+
+        EXPECT_CALL(builder.m_mhip, hipRuntimeGetVersion).Times(2);
+        EXPECT_CALL(builder.m_mhip, hipGetProcAddress(StrEq("hipAmdFileRead"), _, _, _))
+            .WillOnce(Return(builder.m_hip_amd_file_read));
+        EXPECT_CALL(builder.m_mhip, hipGetProcAddress(StrEq("hipAmdFileWrite"), _, _, _))
+            .WillOnce(Return(builder.m_hip_amd_file_write));
+    }
+};
+
+ConfigurationExpectation
+ConfigurationExpectationBuilder::build()
+{
+    return ConfigurationExpectation(*this);
+}
+
+struct HipFileConfiguration : public Test {
+    StrictMock<MSys> msys;
+    StrictMock<MHip> mhip;
+};
+
+TEST_F(HipFileConfiguration, FastpathEnabledIfForceCompatModeEnvironmentVariableIsNotSetOrInvalid)
+{
+    ConfigurationExpectationBuilder{msys, mhip}.build();
+    ASSERT_TRUE(Configuration().fastpath());
+}
+
+TEST_F(HipFileConfiguration, FastpathEnabledIfForceCompatModeEnvironmentVariableIsFalse)
+{
+    ConfigurationExpectationBuilder{msys, mhip}.env_force_compat_mode("false").build();
+    ASSERT_TRUE(Configuration().fastpath());
+}
+
+TEST_F(HipFileConfiguration, FastpathDisabledIfForceCompatModeEnvironmentVariableIsTrue)
+{
+    ConfigurationExpectationBuilder{msys, mhip}.env_force_compat_mode("true").build();
+    ASSERT_FALSE(Configuration().fastpath());
+}
+
+TEST_F(HipFileConfiguration, FastpathDisabledIfHipAmdFileReadIsNotFound)
+{
+    ConfigurationExpectationBuilder{msys, mhip}.hip_amd_file_read(nullptr).build();
+    ASSERT_FALSE(Configuration().fastpath());
+}
+
+TEST_F(HipFileConfiguration, FastpathDisabledIfHipAmdFileWriteIsNotFound)
+{
+    ConfigurationExpectationBuilder{msys, mhip}.hip_amd_file_write(nullptr).build();
+    ASSERT_FALSE(Configuration().fastpath());
+}
+
+TEST_F(HipFileConfiguration, FallbackEnabledIfAllowCompatModeEnvironmentVariableIsNotSetOrInvalid)
+{
+    ConfigurationExpectationBuilder{msys, mhip}.build();
+    ASSERT_TRUE(Configuration().fallback());
+}
+
+TEST_F(HipFileConfiguration, FallbackEnabledIfAllowCompatModeEnvironmentVariableIsTrue)
+{
+    ConfigurationExpectationBuilder{msys, mhip}.env_allow_compat_mode("true").build();
+    ASSERT_TRUE(Configuration().fallback());
+}
+
+TEST_F(HipFileConfiguration, FallbackDisabledIfAllowCompatModeEnvironmentVariableIsFalse)
+{
+    ConfigurationExpectationBuilder{msys, mhip}.env_allow_compat_mode("false").build();
+    ASSERT_FALSE(Configuration().fallback());
+}
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/hipfile/test/amd_detail/environment.cpp
+++ b/hipfile/test/amd_detail/environment.cpp
@@ -1,0 +1,63 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "environment.h"
+#include "msys.h"
+
+#include <gtest/gtest.h>
+
+using namespace hipFile;
+using namespace testing;
+using namespace std;
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
+
+TEST(HipFileEnvironment, GetBoolReturnsNulloptIfNotSet)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(nullptr));
+    ASSERT_EQ(hipFile::Environment::get<bool>(""), nullopt);
+}
+
+TEST(HipFileEnvironment, GetBoolReturnsNulloptIfValueIsInvalid)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("blah")));
+    ASSERT_EQ(hipFile::Environment::get<bool>(""), nullopt);
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("")));
+    ASSERT_EQ(hipFile::Environment::get<bool>(""), nullopt);
+}
+
+TEST(HipFileEnvironment, GetBoolReturnsOptionalTrueIfTrue)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("true")));
+    ASSERT_EQ(hipFile::Environment::get<bool>(""), make_optional<>(true));
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("TRUE")));
+    ASSERT_EQ(hipFile::Environment::get<bool>(""), make_optional<>(true));
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("TrUe")));
+    ASSERT_EQ(hipFile::Environment::get<bool>(""), make_optional<>(true));
+}
+
+TEST(HipFileEnvironment, GetBoolReturnsOptionalFalseIfFalse)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("false")));
+    ASSERT_EQ(hipFile::Environment::get<bool>(""), make_optional<>(false));
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("FALSE")));
+    ASSERT_EQ(hipFile::Environment::get<bool>(""), make_optional<>(false));
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("FaLsE")));
+    ASSERT_EQ(hipFile::Environment::get<bool>(""), make_optional<>(false));
+}
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/hipfile/test/amd_detail/fallback.cpp
+++ b/hipfile/test/amd_detail/fallback.cpp
@@ -123,11 +123,6 @@ struct FallbackIo : public HipFileOpened {
         StrictMock<MSys>            msys;
         StrictMock<MLibMountHelper> mlibmounthelper;
 
-        // Initialize DriverState::backends
-        EXPECT_CALL(mhip, hipRuntimeGetVersion);
-        EXPECT_CALL(mhip, hipGetProcAddress(StrEq("hipAmdFileRead"), _, _, _));
-        Context<DriverState>::get()->getBackends();
-
         expect_buffer_registration(mhip, hipMemoryTypeDevice);
         Context<DriverState>::get()->registerBuffer(buffer_data.data(), buffer_data.size(), 0);
         buffer = Context<DriverState>::get()->getBuffer(buffer_data.data());

--- a/hipfile/test/amd_detail/mconfiguration.h
+++ b/hipfile/test/amd_detail/mconfiguration.h
@@ -1,0 +1,19 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "configuration.h"
+
+#include <gmock/gmock.h>
+
+namespace rocFile {
+
+struct MConfiguration : IConfiguration {
+    MOCK_METHOD(bool, fastpath, (), (const, noexcept, override));
+    MOCK_METHOD(bool, fallback, (), (const, noexcept, override));
+};
+
+}

--- a/hipfile/test/amd_detail/msys.h
+++ b/hipfile/test/amd_detail/msys.h
@@ -32,5 +32,7 @@ struct MSys : Sys {
                 (const override));
 
     MOCK_METHOD(int, fcntl, (int fd, int op, uintptr_t arg), (const override));
+
+    MOCK_METHOD(char *, getenv, (const char *name), (const, noexcept, override));
 };
 }

--- a/util/fio/write-read-verify.fio
+++ b/util/fio/write-read-verify.fio
@@ -1,0 +1,20 @@
+; Used by CI workflow to test hipfile with fio
+[global]
+ioengine=libhipfile
+rocm_io=hipfile
+direct=1
+gpu_dev_ids=0
+filename=fio.dat
+size=1G
+bs=1M
+verify=md5
+numjobs=1
+
+[write]
+rw=write
+do_verify=0
+
+[read]
+stonewall
+rw=read
+do_verify=1


### PR DESCRIPTION
## Motivation

Introduce infrastructure that will allow hipFile behavior to be controlled with environment variables and settings in configuration files.

This patch series allows users to specify HIPFILE_ALLOW_COMPAT_MODE=false to force IO to take the AMD Infinity Storage (AIS) path path or, HIPFILE_FORCE_COMPAT_MODE=true to force IO to use the POSIX path.