### PR TITLE
hipfile: Use internal file descriptors for IO

### DIFF
--- a/hipfile/examples/aiscp/aiscp.cpp
+++ b/hipfile/examples/aiscp/aiscp.cpp
@@ -100,7 +100,7 @@ main(int argc, char *argv[])
         block_size = static_cast<size_t>(statbuf.st_blksize);
     }
 
-    if (open_file(dst_path, O_DIRECT | O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH, &dst_fd,
+    if (open_file(dst_path, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH, &dst_fd,
                   &dst_handle)) {
         goto program_exit;
     }
@@ -109,7 +109,7 @@ main(int argc, char *argv[])
         goto close_dst;
     }
 
-    if (open_file(src_path, O_DIRECT | O_RDONLY, 0, &src_fd, &src_handle)) {
+    if (open_file(src_path, O_RDONLY, 0, &src_fd, &src_handle)) {
         goto close_dst;
     }
 

--- a/hipfile/src/amd_detail/CMakeLists.txt
+++ b/hipfile/src/amd_detail/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HIPFILE_SOURCES
     context.cpp
     environment.cpp
     file.cpp
+    file-descriptor.cpp
     hip.cpp
     hipfile.cpp
     mountinfo.cpp

--- a/hipfile/src/amd_detail/backend/fallback.cpp
+++ b/hipfile/src/amd_detail/backend/fallback.cpp
@@ -86,7 +86,8 @@ Fallback::io(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer,
         try {
             switch (io_type) {
                 case IoType::Read:
-                    io_bytes = Context<Sys>::get()->pread(file->getFd(), bounce_buffer.get(), count, offset);
+                    io_bytes = Context<Sys>::get()->pread(file->getFdUnbuffered(), bounce_buffer.get(), count,
+                                                          offset);
                     if (io_bytes > 0) {
                         Context<Hip>::get()->hipMemcpy(device_buffer_position, bounce_buffer.get(),
                                                        static_cast<size_t>(io_bytes), hipMemcpyHostToDevice);
@@ -96,7 +97,8 @@ Fallback::io(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer,
                     Context<Hip>::get()->hipMemcpy(bounce_buffer.get(), device_buffer_position, count,
                                                    hipMemcpyDeviceToHost);
                     Context<Hip>::get()->hipStreamSynchronize(nullptr);
-                    io_bytes = Context<Sys>::get()->pwrite(file->getFd(), bounce_buffer.get(), count, offset);
+                    io_bytes = Context<Sys>::get()->pwrite(file->getFdUnbuffered(), bounce_buffer.get(),
+                                                           count, offset);
                     break;
                 default:
                     throw std::runtime_error("Invalid IO type");

--- a/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -127,9 +127,9 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
 {
     bool accept_io{true};
 
-    accept_io &= !!(file->getStatusFlags() & O_DIRECT);
-
     accept_io &= buffer->getType() == hipMemoryTypeDevice;
+    accept_io &= 0 <= file_offset;
+    accept_io &= 0 <= buffer_offset;
 
 #if defined(STATX_DIOALIGN)
     const struct statx &stx{file->getStatx()};
@@ -156,7 +156,7 @@ Fastpath::io(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, si
     size_t             nbytes{};
     size_t             buflen{buffer->getLength()};
 
-    handle.fd = file->getFd();
+    handle.fd = file->getFdUnbuffered();
 
     if (file_offset < 0) {
         throw std::invalid_argument("Negative file offset");

--- a/hipfile/src/amd_detail/file-descriptor.cpp
+++ b/hipfile/src/amd_detail/file-descriptor.cpp
@@ -1,0 +1,45 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "context.h"
+#include "file-descriptor.h"
+#include "sys.h"
+
+using namespace hipFile;
+
+FileDescriptor::FileDescriptor(int fd) : m_fd(fd)
+{
+}
+
+FileDescriptor::~FileDescriptor()
+{
+    if (m_fd != -1) {
+        Context<Sys>::get()->close(m_fd);
+    }
+}
+
+FileDescriptor::FileDescriptor(FileDescriptor &&other) noexcept : m_fd(other.m_fd)
+{
+    other.m_fd = -1;
+}
+
+FileDescriptor &
+FileDescriptor::operator=(FileDescriptor &&other) noexcept
+{
+    if (this != &other) {
+        if (m_fd != -1) {
+            Context<Sys>::get()->close(m_fd);
+        }
+        m_fd       = other.m_fd;
+        other.m_fd = -1;
+    }
+    return *this;
+}
+
+int
+FileDescriptor::get() const
+{
+    return m_fd;
+}

--- a/hipfile/src/amd_detail/file-descriptor.h
+++ b/hipfile/src/amd_detail/file-descriptor.h
@@ -1,0 +1,30 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+namespace hipFile {
+
+/// @brief Manages the lifetime of a file descriptor
+class FileDescriptor {
+public:
+    explicit FileDescriptor(int fd);
+
+    ~FileDescriptor();
+
+    FileDescriptor(const FileDescriptor &)            = delete;
+    FileDescriptor &operator=(const FileDescriptor &) = delete;
+
+    FileDescriptor(FileDescriptor &&other) noexcept;
+
+    FileDescriptor &operator=(FileDescriptor &&other) noexcept;
+
+    int get() const;
+
+private:
+    int m_fd;
+};
+
+}

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -56,6 +56,18 @@ UnregisteredFile::getFd() const noexcept
     return m_fd;
 }
 
+FileDescriptor &&
+UnregisteredFile::takeFdBuffered(const PassKey<File> &) noexcept
+{
+    return std::move(m_fd_buffered);
+}
+
+FileDescriptor &&
+UnregisteredFile::takeFdUnbuffered(const PassKey<File> &) noexcept
+{
+    return std::move(m_fd_unbuffered);
+}
+
 struct statx
 UnregisteredFile::getStatx() const noexcept
 {
@@ -81,7 +93,9 @@ IFile::getHandle() const
 }
 
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
-    : fd{uf.getFd()}, stx{uf.getStatx()}, status_flags{uf.getFlags()}, mountinfo{uf.getMountInfo()}
+    : fd{uf.getFd()}, fd_buffered{uf.takeFdBuffered(PassKey<File>{})},
+      fd_unbuffered{uf.takeFdUnbuffered(PassKey<File>{})}, stx{uf.getStatx()}, status_flags{uf.getFlags()},
+      mountinfo{uf.getMountInfo()}
 {
 }
 
@@ -89,6 +103,18 @@ int
 File::getFd() const
 {
     return fd;
+}
+
+int
+File::getFdBuffered() const
+{
+    return fd_buffered.get();
+}
+
+int
+File::getFdUnbuffered() const
+{
+    return fd_unbuffered.get();
 }
 
 const struct statx &

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -69,7 +69,7 @@ IFile::getHandle() const
     return reinterpret_cast<hipFileHandle_t>(const_cast<IFile *>(this));
 }
 
-File::File(const UnregisteredFile &uf, const PassKey<FileMap> &)
+File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
     : fd{uf.getFd()}, stx{uf.getStatx()}, status_flags{uf.getFlags()}, mountinfo{uf.getMountInfo()}
 {
 }
@@ -110,13 +110,13 @@ FileMap::getFile(hipFileHandle_t fh)
 }
 
 hipFileHandle_t
-FileMap::registerFile(const UnregisteredFile &uf)
+FileMap::registerFile(UnregisteredFile &&uf)
 {
     if (from_fd.end() != from_fd.find(uf.getFd())) {
         throw FileAlreadyRegistered();
     }
 
-    auto file                  = std::shared_ptr<IFile>(new File(uf, PassKey<FileMap>{}));
+    auto file                  = std::shared_ptr<IFile>(new File(std::move(uf), PassKey<FileMap>{}));
     from_fd[file->getFd()]     = file;
     from_fh[file->getHandle()] = file;
 

--- a/hipfile/src/amd_detail/file.cpp
+++ b/hipfile/src/amd_detail/file.cpp
@@ -5,6 +5,7 @@
 
 #include "context.h"
 #include "file.h"
+#include "file-descriptor.h"
 #include "mountinfo.h"
 #include "passkey.h"
 #include "sys.h"
@@ -35,8 +36,18 @@ UnregisteredFile::UnregisteredFile(int fd)
                                                  )},
       m_flags{Context<Sys>::get()->fcntl(fd, F_GETFL, 0)},
       m_mountinfo{
-          Context<LibMountHelper>::get()->getMountInfo(makedev(m_stx.stx_dev_major, m_stx.stx_dev_minor))}
+          Context<LibMountHelper>::get()->getMountInfo(makedev(m_stx.stx_dev_major, m_stx.stx_dev_minor))},
+      m_fd_buffered(FileDescriptor(Context<Sys>::get()->fcntl(fd, F_DUPFD_CLOEXEC, 0))),
+      m_fd_unbuffered(FileDescriptor(Context<Sys>::get()->fcntl(fd, F_DUPFD_CLOEXEC, 0)))
 {
+    if (m_flags & O_DIRECT) {
+        Context<Sys>::get()->fcntl(m_fd_buffered.get(), F_SETFL,
+                                   static_cast<unsigned long>(m_flags & ~O_DIRECT));
+    }
+    else {
+        Context<Sys>::get()->fcntl(m_fd_unbuffered.get(), F_SETFL,
+                                   static_cast<unsigned long>(m_flags | O_DIRECT));
+    }
 }
 
 int

--- a/hipfile/src/amd_detail/file.h
+++ b/hipfile/src/amd_detail/file.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "file-descriptor.h"
 #include "hipfile.h"
 #include "mountinfo.h"
 #include "passkey.h"
@@ -61,7 +62,7 @@ public:
     std::optional<MountInfo> getMountInfo() const noexcept;
 
 private:
-    /// @brief The file descriptor
+    /// @brief The file descriptor provided by the client
     int m_fd;
 
     /// @brief Information provided by statx (2)
@@ -72,6 +73,12 @@ private:
 
     /// @brief Information obtained from /proc/self/mountinfo
     std::optional<MountInfo> m_mountinfo;
+
+    /// @brief hipFile's buffered duplicate of the client file descriptor
+    FileDescriptor m_fd_buffered;
+
+    /// @brief hipFile's unbuffered duplicate of the client file descriptor
+    FileDescriptor m_fd_unbuffered;
 };
 
 class IFile {

--- a/hipfile/src/amd_detail/file.h
+++ b/hipfile/src/amd_detail/file.h
@@ -111,7 +111,7 @@ public:
     /// @brief Construct a registered file
     /// @param uf An unregistered file
     /// @param k  Key class instance (see passkey.h)
-    File(const UnregisteredFile &uf, const PassKey<FileMap> &k);
+    File(UnregisteredFile &&uf, const PassKey<FileMap> &k);
 
 private:
     /// @brief The file descriptor
@@ -136,7 +136,7 @@ public:
     /// @brief Registers a file. Files must be registered before they can be used with hipFile IO APIs
     /// @attention A unique_lock on HipFileMutex must be held
     /// @param uf An unregistered file
-    virtual hipFileHandle_t registerFile(const UnregisteredFile &uf);
+    virtual hipFileHandle_t registerFile(UnregisteredFile &&uf);
 
     /// @brief Deregisters the file associated with the provided file handle
     /// @attention A unique_lock on HipFileMutex must be held

--- a/hipfile/src/amd_detail/file.h
+++ b/hipfile/src/amd_detail/file.h
@@ -39,6 +39,8 @@ struct FileOperationsOutstanding : public std::runtime_error {
     }
 };
 
+class File;
+
 class UnregisteredFile {
 public:
     /// @brief Construct an unregistered file
@@ -51,6 +53,12 @@ public:
 
     /// @return Returns the file descriptor
     int getFd() const noexcept;
+
+    /// @return Moves m_fd_buffered out of the instance
+    FileDescriptor &&takeFdBuffered(const PassKey<File> &) noexcept;
+
+    /// @return Moves m_fd_unbuffered out of the instance
+    FileDescriptor &&takeFdUnbuffered(const PassKey<File> &) noexcept;
 
     /// @return Returns the information provided by statx (2)
     struct statx getStatx() const noexcept;
@@ -90,6 +98,8 @@ public:
     virtual hipFileHandle_t getHandle() const;
 
     virtual int                      getFd() const             = 0;
+    virtual int                      getFdBuffered() const     = 0;
+    virtual int                      getFdUnbuffered() const   = 0;
     virtual const struct statx      &getStatx() const noexcept = 0;
     virtual int                      getStatusFlags() const    = 0;
     virtual std::optional<MountInfo> getMountInfo() const      = 0;
@@ -111,6 +121,8 @@ public:
     File &operator=(File &&) = delete;
 
     virtual int                      getFd() const override;
+    virtual int                      getFdBuffered() const override;
+    virtual int                      getFdUnbuffered() const override;
     virtual const struct statx      &getStatx() const noexcept override;
     virtual int                      getStatusFlags() const override;
     virtual std::optional<MountInfo> getMountInfo() const override;
@@ -121,8 +133,14 @@ public:
     File(UnregisteredFile &&uf, const PassKey<FileMap> &k);
 
 private:
-    /// @brief The file descriptor
+    /// @brief The client's file descriptor
     int fd;
+
+    /// @brief hipFile's buffered duplicate of the client file descriptor
+    FileDescriptor fd_buffered;
+
+    /// @brief hipFile's unbuffered duplicate of the client file descriptor
+    FileDescriptor fd_unbuffered;
 
     /// @brief File status information obtained from statx (2)
     struct statx stx;

--- a/hipfile/src/amd_detail/hipfile.cpp
+++ b/hipfile/src/amd_detail/hipfile.cpp
@@ -65,7 +65,7 @@ try {
     switch (descr->type) {
         case hipFileHandleTypeOpaqueFD: {
             UnregisteredFile uf{descr->handle.fd};
-            *fh = Context<DriverState>::get()->registerFile(uf);
+            *fh = Context<DriverState>::get()->registerFile(std::move(uf));
             return {hipFileSuccess, hipSuccess};
         }
         case hipFileHandleTypeOpaqueWin32:

--- a/hipfile/src/amd_detail/state.cpp
+++ b/hipfile/src/amd_detail/state.cpp
@@ -120,7 +120,7 @@ DriverState::getBuffer(const void *buf, size_t length, int flags)
 //
 
 hipFileHandle_t
-DriverState::registerFile(const UnregisteredFile &uf)
+DriverState::registerFile(UnregisteredFile &&uf)
 {
     unique_lock<shared_mutex> ulock{state_mutex};
 
@@ -130,7 +130,7 @@ DriverState::registerFile(const UnregisteredFile &uf)
         ref_count++;
     }
 
-    return file_map->registerFile(uf);
+    return file_map->registerFile(std::move(uf));
 }
 
 void

--- a/hipfile/src/amd_detail/state.h
+++ b/hipfile/src/amd_detail/state.h
@@ -116,7 +116,7 @@ public:
     /// @brief Registers a file. Files must be registered before they can be used with hipFile IO APIs
     /// @param [in] uf An unregistered file
     /// @return A handle to be used when calling hipFile IO APIs
-    virtual hipFileHandle_t registerFile(const UnregisteredFile &uf);
+    virtual hipFileHandle_t registerFile(UnregisteredFile &&uf);
 
     /// @brief Deregisters the file associated with the provided file handle
     /// @param [in] fh The handle of the file to deregister

--- a/hipfile/src/amd_detail/sys.cpp
+++ b/hipfile/src/amd_detail/sys.cpp
@@ -23,6 +23,12 @@ throwOn(const L throw_value, R value)
     return value;
 }
 
+void
+Sys::close(int fd) const
+{
+    throwOn<Sys::RuntimeError>(-1, ::close(fd));
+}
+
 void *
 Sys::mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) const
 {

--- a/hipfile/src/amd_detail/sys.h
+++ b/hipfile/src/amd_detail/sys.h
@@ -25,6 +25,8 @@ namespace hipFile {
 struct Sys {
     virtual ~Sys() = default;
 
+    virtual void close(int fd) const;
+
     virtual void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) const;
     virtual void  munmap(void *addr, size_t length) const;
 

--- a/hipfile/test/amd_detail/CMakeLists.txt
+++ b/hipfile/test/amd_detail/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_SOURCE_FILES
     buffer.cpp
     driver.cpp
     environment.cpp
+    file-descriptor.cpp
     handle.cpp
     hip.cpp
     hipfile-api.cpp

--- a/hipfile/test/amd_detail/fastpath.cpp
+++ b/hipfile/test/amd_detail/fastpath.cpp
@@ -58,7 +58,7 @@ struct FastpathTestBase {
     const size_t        DEFAULT_BUFFER_LENGTH{DEFAULT_IO_SIZE + static_cast<size_t>(DEFAULT_BUFFER_OFFSET)};
     const hipMemoryType DEFAULT_BUFFER_TYPE{hipMemoryTypeDevice};
     const int           DEFAULT_FILE_DESCRIPTOR{7};
-    const int           DEFAULT_FILE_FLAGS{O_DIRECT};
+    const int           DEFAULT_FILE_FLAGS{~O_DIRECT};
     const off_t         DEFAULT_FILE_OFFSET{8192};
     const struct statx  DEFAULT_STATX {
         []() {
@@ -81,7 +81,6 @@ struct FastpathTest : public FastpathTestBase, public Test {};
 
 TEST_F(FastpathTest, DefaultExpecations)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -89,19 +88,8 @@ TEST_F(FastpathTest, DefaultExpecations)
               SCORE_ACCEPT);
 }
 
-TEST_F(FastpathTest, BufferedFile)
-{
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS & ~O_DIRECT));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-
-    ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
-              SCORE_REJECT);
-}
-
 TEST_F(FastpathTest, ScoreRejectsNegativeAlignedFileOffset)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS & ~O_DIRECT));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -112,7 +100,6 @@ TEST_F(FastpathTest, ScoreRejectsNegativeAlignedFileOffset)
 
 TEST_F(FastpathTest, ScoreRejectsNegativeAlignedBufferOffset)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS & ~O_DIRECT));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -125,7 +112,6 @@ struct FastpathSupportedHipMemoryParam : public FastpathTestBase, public TestWit
 
 TEST_P(FastpathSupportedHipMemoryParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(GetParam()));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -139,7 +125,6 @@ struct FastpathUnsupportedHipMemoryParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathUnsupportedHipMemoryParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(GetParam()));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -154,7 +139,6 @@ struct FastpathAlignedIoSizesParam : public FastpathTestBase, public TestWithPar
 
 TEST_P(FastpathAlignedIoSizesParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -169,7 +153,6 @@ struct FastpathUnalignedIoSizesParam : public FastpathTestBase, public TestWithP
 
 TEST_P(FastpathUnalignedIoSizesParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -184,7 +167,6 @@ struct FastpathAlignedFileOffsetsParam : public FastpathTestBase, public TestWit
 
 TEST_P(FastpathAlignedFileOffsetsParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -199,7 +181,6 @@ struct FastpathUnalignedFileOffsetsParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathUnalignedFileOffsetsParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -214,7 +195,6 @@ struct FastpathAlignedBufferOffsetsParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathAlignedBufferOffsetsParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -230,7 +210,6 @@ struct FastpathUnalignedBufferOffsetsParam : public FastpathTestBase, public Tes
 
 TEST_P(FastpathUnalignedBufferOffsetsParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -247,14 +226,14 @@ struct FastpathIoParam : public FastpathTestBase, public TestWithParam<IoType> {
     {
         EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-        EXPECT_CALL(*mfile, getFd).WillOnce(Return(DEFAULT_FILE_DESCRIPTOR));
+        EXPECT_CALL(*mfile, getFdUnbuffered).WillOnce(Return(DEFAULT_FILE_DESCRIPTOR));
     }
 
     void expect_io(int fd, void *bufptr, size_t buflen)
     {
         EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(bufptr));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(buflen));
-        EXPECT_CALL(*mfile, getFd).WillOnce(Return(fd));
+        EXPECT_CALL(*mfile, getFdUnbuffered).WillOnce(Return(fd));
     }
 };
 

--- a/hipfile/test/amd_detail/file-descriptor.cpp
+++ b/hipfile/test/amd_detail/file-descriptor.cpp
@@ -1,0 +1,58 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "file-descriptor.h"
+#include "msys.h"
+
+#include <gtest/gtest.h>
+
+using namespace hipFile;
+using namespace testing;
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
+
+struct HipFileFileDescriptor : public Test {
+    StrictMock<MSys> msys;
+};
+
+TEST_F(HipFileFileDescriptor, FileDescriptorClosesFileOnDestruction)
+{
+    FileDescriptor fd{42};
+    EXPECT_CALL(msys, close(42));
+}
+
+TEST_F(HipFileFileDescriptor, FileDescriptorDoesNotCloseFileIfFileDescriptorIsNegativeOne)
+{
+    FileDescriptor fd{-1};
+}
+
+TEST_F(HipFileFileDescriptor, FileDescriptorHandlesMoveCopyConstructor)
+{
+    FileDescriptor fd_a{42};
+    FileDescriptor fd_b{std::move(fd_a)};
+    ASSERT_EQ(fd_a.get(), -1);
+    EXPECT_CALL(msys, close(42));
+}
+
+TEST_F(HipFileFileDescriptor, EmptyFileDescriptorHandlesMoveAssignment)
+{
+    FileDescriptor fd_a{42};
+    FileDescriptor fd_b{-1};
+    fd_b = std::move(fd_a);
+    ASSERT_EQ(fd_a.get(), -1);
+    EXPECT_CALL(msys, close(42));
+}
+
+TEST_F(HipFileFileDescriptor, FileDescriptorHandlesMoveAssignment)
+{
+    FileDescriptor fd_a{42};
+    FileDescriptor fd_b{43};
+    EXPECT_CALL(msys, close(43));
+    fd_b = std::move(fd_a);
+    ASSERT_EQ(fd_a.get(), -1);
+    EXPECT_CALL(msys, close(42));
+}
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/hipfile/test/amd_detail/handle.cpp
+++ b/hipfile/test/amd_detail/handle.cpp
@@ -26,26 +26,84 @@
 
 using namespace hipFile;
 using namespace testing;
+using namespace std;
 
 // Put tests inside the macros to suppress the global constructor
 // warnings
 HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
 
-void
-expect_file_registration(MSys &msys, MLibMountHelper &mlibmounthelper)
+struct ExpectUnregisteredFile;
+
+struct ExpectUnregisteredFileBuilder {
+    MSys                  &m_msys;
+    MLibMountHelper       &m_mlibmounthelper;
+    optional<struct statx> m_statx;
+    optional<int>          m_fcntl_flags;
+    optional<MountInfo>    m_mountinfo;
+
+    ExpectUnregisteredFileBuilder(MSys &msys, MLibMountHelper &mlibmounthelper)
+        : m_msys(msys), m_mlibmounthelper(mlibmounthelper)
+    {
+    }
+
+    ExpectUnregisteredFileBuilder &statx(const struct statx &statxbuf)
+    {
+        m_statx = statxbuf;
+        return *this;
+    }
+
+    ExpectUnregisteredFileBuilder &fcntl_flags(int flags)
+    {
+        m_fcntl_flags = flags;
+        return *this;
+    }
+
+    ExpectUnregisteredFileBuilder &mountinfo(const MountInfo &mountinfo)
+    {
+        m_mountinfo = mountinfo;
+        return *this;
+    }
+
+    ExpectUnregisteredFile build();
+};
+
+struct ExpectUnregisteredFile {
+    ExpectUnregisteredFile(const ExpectUnregisteredFileBuilder &builder)
+    {
+        if (builder.m_statx) {
+            EXPECT_CALL(builder.m_msys, statx).WillOnce(Return(builder.m_statx.value()));
+        }
+        else {
+            EXPECT_CALL(builder.m_msys, statx);
+        }
+
+        if (builder.m_fcntl_flags) {
+            EXPECT_CALL(builder.m_msys, fcntl(_, F_GETFL, 0)).WillOnce(Return(builder.m_fcntl_flags.value()));
+        }
+        else {
+            EXPECT_CALL(builder.m_msys, fcntl(_, F_GETFL, 0));
+        }
+
+        if (builder.m_mountinfo) {
+            EXPECT_CALL(builder.m_mlibmounthelper, getMountInfo)
+                .WillOnce(Return(builder.m_mountinfo.value()));
+        }
+        else {
+            EXPECT_CALL(builder.m_mlibmounthelper, getMountInfo);
+        }
+    }
+};
+
+ExpectUnregisteredFile
+ExpectUnregisteredFileBuilder::build()
 {
-    EXPECT_CALL(msys, statx);
-    EXPECT_CALL(msys, fcntl(_, F_GETFL, 0));
-    EXPECT_CALL(mlibmounthelper, getMountInfo);
+    return ExpectUnregisteredFile(*this);
 }
 
 void
-expect_file_registration(MSys &msys, MLibMountHelper &mlibmounthelper, struct statx stxbuf, int fcntl_flags,
-                         MountInfo mountinfo)
+expect_file_registration(MSys &msys, MLibMountHelper &mlibmounthelper)
 {
-    EXPECT_CALL(msys, statx).WillOnce(Return(stxbuf));
-    EXPECT_CALL(msys, fcntl(_, F_GETFL, 0)).WillOnce(Return(fcntl_flags));
-    EXPECT_CALL(mlibmounthelper, getMountInfo).WillOnce(Return(mountinfo));
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
 }
 
 struct HipFileHandle : public HipFileOpened {
@@ -57,7 +115,7 @@ TEST_F(HipFileHandle, register_handle_internal_linux_fd)
 {
     int fd{0xBADF00D};
 
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_NE(Context<DriverState>::get()->registerFile(fd), nullptr);
 }
 
@@ -72,7 +130,11 @@ TEST_F(HipFileHandle, file_initialization)
     mountinfo.type                         = FilesystemType::ext4;
     mountinfo.options.ext4.journaling_mode = ExtJournalingMode::ordered;
 
-    expect_file_registration(msys, mlibmounthelper, stxbuf, status_flags, mountinfo);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .statx(stxbuf)
+        .fcntl_flags(status_flags)
+        .mountinfo(mountinfo)
+        .build();
     auto fh{Context<DriverState>::get()->registerFile(fd)};
     auto file{Context<DriverState>::get()->getFile(fh)};
 
@@ -89,9 +151,9 @@ TEST_F(HipFileHandle, file_initialization)
 TEST_F(HipFileHandle, register_handle_internal_linux_fd_already_registered)
 {
     int fd{0xBADF00D};
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_NE(Context<DriverState>::get()->registerFile(fd), nullptr);
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_THROW(Context<DriverState>::get()->registerFile(fd), FileAlreadyRegistered);
 }
 
@@ -103,7 +165,7 @@ TEST_F(HipFileHandle, register_handle_linux_fd)
     rfd.type      = hipFileHandleTypeOpaqueFD;
     rfd.handle.fd = 0xBADF00D;
 
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HIPFILE_SUCCESS);
     ASSERT_NE(fh, nullptr);
 }
@@ -158,10 +220,10 @@ TEST_F(HipFileHandle, register_handle_linux_fd_already_registered)
     rfd.type      = hipFileHandleTypeOpaqueFD;
     rfd.handle.fd = 0xBADF00D;
 
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HIPFILE_SUCCESS);
     ASSERT_NE(fh, nullptr);
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HipFileOpError(hipFileHandleAlreadyRegistered));
 }
 
