### PR TITLE
Add a sleep-on-exit argument that can be used on system and unit tests.

### DIFF
--- a/hipfile/test/amd_detail/CMakeLists.txt
+++ b/hipfile/test/amd_detail/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 include(AISAddExecutable)
 include(AISUseGTest)
+find_package(Boost COMPONENTS program_options REQUIRED)
 
 set(SHARED_SOURCE_FILES
     "${CMAKE_SOURCE_DIR}/hipfile/test/common/magic-word.cpp"
@@ -22,6 +23,7 @@ set(TEST_SOURCE_FILES
     hipfile-api.cpp
     fallback.cpp
     fastpath.cpp
+    main.cpp
     mountinfo.cpp
     stream.cpp
 )
@@ -44,7 +46,7 @@ target_compile_options(internal_tests PRIVATE "-UNDEBUG")
 # Add gtest
 target_link_libraries(internal_tests PRIVATE GTest::gmock)
 target_link_libraries(internal_tests PRIVATE GTest::gtest)
-target_link_libraries(internal_tests PRIVATE GTest::gtest_main)
+target_link_libraries(internal_tests PRIVATE Boost::program_options)
 
 ais_gtest_discover_tests(
     internal_tests

--- a/hipfile/test/amd_detail/main.cpp
+++ b/hipfile/test/amd_detail/main.cpp
@@ -1,0 +1,36 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "hipfile-warnings.h"
+#include "test-options.h"
+
+#include <chrono>
+#include <gtest/gtest.h>
+#include <thread>
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
+HIPFILE_WARN_NO_EXIT_DTOR_OFF
+static UnitTestOptions test_env;
+HIPFILE_WARN_NO_EXIT_DTOR_ON
+HIPFILE_WARN_NO_GLOBAL_CTOR_ON
+
+static void
+sleepOnExit()
+{
+    if (test_env.sleep_seconds > 0) {
+        std::this_thread::sleep_for(std::chrono::seconds(test_env.sleep_seconds));
+    }
+}
+
+int
+main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+
+    test_env.parseTestOptions(argc, argv);
+    std::atexit(sleepOnExit);
+
+    return RUN_ALL_TESTS();
+}

--- a/hipfile/test/common/test-options.h
+++ b/hipfile/test/common/test-options.h
@@ -10,18 +10,23 @@
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/value_semantic.hpp>
 #include <boost/program_options/variables_map.hpp>
+#include <cstdint>
 
 struct SystemTestOptions {
     std::string ais_capable_dir;
+    uint32_t    sleep_seconds;
     void        parseTestOptions(int argc, char **argv)
     {
         namespace po = boost::program_options;
         po::options_description desc("System test options");
         desc.add_options()("ais-capable-dir", po::value<std::string>()->default_value("/tmp"),
                            "Path to AIS capable directory");
+        desc.add_options()("sleep-on-exit", po::value<uint32_t>()->default_value(0),
+                           "Sleep before returning to main");
         po::variables_map vm;
         po::store(po::parse_command_line(argc, argv, desc), vm);
 
         ais_capable_dir = vm["ais-capable-dir"].as<std::string>();
+        sleep_seconds   = vm["sleep-on-exit"].as<uint32_t>();
     }
 };

--- a/hipfile/test/common/test-options.h
+++ b/hipfile/test/common/test-options.h
@@ -30,3 +30,18 @@ struct SystemTestOptions {
         sleep_seconds   = vm["sleep-on-exit"].as<uint32_t>();
     }
 };
+
+struct UnitTestOptions {
+    uint32_t sleep_seconds;
+    void     parseTestOptions(int argc, char **argv)
+    {
+        namespace po = boost::program_options;
+        po::options_description desc("System test options");
+        desc.add_options()("sleep-on-exit", po::value<uint32_t>()->default_value(0),
+                           "Sleep before returning to main");
+        po::variables_map vm;
+        po::store(po::parse_command_line(argc, argv, desc), vm);
+
+        sleep_seconds = vm["sleep-on-exit"].as<uint32_t>();
+    }
+};

--- a/hipfile/test/system/main.cpp
+++ b/hipfile/test/system/main.cpp
@@ -6,7 +6,9 @@
 #include "hipfile-warnings.h"
 #include "test-options.h"
 
+#include <chrono>
 #include <gtest/gtest.h>
+#include <thread>
 
 extern SystemTestOptions test_env;
 HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
@@ -15,12 +17,21 @@ SystemTestOptions test_env;
 HIPFILE_WARN_NO_EXIT_DTOR_ON
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON
 
+static void
+sleepOnExit()
+{
+    if (test_env.sleep_seconds > 0) {
+        std::this_thread::sleep_for(std::chrono::seconds(test_env.sleep_seconds));
+    }
+}
+
 int
 main(int argc, char **argv)
 {
     testing::InitGoogleTest(&argc, argv);
 
     test_env.parseTestOptions(argc, argv);
+    std::atexit(sleepOnExit);
 
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
When using bpftrace, symbols are looked up asynchronously in certain cases.  The program needs to be running for this symbol lookup to work, so a short running program may exit before symbols are known for calls of interest.  This option allows you to add a sleep on exit to give time for symbol lookup to work.

This won't help with destructors of objects with static lifetimes, but will generally let you trace calls of interest.