### PR TITLE
Turn off sanitizers in executables

### DIFF
--- a/cmake/AISAddExecutable.cmake
+++ b/cmake/AISAddExecutable.cmake
@@ -33,6 +33,9 @@ function(ais_add_executable)
     add_executable(${arg_NAME} ${arg_SRCS})
     ais_set_compiler_flags(${arg_NAME})
 
+    # Turn sanitizers off for executables
+    target_compile_options(${arg_NAME} PRIVATE -fno-sanitize=all)
+
     get_target_property(linker_language ${arg_NAME} LINKER_LANGUAGE)
     if(linker_language STREQUAL "HIP")
         target_link_libraries(${arg_NAME} PRIVATE hip::device)


### PR DESCRIPTION
This is a bit crude, but GTest has severe problems when the test applications are built with the sanitizers.

This change will disable compiling the test applications with the sanitizer flags. It will still compile the library with sanitizers and we still need to link the test programs with the sanitizer libraries.