@@ -200,7 +262,7 @@ TEST_F(HipFileHandle, deregister_handle_doesnt_throw_if_not_registered)
 
 TEST_F(HipFileHandle, deregister_handle_internal)
 {
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     auto fh = Context<DriverState>::get()->registerFile(0xBADF00D);
     Context<DriverState>::get()->deregisterFile(fh);
     ASSERT_THROW(Context<DriverState>::get()->deregisterFile(fh), FileNotRegistered);
@@ -214,7 +276,7 @@ TEST_F(HipFileHandle, deregister_handle)
     rfd.type      = hipFileHandleTypeOpaqueFD;
     rfd.handle.fd = 0xBADF00D;
 
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HIPFILE_SUCCESS);
     hipFileHandleDeregister(fh);
     hipFileHandleDeregister(fh);
@@ -222,7 +284,7 @@ TEST_F(HipFileHandle, deregister_handle)
 
 TEST_F(HipFileHandle, deregister_handle_internal_fails_when_operations_are_oustanding)
 {
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     auto fh = Context<DriverState>::get()->registerFile(0xBADF00D);
     {
         auto file = Context<DriverState>::get()->getFile(fh);
@@ -239,7 +301,7 @@ TEST_F(HipFileHandle, deregister_handle_fails_when_operations_are_oustanding)
     rfd.type      = hipFileHandleTypeOpaqueFD;
     rfd.handle.fd = 0xBADF00D;
 
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HIPFILE_SUCCESS);
     {
         auto file = Context<DriverState>::get()->getFile(fh);

--- a/hipfile/test/amd_detail/handle.cpp
+++ b/hipfile/test/amd_detail/handle.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <optional>
 #include <stdexcept>
+#include <sys/eventfd.h>
 
 using namespace hipFile;
 using namespace testing;
@@ -143,11 +144,18 @@ TEST_F(HipFileHandle, register_handle_internal_linux_fd)
 TEST_F(HipFileHandle, file_initialization)
 {
     int          fd{0x12345678};
-    int          fd_buffered{0x33445566};
-    int          fd_unbuffered{0x77889900};
     int          status_flags{0x789ABCDE};
     struct statx stxbuf;
     memset(&stxbuf, 0xA5, sizeof(stxbuf));
+
+    // FileDescriptor will call close() on file.fd_buffered and file.fd_unbuffered
+    // _after_ StrictMock<Sys> is destroyed. Return eventfds when the client
+    // fd is duplicated so that Sys::close() has a valid file descriptor to
+    // close.
+    int fd_buffered{eventfd(0, 0)};
+    ASSERT_NE(fd_buffered, -1);
+    int fd_unbuffered{eventfd(0, 0)};
+    ASSERT_NE(fd_unbuffered, -1);
 
     MountInfo mountinfo;
     mountinfo.type                         = FilesystemType::ext4;
@@ -160,7 +168,6 @@ TEST_F(HipFileHandle, file_initialization)
         .fd_buffered(fd_buffered)
         .fd_unbuffered(fd_unbuffered)
         .build();
-    EXPECT_CALL(msys, close).Times(2);
     auto fh{Context<DriverState>::get()->registerFile(fd)};
     auto file{Context<DriverState>::get()->getFile(fh)};
 
@@ -172,6 +179,8 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_EQ(mountinfo.type, file->getMountInfo().value().type);
     EXPECT_EQ(mountinfo.options.ext4.journaling_mode,
               file->getMountInfo().value().options.ext4.journaling_mode);
+    EXPECT_EQ(fd_buffered, file->getFdBuffered());
+    EXPECT_EQ(fd_unbuffered, file->getFdUnbuffered());
 }
 
 TEST_F(HipFileHandle, register_handle_internal_linux_fd_already_registered)
@@ -395,6 +404,31 @@ TEST_F(HipFileHandle, UnregistgeredFileClosesDupedFileDescriptorsWhenDestroyed)
     EXPECT_CALL(msys, close(fd_buffered));
     EXPECT_CALL(msys, close(fd_unbuffered));
     UnregisteredFile(97);
+}
+
+TEST_F(HipFileHandle, FileClosesDupedFileDescriptorsWhenDestroyed)
+{
+    int fd{0xABBA};
+    int fd_buffered{0x0D06F00D};
+    int fd_unbuffered{0x0BADF00D};
+
+    // To get a File we need to go through the registration process which
+    // creates and consumes an UnregisteredFile to create a file
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_buffered(fd_buffered)
+        .fd_unbuffered(fd_unbuffered)
+        .build();
+
+    // FileDescriptors managing fd_buffered and fd_unbuffered are moved from
+    // UnregisteredFile to File.  The file descriptors should not be closed when
+    // they are transferred
+    auto file_handle{Context<DriverState>::get()->registerFile(UnregisteredFile{fd})};
+
+    // Now that file owns fd_buffered and fd_unbuffered, they should be closed
+    // when file is unregistered and ultimately destroyed
+    EXPECT_CALL(msys, close(fd_buffered));
+    EXPECT_CALL(msys, close(fd_unbuffered));
+    Context<DriverState>::get()->deregisterFile(file_handle);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/hipfile/test/amd_detail/handle.cpp
+++ b/hipfile/test/amd_detail/handle.cpp
@@ -40,6 +40,8 @@ struct ExpectUnregisteredFileBuilder {
     optional<struct statx> m_statx;
     optional<int>          m_fcntl_flags;
     optional<MountInfo>    m_mountinfo;
+    optional<int>          m_fd_buffered;
+    optional<int>          m_fd_unbuffered;
 
     ExpectUnregisteredFileBuilder(MSys &msys, MLibMountHelper &mlibmounthelper)
         : m_msys(msys), m_mlibmounthelper(mlibmounthelper)
@@ -61,6 +63,18 @@ struct ExpectUnregisteredFileBuilder {
     ExpectUnregisteredFileBuilder &mountinfo(const MountInfo &mountinfo)
     {
         m_mountinfo = mountinfo;
+        return *this;
+    }
+
+    ExpectUnregisteredFileBuilder &fd_buffered(int fd_buffered)
+    {
+        m_fd_buffered = fd_buffered;
+        return *this;
+    }
+
+    ExpectUnregisteredFileBuilder &fd_unbuffered(int fd_unbuffered)
+    {
+        m_fd_unbuffered = fd_unbuffered;
         return *this;
     }
 
@@ -91,6 +105,13 @@ struct ExpectUnregisteredFile {
         else {
             EXPECT_CALL(builder.m_mlibmounthelper, getMountInfo);
         }
+
+        EXPECT_CALL(builder.m_msys, fcntl(_, F_DUPFD_CLOEXEC, _))
+            .Times(2)
+            .WillOnce(Return(builder.m_fd_buffered ? builder.m_fd_buffered.value() : -1))
+            .WillOnce(Return(builder.m_fd_unbuffered ? builder.m_fd_unbuffered.value() : -1));
+
+        EXPECT_CALL(builder.m_msys, fcntl(_, F_SETFL, _)).Times(1);
     }
 };
 
@@ -122,6 +143,8 @@ TEST_F(HipFileHandle, register_handle_internal_linux_fd)
 TEST_F(HipFileHandle, file_initialization)
 {
     int          fd{0x12345678};
+    int          fd_buffered{0x33445566};
+    int          fd_unbuffered{0x77889900};
     int          status_flags{0x789ABCDE};
     struct statx stxbuf;
     memset(&stxbuf, 0xA5, sizeof(stxbuf));
@@ -134,7 +157,10 @@ TEST_F(HipFileHandle, file_initialization)
         .statx(stxbuf)
         .fcntl_flags(status_flags)
         .mountinfo(mountinfo)
+        .fd_buffered(fd_buffered)
+        .fd_unbuffered(fd_unbuffered)
         .build();
+    EXPECT_CALL(msys, close).Times(2);
     auto fh{Context<DriverState>::get()->registerFile(fd)};
     auto file{Context<DriverState>::get()->getFile(fh)};
 
@@ -308,6 +334,67 @@ TEST_F(HipFileHandle, deregister_handle_fails_when_operations_are_oustanding)
         hipFileHandleDeregister(fh);
     }
     hipFileHandleDeregister(fh);
+}
+
+TEST_F(HipFileHandle, UnregisteredFileUnsetsODirectOnFdBufferedWhenInstantiatedWithUnbufferedFile)
+{
+    int           fd{777777};
+    int           fd_buffered{888888};
+    int           fd_unbuffered{999999};
+    unsigned long fd_flags{~0UL}; // O_DIRECT flag (and all other flags) set
+
+    // Expectations for construction of UnregisteredFile
+    EXPECT_CALL(msys, statx);
+    EXPECT_CALL(msys, fcntl(fd, F_GETFL, 0)).WillOnce(Return(fd_flags));
+    EXPECT_CALL(mlibmounthelper, getMountInfo);
+    EXPECT_CALL(msys, fcntl(fd, F_DUPFD_CLOEXEC, 0))
+        .Times(2)
+        .WillOnce(Return(fd_buffered))
+        .WillOnce(Return(fd_unbuffered));
+    EXPECT_CALL(msys, fcntl(fd_buffered, F_SETFL, fd_flags & ~static_cast<unsigned long>(O_DIRECT))).Times(1);
+
+    // Expectations for destruction of UnregisteredFile
+    EXPECT_CALL(msys, close(fd_buffered));
+    EXPECT_CALL(msys, close(fd_unbuffered));
+
+    UnregisteredFile uf{fd};
+}
+
+TEST_F(HipFileHandle, UnregisteredFileSetsODirectOnFdUnbufferedWhenInstantiatedWithBufferedFile)
+{
+    int           fd{777777};
+    int           fd_buffered{888888};
+    int           fd_unbuffered{999999};
+    unsigned long fd_flags{~static_cast<unsigned long>(O_DIRECT)}; // All flags other than O_DIRECT are set
+
+    // Expectations for construction of UnregisteredFile
+    EXPECT_CALL(msys, statx);
+    EXPECT_CALL(msys, fcntl(fd, F_GETFL, 0)).WillOnce(Return(fd_flags));
+    EXPECT_CALL(mlibmounthelper, getMountInfo);
+    EXPECT_CALL(msys, fcntl(fd, F_DUPFD_CLOEXEC, 0))
+        .Times(2)
+        .WillOnce(Return(fd_buffered))
+        .WillOnce(Return(fd_unbuffered));
+    EXPECT_CALL(msys, fcntl(fd_unbuffered, F_SETFL, ~0UL)).Times(1);
+
+    // Expectations for destruction of UnregisteredFile
+    EXPECT_CALL(msys, close(fd_buffered));
+    EXPECT_CALL(msys, close(fd_unbuffered));
+
+    UnregisteredFile uf{fd};
+}
+
+TEST_F(HipFileHandle, UnregistgeredFileClosesDupedFileDescriptorsWhenDestroyed)
+{
+    int fd_buffered{0x0D06F00D};
+    int fd_unbuffered{0x0BADD00D};
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_buffered(fd_buffered)
+        .fd_unbuffered(fd_unbuffered)
+        .build();
+    EXPECT_CALL(msys, close(fd_buffered));
+    EXPECT_CALL(msys, close(fd_unbuffered));
+    UnregisteredFile(97);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/hipfile/test/amd_detail/mbackend.h
+++ b/hipfile/test/amd_detail/mbackend.h
@@ -13,7 +13,7 @@ namespace hipFile {
 
 struct MBackend : Backend {
     MOCK_METHOD(int, score, (std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t, hoff_t),
-                (const override));
+                (const, override));
     MOCK_METHOD(ssize_t, io,
                 (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
                  hoff_t),

--- a/hipfile/test/amd_detail/mbuffer.h
+++ b/hipfile/test/amd_detail/mbuffer.h
@@ -17,11 +17,11 @@ namespace hipFile {
 
 class MBuffer : public IBuffer {
 public:
-    MOCK_METHOD(void *, getBuffer, (), (const override));
-    MOCK_METHOD(size_t, getLength, (), (const override));
-    MOCK_METHOD(int, getFlags, (), (const override));
-    MOCK_METHOD(hipMemoryType, getType, (), (const override));
-    MOCK_METHOD(int, getGpuId, (), (const override));
+    MOCK_METHOD(void *, getBuffer, (), (const, override));
+    MOCK_METHOD(size_t, getLength, (), (const, override));
+    MOCK_METHOD(int, getFlags, (), (const, override));
+    MOCK_METHOD(hipMemoryType, getType, (), (const, override));
+    MOCK_METHOD(int, getGpuId, (), (const, override));
 };
 
 class MBufferMap : public BufferMap {

--- a/hipfile/test/amd_detail/mfile.h
+++ b/hipfile/test/amd_detail/mfile.h
@@ -30,7 +30,7 @@ public:
     MFileMap()
     {
     }
-    MOCK_METHOD(hipFileHandle_t, registerFile, (const UnregisteredFile &uf), (override));
+    MOCK_METHOD(hipFileHandle_t, registerFile, (UnregisteredFile && uf), (override));
     MOCK_METHOD(void, deregisterFile, (hipFileHandle_t fh), (override));
     MOCK_METHOD(std::shared_ptr<IFile>, getFile, (hipFileHandle_t), (override));
     MOCK_METHOD(void, clear, (), (override));

--- a/hipfile/test/amd_detail/mfile.h
+++ b/hipfile/test/amd_detail/mfile.h
@@ -20,6 +20,8 @@ class MFile : public IFile {
 public:
     MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
     MOCK_METHOD(int, getFd, (), (const, override));
+    MOCK_METHOD(int, getFdBuffered, (), (const, override));
+    MOCK_METHOD(int, getFdUnbuffered, (), (const, override));
     MOCK_METHOD(const struct statx &, getStatx, (), (const, noexcept, override));
     MOCK_METHOD(int, getStatusFlags, (), (const, override));
     MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));

--- a/hipfile/test/amd_detail/mfile.h
+++ b/hipfile/test/amd_detail/mfile.h
@@ -18,11 +18,11 @@ namespace hipFile {
 
 class MFile : public IFile {
 public:
-    MOCK_METHOD(hipFileHandle_t, getHandle, (), (const override));
-    MOCK_METHOD(int, getFd, (), (const override));
+    MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
+    MOCK_METHOD(int, getFd, (), (const, override));
     MOCK_METHOD(const struct statx &, getStatx, (), (const, noexcept, override));
-    MOCK_METHOD(int, getStatusFlags, (), (const override));
-    MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const override));
+    MOCK_METHOD(int, getStatusFlags, (), (const, override));
+    MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));
 };
 
 class MFileMap : public FileMap {

--- a/hipfile/test/amd_detail/mhip.h
+++ b/hipfile/test/amd_detail/mhip.h
@@ -23,23 +23,23 @@ struct MHip : Hip {
     }
     MOCK_METHOD(hipPointerAttribute_t, hipPointerGetAttributes, (const void *ptr), (const override));
     MOCK_METHOD(void, hipMemcpy, (void *dst, const void *src, size_t sizeBytes, hipMemcpyKind kind),
-                (const override));
-    MOCK_METHOD(void, hipStreamSynchronize, (hipStream_t stream), (const override));
-    MOCK_METHOD(void *, hipHostMalloc, (size_t size, unsigned int flags), (const override));
-    MOCK_METHOD(void, hipHostFree, (void *ptr), (const override));
-    MOCK_METHOD(void *, hipHostGetDevicePointer, (void *hstPtr, unsigned int flags), (const override));
-    MOCK_METHOD(int, hipRuntimeGetVersion, (), (const override));
+                (const, override));
+    MOCK_METHOD(void, hipStreamSynchronize, (hipStream_t stream), (const, override));
+    MOCK_METHOD(void *, hipHostMalloc, (size_t size, unsigned int flags), (const, override));
+    MOCK_METHOD(void, hipHostFree, (void *ptr), (const, override));
+    MOCK_METHOD(void *, hipHostGetDevicePointer, (void *hstPtr, unsigned int flags), (const, override));
+    MOCK_METHOD(int, hipRuntimeGetVersion, (), (const, override));
     MOCK_METHOD(void *, hipGetProcAddress,
                 (const char *symbol, int hipVersion, uint64_t flags,
                  hipDriverProcAddressQueryResult *symbolStatus),
-                (const override));
+                (const, override));
     MOCK_METHOD(uint64_t, hipAmdFileRead,
                 (hipAmdFileHandle_t handle, void *devicePtr, uint64_t size, int64_t file_offset),
-                (const override));
+                (const, override));
     MOCK_METHOD(uint64_t, hipAmdFileWrite,
                 (hipAmdFileHandle_t handle, void *devicePtr, uint64_t size, int64_t file_offset),
-                (const override));
-    MOCK_METHOD(HipMemAddressRange, hipMemGetAddressRange, (hipDeviceptr_t dptr), (const override));
+                (const, override));
+    MOCK_METHOD(HipMemAddressRange, hipMemGetAddressRange, (hipDeviceptr_t dptr), (const, override));
 };
 
 }

