### PR TITLE
hipfile: MOCK_METHOD's specs argument should be a comma-separated list

### DIFF
--- a/hipfile/test/amd_detail/mbackend.h
+++ b/hipfile/test/amd_detail/mbackend.h
@@ -13,7 +13,7 @@ namespace hipFile {
 
 struct MBackend : Backend {
     MOCK_METHOD(int, score, (std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t, hoff_t),
-                (const override));
+                (const, override));
     MOCK_METHOD(ssize_t, io,
                 (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
                  hoff_t),

--- a/hipfile/test/amd_detail/mbuffer.h
+++ b/hipfile/test/amd_detail/mbuffer.h
@@ -17,11 +17,11 @@ namespace hipFile {
 
 class MBuffer : public IBuffer {
 public:
-    MOCK_METHOD(void *, getBuffer, (), (const override));
-    MOCK_METHOD(size_t, getLength, (), (const override));
-    MOCK_METHOD(int, getFlags, (), (const override));
-    MOCK_METHOD(hipMemoryType, getType, (), (const override));
-    MOCK_METHOD(int, getGpuId, (), (const override));
+    MOCK_METHOD(void *, getBuffer, (), (const, override));
+    MOCK_METHOD(size_t, getLength, (), (const, override));
+    MOCK_METHOD(int, getFlags, (), (const, override));
+    MOCK_METHOD(hipMemoryType, getType, (), (const, override));
+    MOCK_METHOD(int, getGpuId, (), (const, override));
 };
 
 class MBufferMap : public BufferMap {

--- a/hipfile/test/amd_detail/mfile.h
+++ b/hipfile/test/amd_detail/mfile.h
@@ -18,11 +18,11 @@ namespace hipFile {
 
 class MFile : public IFile {
 public:
-    MOCK_METHOD(hipFileHandle_t, getHandle, (), (const override));
-    MOCK_METHOD(int, getFd, (), (const override));
+    MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
+    MOCK_METHOD(int, getFd, (), (const, override));
     MOCK_METHOD(const struct statx &, getStatx, (), (const, noexcept, override));
-    MOCK_METHOD(int, getStatusFlags, (), (const override));
-    MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const override));
+    MOCK_METHOD(int, getStatusFlags, (), (const, override));
+    MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));
 };
 
 class MFileMap : public FileMap {

--- a/hipfile/test/amd_detail/mhip.h
+++ b/hipfile/test/amd_detail/mhip.h
@@ -23,23 +23,23 @@ struct MHip : Hip {
     }
     MOCK_METHOD(hipPointerAttribute_t, hipPointerGetAttributes, (const void *ptr), (const override));
     MOCK_METHOD(void, hipMemcpy, (void *dst, const void *src, size_t sizeBytes, hipMemcpyKind kind),
-                (const override));
-    MOCK_METHOD(void, hipStreamSynchronize, (hipStream_t stream), (const override));
-    MOCK_METHOD(void *, hipHostMalloc, (size_t size, unsigned int flags), (const override));
-    MOCK_METHOD(void, hipHostFree, (void *ptr), (const override));
-    MOCK_METHOD(void *, hipHostGetDevicePointer, (void *hstPtr, unsigned int flags), (const override));
-    MOCK_METHOD(int, hipRuntimeGetVersion, (), (const override));
+                (const, override));
+    MOCK_METHOD(void, hipStreamSynchronize, (hipStream_t stream), (const, override));
+    MOCK_METHOD(void *, hipHostMalloc, (size_t size, unsigned int flags), (const, override));
+    MOCK_METHOD(void, hipHostFree, (void *ptr), (const, override));
+    MOCK_METHOD(void *, hipHostGetDevicePointer, (void *hstPtr, unsigned int flags), (const, override));
+    MOCK_METHOD(int, hipRuntimeGetVersion, (), (const, override));
     MOCK_METHOD(void *, hipGetProcAddress,
                 (const char *symbol, int hipVersion, uint64_t flags,
                  hipDriverProcAddressQueryResult *symbolStatus),
-                (const override));
+                (const, override));
     MOCK_METHOD(uint64_t, hipAmdFileRead,
                 (hipAmdFileHandle_t handle, void *devicePtr, uint64_t size, int64_t file_offset),
-                (const override));
+                (const, override));
     MOCK_METHOD(uint64_t, hipAmdFileWrite,
                 (hipAmdFileHandle_t handle, void *devicePtr, uint64_t size, int64_t file_offset),
-                (const override));
-    MOCK_METHOD(HipMemAddressRange, hipMemGetAddressRange, (hipDeviceptr_t dptr), (const override));
+                (const, override));
+    MOCK_METHOD(HipMemAddressRange, hipMemGetAddressRange, (hipDeviceptr_t dptr), (const, override));
 };
 
 }