--- a/hipfile/test/amd_detail/mstate.h
+++ b/hipfile/test/amd_detail/mstate.h
@@ -34,7 +34,7 @@ public:
     MOCK_METHOD(void, deregisterBuffer, (const void *buf), (override));
     MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *buf), (override));
     MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *buf, size_t length, int flags), (override));
-    MOCK_METHOD(hipFileHandle_t, registerFile, (const UnregisteredFile &uf), (override));
+    MOCK_METHOD(hipFileHandle_t, registerFile, (UnregisteredFile && uf), (override));
     MOCK_METHOD(void, deregisterFile, (hipFileHandle_t fh), (override));
     MOCK_METHOD(std::shared_ptr<IFile>, getFile, (hipFileHandle_t fh), (override));
     MOCK_METHOD(file_buffer_pair, getFileAndBuffer,

--- a/hipfile/test/amd_detail/mstate.h
+++ b/hipfile/test/amd_detail/mstate.h
@@ -42,7 +42,7 @@ public:
     MOCK_METHOD(void, incrRefCount, (), (override));
     MOCK_METHOD(void, decrRefCount, (), (override));
     MOCK_METHOD(int64_t, getRefCount, (), (override, const));
-    MOCK_METHOD(std::vector<std::shared_ptr<Backend>>, getBackends, (), (const override));
+    MOCK_METHOD(std::vector<std::shared_ptr<Backend>>, getBackends, (), (const, override));
 };
 
 }

--- a/hipfile/test/amd_detail/mstream.h
+++ b/hipfile/test/amd_detail/mstream.h
@@ -10,11 +10,11 @@ namespace hipFile {
 
 class MStream : public IStream {
 public:
-    MOCK_METHOD(hipStream_t, getHipStream, (), (const override));
-    MOCK_METHOD(bool, fixedBufferOffset, (), (const override));
-    MOCK_METHOD(bool, fixedFileOffset, (), (const override));
-    MOCK_METHOD(bool, fixedIOSize, (), (const override));
-    MOCK_METHOD(bool, pageAligned, (), (const override));
+    MOCK_METHOD(hipStream_t, getHipStream, (), (const, override));
+    MOCK_METHOD(bool, fixedBufferOffset, (), (const, override));
+    MOCK_METHOD(bool, fixedFileOffset, (), (const, override));
+    MOCK_METHOD(bool, fixedIOSize, (), (const, override));
+    MOCK_METHOD(bool, pageAligned, (), (const, override));
 };
 
 }

--- a/hipfile/test/amd_detail/msys.h
+++ b/hipfile/test/amd_detail/msys.h
@@ -18,6 +18,7 @@ struct MSys : Sys {
     MSys() : co{this}
     {
     }
+    MOCK_METHOD(void, close, (int), (const, override));
     MOCK_METHOD(void *, mmap, (void *addr, size_t length, int prot, int flags, int fd, off_t offset),
                 (const, override));
     MOCK_METHOD(void, munmap, (void *addr, size_t length), (const, override));

--- a/hipfile/test/amd_detail/msys.h
+++ b/hipfile/test/amd_detail/msys.h
@@ -19,19 +19,19 @@ struct MSys : Sys {
     {
     }
     MOCK_METHOD(void *, mmap, (void *addr, size_t length, int prot, int flags, int fd, off_t offset),
-                (const override));
-    MOCK_METHOD(void, munmap, (void *addr, size_t length), (const override));
+                (const, override));
+    MOCK_METHOD(void, munmap, (void *addr, size_t length), (const, override));
 
-    MOCK_METHOD(ssize_t, pread, (int fd, void *buf, size_t count, off_t offset), (const override));
-    MOCK_METHOD(ssize_t, pwrite, (int fd, void *buf, size_t count, off_t offset), (const override));
+    MOCK_METHOD(ssize_t, pread, (int fd, void *buf, size_t count, off_t offset), (const, override));
+    MOCK_METHOD(ssize_t, pwrite, (int fd, void *buf, size_t count, off_t offset), (const, override));
 
-    MOCK_METHOD(void, syslog, (int priority, const char *msg), (const override));
+    MOCK_METHOD(void, syslog, (int priority, const char *msg), (const, override));
 
-    MOCK_METHOD(struct stat, fstat, (int fd), (const override));
+    MOCK_METHOD(struct stat, fstat, (int fd), (const, override));
     MOCK_METHOD(struct statx, statx, (int dirfd, const char *pathname, int flags, unsigned int mask),
-                (const override));
+                (const, override));
 