--- a/hipfile/test/amd_detail/mstate.h
+++ b/hipfile/test/amd_detail/mstate.h
@@ -42,7 +42,7 @@ public:
     MOCK_METHOD(void, incrRefCount, (), (override));
     MOCK_METHOD(void, decrRefCount, (), (override));
     MOCK_METHOD(int64_t, getRefCount, (), (override, const));
-    MOCK_METHOD(std::vector<std::shared_ptr<Backend>>, getBackends, (), (const override));
+    MOCK_METHOD(std::vector<std::shared_ptr<Backend>>, getBackends, (), (const, override));
 };
 
 }

--- a/hipfile/test/amd_detail/mstream.h
+++ b/hipfile/test/amd_detail/mstream.h
@@ -10,11 +10,11 @@ namespace hipFile {
 
 class MStream : public IStream {
 public:
-    MOCK_METHOD(hipStream_t, getHipStream, (), (const override));
-    MOCK_METHOD(bool, fixedBufferOffset, (), (const override));
-    MOCK_METHOD(bool, fixedFileOffset, (), (const override));
-    MOCK_METHOD(bool, fixedIOSize, (), (const override));
-    MOCK_METHOD(bool, pageAligned, (), (const override));
+    MOCK_METHOD(hipStream_t, getHipStream, (), (const, override));
+    MOCK_METHOD(bool, fixedBufferOffset, (), (const, override));
+    MOCK_METHOD(bool, fixedFileOffset, (), (const, override));
+    MOCK_METHOD(bool, fixedIOSize, (), (const, override));
+    MOCK_METHOD(bool, pageAligned, (), (const, override));
 };
 
 }

--- a/hipfile/test/amd_detail/msys.h
+++ b/hipfile/test/amd_detail/msys.h
@@ -19,19 +19,19 @@ struct MSys : Sys {
     {
     }
     MOCK_METHOD(void *, mmap, (void *addr, size_t length, int prot, int flags, int fd, off_t offset),
-                (const override));
-    MOCK_METHOD(void, munmap, (void *addr, size_t length), (const override));
+                (const, override));
+    MOCK_METHOD(void, munmap, (void *addr, size_t length), (const, override));
 
-    MOCK_METHOD(ssize_t, pread, (int fd, void *buf, size_t count, off_t offset), (const override));
-    MOCK_METHOD(ssize_t, pwrite, (int fd, void *buf, size_t count, off_t offset), (const override));
+    MOCK_METHOD(ssize_t, pread, (int fd, void *buf, size_t count, off_t offset), (const, override));
+    MOCK_METHOD(ssize_t, pwrite, (int fd, void *buf, size_t count, off_t offset), (const, override));
 
-    MOCK_METHOD(void, syslog, (int priority, const char *msg), (const override));
+    MOCK_METHOD(void, syslog, (int priority, const char *msg), (const, override));
 
-    MOCK_METHOD(struct stat, fstat, (int fd), (const override));
+    MOCK_METHOD(struct stat, fstat, (int fd), (const, override));
     MOCK_METHOD(struct statx, statx, (int dirfd, const char *pathname, int flags, unsigned int mask),
-                (const override));
+                (const, override));
 
-    MOCK_METHOD(int, fcntl, (int fd, int op, uintptr_t arg), (const override));
+    MOCK_METHOD(int, fcntl, (int fd, int op, uintptr_t arg), (const, override));
 
     MOCK_METHOD(char *, getenv, (const char *name), (const, noexcept, override));
 };


### PR DESCRIPTION
See: https://google.github.io/googletest/reference/mocking.html