-    MOCK_METHOD(int, fcntl, (int fd, int op, uintptr_t arg), (const override));
+    MOCK_METHOD(int, fcntl, (int fd, int op, uintptr_t arg), (const, override));
 
     MOCK_METHOD(char *, getenv, (const char *name), (const, noexcept, override));
 };

--- a/hipfile/test/amd_detail/state_mt.cpp
+++ b/hipfile/test/amd_detail/state_mt.cpp
@@ -382,11 +382,13 @@ main()
     // Each thread should be able to create about 10 files
     const unsigned n_files_per_thread = 10;
 
-    if (nofile.rlim_cur <= n_file_reserved + (N_THREADS * n_files_per_thread)) {
+    // hipfile makes two additional file descriptors each time a file is
+    // registered
+    if (nofile.rlim_cur <= n_file_reserved + (N_THREADS * n_files_per_thread * 3)) {
         cerr << "RLIMIT_NOFILE (ulimit -n) is to low" << endl;
         exit(EXIT_FAILURE);
     }
-    n_free_files = nofile.rlim_cur - n_file_reserved;
+    n_free_files = (nofile.rlim_cur - n_file_reserved) / 3;
 
     array<thread, N_THREADS> threads;
 

--- a/util/fio/write-read-verify.fio
+++ b/util/fio/write-read-verify.fio
@@ -2,7 +2,6 @@
 [global]
 ioengine=libhipfile
 rocm_io=hipfile
-direct=1
 gpu_dev_ids=0
 filename=fio.dat
 size=1G


### PR DESCRIPTION
## Motivation

No longer require files to have the O_DIRECT flag set when they are registered with hipFile. This change will also enable hipFile to eventually handle unaligned IO.

## Technical Details

When a file is registered with hipfile, hipfile creates duplicates of the file descriptor. One buffered, one unbuffered (O_DIRECT). hipFile uses these internal file descriptors when performing IO.