### PR TITLE
hipfile: Ensure hipfile has unbuffered and buffered file descriptors

### DIFF
--- a/examples/aiscp/aiscp.cpp
+++ b/examples/aiscp/aiscp.cpp
@@ -100,7 +100,7 @@ main(int argc, char *argv[])
         block_size = static_cast<size_t>(statbuf.st_blksize);
     }
 
-    if (open_file(dst_path, O_DIRECT | O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH, &dst_fd,
+    if (open_file(dst_path, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH, &dst_fd,
                   &dst_handle)) {
         goto program_exit;
     }
@@ -109,7 +109,7 @@ main(int argc, char *argv[])
         goto close_dst;
     }
 
-    if (open_file(src_path, O_DIRECT | O_RDONLY, 0, &src_fd, &src_handle)) {
+    if (open_file(src_path, O_RDONLY, 0, &src_fd, &src_handle)) {
         goto close_dst;
     }
 

--- a/src/amd_detail/CMakeLists.txt
+++ b/src/amd_detail/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HIPFILE_SOURCES
     context.cpp
     environment.cpp
     file.cpp
+    file-descriptor.cpp
     hip.cpp
     hipfile.cpp
     mountinfo.cpp

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -86,7 +86,8 @@ Fallback::io(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer,
         try {
             switch (io_type) {
                 case IoType::Read:
-                    io_bytes = Context<Sys>::get()->pread(file->getFd(), bounce_buffer.get(), count, offset);
+                    io_bytes =
+                        Context<Sys>::get()->pread(file->getClientFd(), bounce_buffer.get(), count, offset);
                     if (io_bytes > 0) {
                         Context<Hip>::get()->hipMemcpy(device_buffer_position, bounce_buffer.get(),
                                                        static_cast<size_t>(io_bytes), hipMemcpyHostToDevice);
@@ -96,7 +97,8 @@ Fallback::io(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer,
                     Context<Hip>::get()->hipMemcpy(bounce_buffer.get(), device_buffer_position, count,
                                                    hipMemcpyDeviceToHost);
                     Context<Hip>::get()->hipStreamSynchronize(nullptr);
-                    io_bytes = Context<Sys>::get()->pwrite(file->getFd(), bounce_buffer.get(), count, offset);
+                    io_bytes =
+                        Context<Sys>::get()->pwrite(file->getClientFd(), bounce_buffer.get(), count, offset);
                     break;
                 default:
                     throw std::runtime_error("Invalid IO type");

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -86,8 +86,8 @@ Fallback::io(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer,
         try {
             switch (io_type) {
                 case IoType::Read:
-                    io_bytes = Context<Sys>::get()->pread(file->getUnbufferedFd(), bounce_buffer.get(), count,
-                                                          offset);
+                    io_bytes =
+                        Context<Sys>::get()->pread(file->getBufferedFd(), bounce_buffer.get(), count, offset);
                     if (io_bytes > 0) {
                         Context<Hip>::get()->hipMemcpy(device_buffer_position, bounce_buffer.get(),
                                                        static_cast<size_t>(io_bytes), hipMemcpyHostToDevice);
@@ -97,8 +97,9 @@ Fallback::io(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer,
                     Context<Hip>::get()->hipMemcpy(bounce_buffer.get(), device_buffer_position, count,
                                                    hipMemcpyDeviceToHost);
                     Context<Hip>::get()->hipStreamSynchronize(nullptr);
-                    io_bytes = Context<Sys>::get()->pwrite(file->getUnbufferedFd(), bounce_buffer.get(),
-                                                           count, offset);
+                    io_bytes = Context<Sys>::get()->pwrite(file->getBufferedFd(), bounce_buffer.get(), count,
+                                                           offset);
+                    Context<Sys>::get()->fdatasync(file->getBufferedFd());
                     break;
                 default:
                     throw std::runtime_error("Invalid IO type");

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -86,8 +86,8 @@ Fallback::io(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer,
         try {
             switch (io_type) {
                 case IoType::Read:
-                    io_bytes =
-                        Context<Sys>::get()->pread(file->getClientFd(), bounce_buffer.get(), count, offset);
+                    io_bytes = Context<Sys>::get()->pread(file->getUnbufferedFd(), bounce_buffer.get(), count,
+                                                          offset);
                     if (io_bytes > 0) {
                         Context<Hip>::get()->hipMemcpy(device_buffer_position, bounce_buffer.get(),
                                                        static_cast<size_t>(io_bytes), hipMemcpyHostToDevice);
@@ -97,8 +97,8 @@ Fallback::io(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer,
                     Context<Hip>::get()->hipMemcpy(bounce_buffer.get(), device_buffer_position, count,
                                                    hipMemcpyDeviceToHost);
                     Context<Hip>::get()->hipStreamSynchronize(nullptr);
-                    io_bytes =
-                        Context<Sys>::get()->pwrite(file->getClientFd(), bounce_buffer.get(), count, offset);
+                    io_bytes = Context<Sys>::get()->pwrite(file->getUnbufferedFd(), bounce_buffer.get(),
+                                                           count, offset);
                     break;
                 default:
                     throw std::runtime_error("Invalid IO type");

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -156,7 +156,7 @@ Fastpath::io(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, si
     size_t             nbytes{};
     size_t             buflen{buffer->getLength()};
 
-    handle.fd = file->getClientFd();
+    handle.fd = file->getUnbufferedFd();
 
     if (file_offset < 0) {
         throw std::invalid_argument("Negative file offset");

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -156,7 +156,7 @@ Fastpath::io(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, si
     size_t             nbytes{};
     size_t             buflen{buffer->getLength()};
 
-    handle.fd = file->getFd();
+    handle.fd = file->getClientFd();
 
     if (file_offset < 0) {
         throw std::invalid_argument("Negative file offset");

--- a/src/amd_detail/file-descriptor.cpp
+++ b/src/amd_detail/file-descriptor.cpp
@@ -1,0 +1,66 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "context.h"
+#include "file-descriptor.h"
+#include "sys.h"
+
+using namespace hipFile;
+
+FileDescriptor
+FileDescriptor::make_managed(int fd)
+{
+    return FileDescriptor(fd, true);
+}
+
+FileDescriptor
+FileDescriptor::make_unmanaged(int fd)
+{
+    return FileDescriptor(fd, false);
+}
+
+FileDescriptor::FileDescriptor() : m_managed(false), m_fd(-1)
+{
+}
+
+FileDescriptor::FileDescriptor(int fd, bool managed) : m_managed(managed), m_fd(fd)
+{
+}
+
+FileDescriptor::~FileDescriptor()
+{
+    if (m_managed && m_fd != -1) {
+        Context<Sys>::get()->close(m_fd);
+    }
+    m_managed = false;
+    m_fd      = -1;
+}
+
+FileDescriptor::FileDescriptor(FileDescriptor &&other) noexcept : m_managed(other.m_managed), m_fd(other.m_fd)
+{
+    other.m_fd      = -1;
+    other.m_managed = false;
+}
+
+FileDescriptor &
+FileDescriptor::operator=(FileDescriptor &&other) noexcept
+{
+    if (this != &other) {
+        if (m_managed && m_fd != -1) {
+            Context<Sys>::get()->close(m_fd);
+        }
+        m_fd            = other.m_fd;
+        m_managed       = other.m_managed;
+        other.m_fd      = -1;
+        other.m_managed = false;
+    }
+    return *this;
+}
+
+int
+FileDescriptor::get() const
+{
+    return m_fd;
+}

--- a/src/amd_detail/file-descriptor.h
+++ b/src/amd_detail/file-descriptor.h
@@ -29,7 +29,7 @@ public:
     FileDescriptor(FileDescriptor &&other) noexcept;
     FileDescriptor &operator=(FileDescriptor &&other) noexcept;
 
-    /// @brief Get the file desciptor
+    /// @brief Get the file descriptor
     /// @return The file descriptor
     int get() const;
 

--- a/src/amd_detail/file-descriptor.h
+++ b/src/amd_detail/file-descriptor.h
@@ -1,0 +1,42 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+namespace hipFile {
+
+/// @brief Manage access to a file descriptor
+class FileDescriptor {
+public:
+    /// @brief Create an FileDescriptor instance that will close fd on destruction
+    /// @param fd A file descriptor
+    /// @return A FileDescriptor instance
+    static FileDescriptor make_managed(int fd);
+
+    /// @brief Create an FileDescriptor instance that will not close fd on destruction
+    /// @param fd A file descriptor
+    /// @return A FileDescriptor instance
+    static FileDescriptor make_unmanaged(int fd);
+
+    /// @brief Create an empty (fd=-1), unmanaged FileDescriptor
+    FileDescriptor();
+    ~FileDescriptor();
+
+    FileDescriptor(const FileDescriptor &)            = delete;
+    FileDescriptor &operator=(const FileDescriptor &) = delete;
+    FileDescriptor(FileDescriptor &&other) noexcept;
+    FileDescriptor &operator=(FileDescriptor &&other) noexcept;
+
+    /// @brief Get the file desciptor
+    /// @return The file descriptor
+    int get() const;
+
+private:
+    FileDescriptor(int fd, bool managed);
+
+    bool m_managed;
+    int  m_fd;
+};
+}

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -25,14 +25,15 @@ using std::vector;
 
 namespace hipFile {
 
-UnregisteredFile::UnregisteredFile(int _fd)
-    : fd(_fd), stx{Context<Sys>::get()->statx(fd, "", AT_EMPTY_PATH,
+UnregisteredFile::UnregisteredFile(int fd)
+    : client_fd(FileDescriptor::make_unmanaged(fd)),
+      stx{Context<Sys>::get()->statx(fd, "", AT_EMPTY_PATH,
 #if defined(STATX_DIOALIGN)
-                                              STATX_TYPE | STATX_MODE | STATX_DIOALIGN
+                                     STATX_TYPE | STATX_MODE | STATX_DIOALIGN
 #else
-                                              STATX_TYPE | STATX_MODE
+                                     STATX_TYPE | STATX_MODE
 #endif
-                                              )},
+                                     )},
       flags{Context<Sys>::get()->fcntl(fd, F_GETFL, 0)},
       mountinfo{Context<LibMountHelper>::get()->getMountInfo(makedev(stx.stx_dev_major, stx.stx_dev_minor))}
 {
@@ -45,14 +46,14 @@ IFile::getHandle() const
 }
 
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
-    : fd{uf.fd}, stx{uf.stx}, status_flags{uf.flags}, mountinfo{uf.mountinfo}
+    : client_fd{std::move(uf.client_fd)}, stx{uf.stx}, status_flags{uf.flags}, mountinfo{uf.mountinfo}
 {
 }
 
 int
-File::getFd() const
+File::getClientFd() const
 {
-    return fd;
+    return client_fd.get();
 }
 
 const struct statx &
@@ -87,13 +88,13 @@ FileMap::getFile(hipFileHandle_t fh)
 hipFileHandle_t
 FileMap::registerFile(UnregisteredFile &&uf)
 {
-    if (from_fd.end() != from_fd.find(uf.fd)) {
+    if (from_fd.end() != from_fd.find(uf.client_fd.get())) {
         throw FileAlreadyRegistered();
     }
 
-    auto file                  = std::shared_ptr<IFile>(new File(std::move(uf), PassKey<FileMap>{}));
-    from_fd[file->getFd()]     = file;
-    from_fh[file->getHandle()] = file;
+    auto file                    = std::shared_ptr<IFile>(new File(std::move(uf), PassKey<FileMap>{}));
+    from_fd[file->getClientFd()] = file;
+    from_fh[file->getHandle()]   = file;
 
     return file->getHandle();
 }
@@ -111,7 +112,7 @@ FileMap::deregisterFile(hipFileHandle_t fh)
         throw FileOperationsOutstanding();
     }
 
-    from_fd.erase(itr->second->getFd());
+    from_fd.erase(itr->second->getClientFd());
     from_fh.erase(fh);
 }
 

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -25,42 +25,17 @@ using std::vector;
 
 namespace hipFile {
 
-UnregisteredFile::UnregisteredFile(int fd)
-    : m_fd(fd), m_stx{Context<Sys>::get()->statx(fd, "", AT_EMPTY_PATH,
+UnregisteredFile::UnregisteredFile(int _fd)
+    : fd(_fd), stx{Context<Sys>::get()->statx(fd, "", AT_EMPTY_PATH,
 #if defined(STATX_DIOALIGN)
-                                                 STATX_TYPE | STATX_MODE | STATX_DIOALIGN
+                                              STATX_TYPE | STATX_MODE | STATX_DIOALIGN
 #else
-                                                 STATX_TYPE | STATX_MODE
+                                              STATX_TYPE | STATX_MODE
 #endif
-                                                 )},
-      m_flags{Context<Sys>::get()->fcntl(fd, F_GETFL, 0)},
-      m_mountinfo{
-          Context<LibMountHelper>::get()->getMountInfo(makedev(m_stx.stx_dev_major, m_stx.stx_dev_minor))}
+                                              )},
+      flags{Context<Sys>::get()->fcntl(fd, F_GETFL, 0)},
+      mountinfo{Context<LibMountHelper>::get()->getMountInfo(makedev(stx.stx_dev_major, stx.stx_dev_minor))}
 {
-}
-
-int
-UnregisteredFile::getFd() const noexcept
-{
-    return m_fd;
-}
-
-struct statx
-UnregisteredFile::getStatx() const noexcept
-{
-    return m_stx;
-}
-
-int
-UnregisteredFile::getFlags() const noexcept
-{
-    return m_flags;
-}
-
-optional<MountInfo>
-UnregisteredFile::getMountInfo() const noexcept
-{
-    return m_mountinfo;
 }
 
 hipFileHandle_t
@@ -69,8 +44,8 @@ IFile::getHandle() const
     return reinterpret_cast<hipFileHandle_t>(const_cast<IFile *>(this));
 }
 
-File::File(const UnregisteredFile &uf, const PassKey<FileMap> &)
-    : fd{uf.getFd()}, stx{uf.getStatx()}, status_flags{uf.getFlags()}, mountinfo{uf.getMountInfo()}
+File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
+    : fd{uf.fd}, stx{uf.stx}, status_flags{uf.flags}, mountinfo{uf.mountinfo}
 {
 }
 
@@ -110,13 +85,13 @@ FileMap::getFile(hipFileHandle_t fh)
 }
 
 hipFileHandle_t
-FileMap::registerFile(const UnregisteredFile &uf)
+FileMap::registerFile(UnregisteredFile &&uf)
 {
-    if (from_fd.end() != from_fd.find(uf.getFd())) {
+    if (from_fd.end() != from_fd.find(uf.fd)) {
         throw FileAlreadyRegistered();
     }
 
-    auto file                  = std::shared_ptr<IFile>(new File(uf, PassKey<FileMap>{}));
+    auto file                  = std::shared_ptr<IFile>(new File(std::move(uf), PassKey<FileMap>{}));
     from_fd[file->getFd()]     = file;
     from_fh[file->getHandle()] = file;
 

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -39,10 +39,7 @@ UnregisteredFile::UnregisteredFile(int fd)
       flags{Context<Sys>::get()->fcntl(fd, F_GETFL, 0)},
       mountinfo{Context<LibMountHelper>::get()->getMountInfo(makedev(stx.stx_dev_major, stx.stx_dev_minor))}
 {
-    vector<char> buf(PATH_MAX, '\0');
-    std::string  symlink_path = "/proc/self/fd/" + std::to_string(fd);
-    ssize_t      len = Context<Sys>::get()->readlink(symlink_path.c_str(), buf.data(), buf.size() - 1);
-    std::string  path(buf.data(), static_cast<unsigned long>(len));
+    std::string path = "/proc/self/fd/" + std::to_string(fd);
 
     if (flags & O_DIRECT) {
         unbuffered_fd = FileDescriptor::make_unmanaged(fd);

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -11,6 +11,7 @@
 #include "sys.h"
 
 #include <algorithm>
+#include <climits>
 #include <cstdlib>
 #include <fcntl.h>
 #include <iterator>
@@ -38,16 +39,20 @@ UnregisteredFile::UnregisteredFile(int fd)
       flags{Context<Sys>::get()->fcntl(fd, F_GETFL, 0)},
       mountinfo{Context<LibMountHelper>::get()->getMountInfo(makedev(stx.stx_dev_major, stx.stx_dev_minor))}
 {
+    vector<char> buf(PATH_MAX, '\0');
+    std::string  symlink_path = "/proc/self/fd/" + std::to_string(fd);
+    ssize_t      len = Context<Sys>::get()->readlink(symlink_path.c_str(), buf.data(), buf.size() - 1);
+    std::string  path(buf.data(), static_cast<unsigned long>(len));
+
     if (flags & O_DIRECT) {
         unbuffered_fd = FileDescriptor::make_unmanaged(fd);
-        buffered_fd   = FileDescriptor::make_managed(Context<Sys>::get()->fcntl(fd, F_DUPFD_CLOEXEC, 0));
-        Context<Sys>::get()->fcntl(buffered_fd.get(), F_SETFL, static_cast<unsigned long>(flags & ~O_DIRECT));
+        buffered_fd   = FileDescriptor::make_managed(
+            Context<Sys>::get()->open(path.c_str(), (flags | O_CLOEXEC) & ~O_DIRECT));
     }
     else {
         buffered_fd   = FileDescriptor::make_unmanaged(fd);
-        unbuffered_fd = FileDescriptor::make_managed(Context<Sys>::get()->fcntl(fd, F_DUPFD_CLOEXEC, 0));
-        Context<Sys>::get()->fcntl(unbuffered_fd.get(), F_SETFL,
-                                   static_cast<unsigned long>(flags | O_DIRECT));
+        unbuffered_fd = FileDescriptor::make_managed(
+            Context<Sys>::get()->open(path.c_str(), (flags | O_CLOEXEC) | O_DIRECT));
     }
 }
 

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -5,6 +5,7 @@
 
 #include "context.h"
 #include "file.h"
+#include "file-descriptor.h"
 #include "mountinfo.h"
 #include "passkey.h"
 #include "sys.h"
@@ -26,7 +27,7 @@ using std::vector;
 namespace hipFile {
 
 UnregisteredFile::UnregisteredFile(int fd)
-    : client_fd(FileDescriptor::make_unmanaged(fd)),
+    : client_fd(FileDescriptor::make_unmanaged(fd)), buffered_fd{}, unbuffered_fd{},
       stx{Context<Sys>::get()->statx(fd, "", AT_EMPTY_PATH,
 #if defined(STATX_DIOALIGN)
                                      STATX_TYPE | STATX_MODE | STATX_DIOALIGN
@@ -37,6 +38,17 @@ UnregisteredFile::UnregisteredFile(int fd)
       flags{Context<Sys>::get()->fcntl(fd, F_GETFL, 0)},
       mountinfo{Context<LibMountHelper>::get()->getMountInfo(makedev(stx.stx_dev_major, stx.stx_dev_minor))}
 {
+    if (flags & O_DIRECT) {
+        unbuffered_fd = FileDescriptor::make_unmanaged(fd);
+        buffered_fd   = FileDescriptor::make_managed(Context<Sys>::get()->fcntl(fd, F_DUPFD_CLOEXEC, 0));
+        Context<Sys>::get()->fcntl(buffered_fd.get(), F_SETFL, static_cast<unsigned long>(flags & ~O_DIRECT));
+    }
+    else {
+        buffered_fd   = FileDescriptor::make_unmanaged(fd);
+        unbuffered_fd = FileDescriptor::make_managed(Context<Sys>::get()->fcntl(fd, F_DUPFD_CLOEXEC, 0));
+        Context<Sys>::get()->fcntl(unbuffered_fd.get(), F_SETFL,
+                                   static_cast<unsigned long>(flags | O_DIRECT));
+    }
 }
 
 hipFileHandle_t
@@ -46,7 +58,8 @@ IFile::getHandle() const
 }
 
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
-    : client_fd{std::move(uf.client_fd)}, stx{uf.stx}, status_flags{uf.flags}, mountinfo{uf.mountinfo}
+    : client_fd{std::move(uf.client_fd)}, buffered_fd{std::move(uf.buffered_fd)},
+      unbuffered_fd{std::move(uf.unbuffered_fd)}, stx{uf.stx}, status_flags{uf.flags}, mountinfo{uf.mountinfo}
 {
 }
 
@@ -54,6 +67,18 @@ int
 File::getClientFd() const
 {
     return client_fd.get();
+}
+
+int
+File::getBufferedFd() const
+{
+    return buffered_fd.get();
+}
+
+int
+File::getUnbufferedFd() const
+{
+    return unbuffered_fd.get();
 }
 
 const struct statx &

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "file-descriptor.h"
 #include "hipfile.h"
 #include "mountinfo.h"
 #include "passkey.h"
@@ -49,7 +50,7 @@ public:
     UnregisteredFile(int fd);
 
     /// @brief The file descriptor provided by the client
-    int fd;
+    FileDescriptor client_fd;
 
     /// @brief Information provided by statx (2)
     struct statx stx;
@@ -69,7 +70,7 @@ public:
     /// @return The handle for this file
     virtual hipFileHandle_t getHandle() const;
 
-    virtual int                      getFd() const             = 0;
+    virtual int                      getClientFd() const       = 0;
     virtual const struct statx      &getStatx() const noexcept = 0;
     virtual int                      getStatusFlags() const    = 0;
     virtual std::optional<MountInfo> getMountInfo() const      = 0;
@@ -90,7 +91,7 @@ public:
     File(File &&)            = delete;
     File &operator=(File &&) = delete;
 
-    virtual int                      getFd() const override;
+    virtual int                      getClientFd() const override;
     virtual const struct statx      &getStatx() const noexcept override;
     virtual int                      getStatusFlags() const override;
     virtual std::optional<MountInfo> getMountInfo() const override;
@@ -101,8 +102,8 @@ public:
     File(UnregisteredFile &&uf, const PassKey<FileMap> &k);
 
 private:
-    /// @brief The file descriptor
-    int fd;
+    /// @brief The file descriptor provided by the client
+    FileDescriptor client_fd;
 
     /// @brief File status information obtained from statx (2)
     struct statx stx;

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -48,30 +48,17 @@ public:
     /// @param fd A valid file descriptor
     UnregisteredFile(int fd);
 
-    /// @return Returns the file descriptor
-    int getFd() const noexcept;
-
-    /// @return Returns the information provided by statx (2)
-    struct statx getStatx() const noexcept;
-
-    /// @return Returns the flags provided by fcntl (2)
-    int getFlags() const noexcept;
-
-    /// @brief Returns information obtained from /proc/self/mountinfo
-    std::optional<MountInfo> getMountInfo() const noexcept;
-
-private:
-    /// @brief The file descriptor
-    int m_fd;
+    /// @brief The file descriptor provided by the client
+    int fd;
 
     /// @brief Information provided by statx (2)
-    struct statx m_stx;
+    struct statx stx;
 
     /// @brief Flags provided by fcntl(2)
-    int m_flags;
+    int flags;
 
     /// @brief Information obtained from /proc/self/mountinfo
-    std::optional<MountInfo> m_mountinfo;
+    std::optional<MountInfo> mountinfo;
 };
 
 class IFile {
@@ -111,7 +98,7 @@ public:
     /// @brief Construct a registered file
     /// @param uf An unregistered file
     /// @param k  Key class instance (see passkey.h)
-    File(const UnregisteredFile &uf, const PassKey<FileMap> &k);
+    File(UnregisteredFile &&uf, const PassKey<FileMap> &k);
 
 private:
     /// @brief The file descriptor
@@ -136,7 +123,7 @@ public:
     /// @brief Registers a file. Files must be registered before they can be used with hipFile IO APIs
     /// @attention A unique_lock on HipFileMutex must be held
     /// @param uf An unregistered file
-    virtual hipFileHandle_t registerFile(const UnregisteredFile &uf);
+    virtual hipFileHandle_t registerFile(UnregisteredFile &&uf);
 
     /// @brief Deregisters the file associated with the provided file handle
     /// @attention A unique_lock on HipFileMutex must be held

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -52,6 +52,12 @@ public:
     /// @brief The file descriptor provided by the client
     FileDescriptor client_fd;
 
+    /// @brief Buffered file descriptor (!O_DIRECT)
+    FileDescriptor buffered_fd;
+
+    /// @brief Unbuffered file descriptor (O_DIRECT)
+    FileDescriptor unbuffered_fd;
+
     /// @brief Information provided by statx (2)
     struct statx stx;
 
@@ -71,6 +77,8 @@ public:
     virtual hipFileHandle_t getHandle() const;
 
     virtual int                      getClientFd() const       = 0;
+    virtual int                      getBufferedFd() const     = 0;
+    virtual int                      getUnbufferedFd() const   = 0;
     virtual const struct statx      &getStatx() const noexcept = 0;
     virtual int                      getStatusFlags() const    = 0;
     virtual std::optional<MountInfo> getMountInfo() const      = 0;
@@ -92,6 +100,8 @@ public:
     File &operator=(File &&) = delete;
 
     virtual int                      getClientFd() const override;
+    virtual int                      getBufferedFd() const override;
+    virtual int                      getUnbufferedFd() const override;
     virtual const struct statx      &getStatx() const noexcept override;
     virtual int                      getStatusFlags() const override;
     virtual std::optional<MountInfo> getMountInfo() const override;
@@ -104,6 +114,12 @@ public:
 private:
     /// @brief The file descriptor provided by the client
     FileDescriptor client_fd;
+
+    /// @brief Buffered file descriptor (!O_DIRECT)
+    FileDescriptor buffered_fd;
+
+    /// @brief Unbuffered file descriptor (O_DIRECT)
+    FileDescriptor unbuffered_fd;
 
     /// @brief File status information obtained from statx (2)
     struct statx stx;

--- a/src/amd_detail/hipfile.cpp
+++ b/src/amd_detail/hipfile.cpp
@@ -65,7 +65,7 @@ try {
     switch (descr->type) {
         case hipFileHandleTypeOpaqueFD: {
             UnregisteredFile uf{descr->handle.fd};
-            *fh = Context<DriverState>::get()->registerFile(uf);
+            *fh = Context<DriverState>::get()->registerFile(std::move(uf));
             return {hipFileSuccess, hipSuccess};
         }
         case hipFileHandleTypeOpaqueWin32:

--- a/src/amd_detail/state.cpp
+++ b/src/amd_detail/state.cpp
@@ -120,7 +120,7 @@ DriverState::getBuffer(const void *buf, size_t length, int flags)
 //
 
 hipFileHandle_t
-DriverState::registerFile(const UnregisteredFile &uf)
+DriverState::registerFile(UnregisteredFile &&uf)
 {
     unique_lock<shared_mutex> ulock{state_mutex};
 
@@ -130,7 +130,7 @@ DriverState::registerFile(const UnregisteredFile &uf)
         ref_count++;
     }
 
-    return file_map->registerFile(uf);
+    return file_map->registerFile(std::move(uf));
 }
 
 void

--- a/src/amd_detail/state.h
+++ b/src/amd_detail/state.h
@@ -116,7 +116,7 @@ public:
     /// @brief Registers a file. Files must be registered before they can be used with hipFile IO APIs
     /// @param [in] uf An unregistered file
     /// @return A handle to be used when calling hipFile IO APIs
-    virtual hipFileHandle_t registerFile(const UnregisteredFile &uf);
+    virtual hipFileHandle_t registerFile(UnregisteredFile &&uf);
 
     /// @brief Deregisters the file associated with the provided file handle
     /// @param [in] fh The handle of the file to deregister

--- a/src/amd_detail/sys.cpp
+++ b/src/amd_detail/sys.cpp
@@ -66,6 +66,12 @@ Sys::pwrite(int fd, void *buf, size_t count, off_t offset) const
     return throwOn<Sys::RuntimeError>(-1, ::pwrite(fd, buf, count, offset));
 }
 
+ssize_t
+Sys::readlink(const char *pathname, char *buf, size_t bufsize)
+{
+    return throwOn<Sys::RuntimeError>(-1, ::readlink(pathname, buf, bufsize));
+}
+
 void
 Sys::syslog(int priority, const char *msg) const
 {

--- a/src/amd_detail/sys.cpp
+++ b/src/amd_detail/sys.cpp
@@ -23,6 +23,18 @@ throwOn(const L throw_value, R value)
     return value;
 }
 
+int
+Sys::open(const char *pathname, int flags)
+{
+    return throwOn<Sys::RuntimeError>(-1, ::open(pathname, flags));
+}
+
+int
+Sys::open(const char *pathname, int flags, mode_t mode)
+{
+    return throwOn<Sys::RuntimeError>(-1, ::open(pathname, flags, mode));
+}
+
 void
 Sys::close(int fd) const
 {

--- a/src/amd_detail/sys.cpp
+++ b/src/amd_detail/sys.cpp
@@ -41,6 +41,12 @@ Sys::close(int fd) const
     throwOn<Sys::RuntimeError>(-1, ::close(fd));
 }
 
+void
+Sys::fdatasync(int fd) const
+{
+    throwOn<Sys::RuntimeError>(-1, ::fdatasync(fd));
+}
+
 void *
 Sys::mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) const
 {

--- a/src/amd_detail/sys.cpp
+++ b/src/amd_detail/sys.cpp
@@ -24,13 +24,13 @@ throwOn(const L throw_value, R value)
 }
 
 int
-Sys::open(const char *pathname, int flags)
+Sys::open(const char *pathname, int flags) const
 {
     return throwOn<Sys::RuntimeError>(-1, ::open(pathname, flags));
 }
 
 int
-Sys::open(const char *pathname, int flags, mode_t mode)
+Sys::open(const char *pathname, int flags, mode_t mode) const
 {
     return throwOn<Sys::RuntimeError>(-1, ::open(pathname, flags, mode));
 }
@@ -67,7 +67,7 @@ Sys::pwrite(int fd, void *buf, size_t count, off_t offset) const
 }
 
 ssize_t
-Sys::readlink(const char *pathname, char *buf, size_t bufsize)
+Sys::readlink(const char *pathname, char *buf, size_t bufsize) const
 {
     return throwOn<Sys::RuntimeError>(-1, ::readlink(pathname, buf, bufsize));
 }

--- a/src/amd_detail/sys.cpp
+++ b/src/amd_detail/sys.cpp
@@ -23,6 +23,12 @@ throwOn(const L throw_value, R value)
     return value;
 }
 
+void
+Sys::close(int fd) const
+{
+    throwOn<Sys::RuntimeError>(-1, ::close(fd));
+}
+
 void *
 Sys::mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) const
 {

--- a/src/amd_detail/sys.h
+++ b/src/amd_detail/sys.h
@@ -29,6 +29,8 @@ struct Sys {
     virtual int  open(const char *pathname, int flags, mode_t mode) const;
     virtual void close(int fd) const;
 
+    virtual void fdatasync(int fd) const;
+
     virtual void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) const;
     virtual void  munmap(void *addr, size_t length) const;
 

--- a/src/amd_detail/sys.h
+++ b/src/amd_detail/sys.h
@@ -35,6 +35,8 @@ struct Sys {
     virtual ssize_t pread(int fd, void *buf, size_t count, off_t offset) const;
     virtual ssize_t pwrite(int fd, void *buf, size_t count, off_t offset) const;
 
+    virtual ssize_t readlink(const char *pathname, char *buf, size_t bufsize);
+
     virtual void syslog(int priority, const char *msg) const;
 
     virtual struct stat  fstat(int fd) const;

--- a/src/amd_detail/sys.h
+++ b/src/amd_detail/sys.h
@@ -25,6 +25,8 @@ namespace hipFile {
 struct Sys {
     virtual ~Sys() = default;
 
+    virtual void close(int fd) const;
+
     virtual void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) const;
     virtual void  munmap(void *addr, size_t length) const;
 

--- a/src/amd_detail/sys.h
+++ b/src/amd_detail/sys.h
@@ -25,6 +25,8 @@ namespace hipFile {
 struct Sys {
     virtual ~Sys() = default;
 
+    virtual int  open(const char *pathname, int flags);
+    virtual int  open(const char *pathname, int flags, mode_t mode);
     virtual void close(int fd) const;
 
     virtual void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) const;

--- a/src/amd_detail/sys.h
+++ b/src/amd_detail/sys.h
@@ -25,8 +25,8 @@ namespace hipFile {
 struct Sys {
     virtual ~Sys() = default;
 
-    virtual int  open(const char *pathname, int flags);
-    virtual int  open(const char *pathname, int flags, mode_t mode);
+    virtual int  open(const char *pathname, int flags) const;
+    virtual int  open(const char *pathname, int flags, mode_t mode) const;
     virtual void close(int fd) const;
 
     virtual void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) const;
@@ -35,7 +35,7 @@ struct Sys {
     virtual ssize_t pread(int fd, void *buf, size_t count, off_t offset) const;
     virtual ssize_t pwrite(int fd, void *buf, size_t count, off_t offset) const;
 
-    virtual ssize_t readlink(const char *pathname, char *buf, size_t bufsize);
+    virtual ssize_t readlink(const char *pathname, char *buf, size_t bufsize) const;
 
     virtual void syslog(int priority, const char *msg) const;
 

--- a/test/amd_detail/CMakeLists.txt
+++ b/test/amd_detail/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_SOURCE_FILES
     buffer.cpp
     driver.cpp
     environment.cpp
+    file-descriptor.cpp
     handle.cpp
     hip.cpp
     hipfile-api.cpp

--- a/test/amd_detail/fallback.cpp
+++ b/test/amd_detail/fallback.cpp
@@ -272,6 +272,7 @@ TEST_P(FallbackParam, fallback_io_truncates_size_to_MAX_RW_COUNT)
                 .WillRepeatedly(testing::Invoke([](int, void *, size_t count, hoff_t) -> ssize_t {
                     return static_cast<ssize_t>(count);
                 }));
+            EXPECT_CALL(msys, fdatasync).Times(AnyNumber());
             break;
         default:
             FAIL();
@@ -305,6 +306,7 @@ TEST_P(FallbackParam, fallback_io_allocates_chunk_sized_host_bounce_buffer)
             EXPECT_CALL(mhip, hipMemcpy);
             EXPECT_CALL(mhip, hipStreamSynchronize);
             EXPECT_CALL(msys, pwrite).WillOnce(testing::Return(0));
+            EXPECT_CALL(msys, fdatasync);
             break;
         default:
             FAIL();
@@ -346,6 +348,7 @@ struct FallbackWrite : public FallbackIo {
         EXPECT_CALL(mhip, hipStreamSynchronize).WillRepeatedly(testing::Return());
         EXPECT_CALL(msys, pwrite).WillRepeatedly(testing::Invoke(this, &FallbackWrite::fake_pwrite));
         EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
+        EXPECT_CALL(msys, fdatasync).Times(AnyNumber());
     }
 
     // Test if the file contains the correct data

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -247,14 +247,14 @@ struct FastpathIoParam : public FastpathTestBase, public TestWithParam<IoType> {
     {
         EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-        EXPECT_CALL(*mfile, getFd).WillOnce(Return(DEFAULT_FILE_DESCRIPTOR));
+        EXPECT_CALL(*mfile, getClientFd).WillOnce(Return(DEFAULT_FILE_DESCRIPTOR));
     }
 
     void expect_io(int fd, void *bufptr, size_t buflen)
     {
         EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(bufptr));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(buflen));
-        EXPECT_CALL(*mfile, getFd).WillOnce(Return(fd));
+        EXPECT_CALL(*mfile, getClientFd).WillOnce(Return(fd));
     }
 };
 

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -247,14 +247,14 @@ struct FastpathIoParam : public FastpathTestBase, public TestWithParam<IoType> {
     {
         EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-        EXPECT_CALL(*mfile, getClientFd).WillOnce(Return(DEFAULT_FILE_DESCRIPTOR));
+        EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_FILE_DESCRIPTOR));
     }
 
     void expect_io(int fd, void *bufptr, size_t buflen)
     {
         EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(bufptr));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(buflen));
-        EXPECT_CALL(*mfile, getClientFd).WillOnce(Return(fd));
+        EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(fd));
     }
 };
 

--- a/test/amd_detail/file-descriptor.cpp
+++ b/test/amd_detail/file-descriptor.cpp
@@ -1,0 +1,93 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "file-descriptor.h"
+#include "msys.h"
+
+#include <gtest/gtest.h>
+
+using namespace hipFile;
+using namespace testing;
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
+
+struct HipFileFileDescriptor : public Test {
+    StrictMock<MSys> msys;
+};
+
+TEST_F(HipFileFileDescriptor, ManagedFileDescriptorClosesOnDestruction)
+{
+    auto fd{FileDescriptor::make_managed(42)};
+    EXPECT_CALL(msys, close(42));
+}
+
+TEST_F(HipFileFileDescriptor, ManagedFileDescriptorDoesNotCloseOnDestructionIfFdIsNegativeOne)
+{
+    auto fd{FileDescriptor::make_managed(-1)};
+}
+
+TEST_F(HipFileFileDescriptor, UnmanagedFileDescriptorDoesNotCloseOnDestruction)
+{
+    auto fd{FileDescriptor::make_unmanaged(42)};
+}
+
+TEST_F(HipFileFileDescriptor, ManagedFileDescriptorMoveCopyConstructor)
+{
+    auto fd_a{FileDescriptor::make_managed(42)};
+    auto fd_b{std::move(fd_a)};
+    ASSERT_EQ(fd_a.get(), -1);
+    ASSERT_EQ(fd_b.get(), 42);
+    EXPECT_CALL(msys, close(42));
+}
+
+TEST_F(HipFileFileDescriptor, UnmanagedFileDescriptorMoveCopyConstructor)
+{
+    auto fd_a{FileDescriptor::make_unmanaged(42)};
+    auto fd_b{std::move(fd_a)};
+    ASSERT_EQ(fd_a.get(), -1);
+    ASSERT_EQ(fd_b.get(), 42);
+}
+
+TEST_F(HipFileFileDescriptor, ManagedFileDescriptorToManagedFileDescriptorMoveAssignment)
+{
+    auto fd_a{FileDescriptor::make_managed(42)};
+    auto fd_b{FileDescriptor::make_managed(12)};
+    EXPECT_CALL(msys, close(12));
+    fd_b = std::move(fd_a);
+    ASSERT_EQ(fd_a.get(), -1);
+    ASSERT_EQ(fd_b.get(), 42);
+    EXPECT_CALL(msys, close(42));
+}
+
+TEST_F(HipFileFileDescriptor, ManagedFileDescriptorToUnmanagedFileDescriptorMoveAssignment)
+{
+    auto fd_a{FileDescriptor::make_managed(42)};
+    auto fd_b{FileDescriptor::make_unmanaged(12)};
+    fd_b = std::move(fd_a);
+    ASSERT_EQ(fd_a.get(), -1);
+    ASSERT_EQ(fd_b.get(), 42);
+    EXPECT_CALL(msys, close(42));
+}
+
+TEST_F(HipFileFileDescriptor, UnmanagedFileDescriptorToManagedFileDescriptorMoveAssignment)
+{
+    auto fd_a{FileDescriptor::make_unmanaged(42)};
+    auto fd_b{FileDescriptor::make_managed(12)};
+    EXPECT_CALL(msys, close(12));
+    fd_b = std::move(fd_a);
+    ASSERT_EQ(fd_a.get(), -1);
+    ASSERT_EQ(fd_b.get(), 42);
+}
+
+TEST_F(HipFileFileDescriptor, UnmanagedFileDescriptorToUnmanagedFileDescriptorMoveAssignment)
+{
+    auto fd_a{FileDescriptor::make_unmanaged(42)};
+    auto fd_b{FileDescriptor::make_unmanaged(12)};
+    fd_b = std::move(fd_a);
+    ASSERT_EQ(fd_a.get(), -1);
+    ASSERT_EQ(fd_b.get(), 42);
+}
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -405,7 +405,7 @@ TEST_F(HipFileHandle, UnregisteredFileOpensUnbufferedIfClientFdIsBuffered)
     EXPECT_CALL(msys, close(open_fd));
 }
 
-TEST_F(HipFileHandle, UnregistgeredFileClosesOpenedFileWhenDestroyed)
+TEST_F(HipFileHandle, UnregisteredFileClosesOpenedFileWhenDestroyed)
 {
     int open_fd{888888};
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).open_fd(open_fd).build();

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -107,8 +107,6 @@ struct ExpectUnregisteredFile {
             EXPECT_CALL(builder.m_mlibmounthelper, getMountInfo);
         }
 
-        EXPECT_CALL(builder.m_msys, readlink);
-
         if (builder.m_open_flags) {
             EXPECT_CALL(builder.m_msys, open(_, builder.m_open_flags.value()))
                 .WillOnce(Return(builder.m_open_fd ? builder.m_open_fd.value() : -1));

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -139,7 +139,7 @@ TEST_F(HipFileHandle, file_initialization)
     auto file{Context<DriverState>::get()->getFile(fh)};
 
     EXPECT_EQ(fh, file->getHandle());
-    EXPECT_EQ(fd, file->getFd());
+    EXPECT_EQ(fd, file->getClientFd());
     auto file_stx{file->getStatx()};
     EXPECT_EQ(0, memcmp(&file_stx, &stxbuf, sizeof(stxbuf)));
     EXPECT_EQ(fd_flags, file->getStatusFlags());

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -41,8 +41,8 @@ struct ExpectUnregisteredFileBuilder {
     optional<struct statx> m_statx;
     optional<int>          m_fd_flags;
     optional<MountInfo>    m_mountinfo;
-    optional<int>          m_fd_dup;
-    optional<int>          m_fd_dup_flags;
+    optional<int>          m_open_fd;
+    optional<int>          m_open_flags;
 
     ExpectUnregisteredFileBuilder(MSys &msys, MLibMountHelper &mlibmounthelper)
         : m_msys(msys), m_mlibmounthelper(mlibmounthelper)
@@ -67,15 +67,15 @@ struct ExpectUnregisteredFileBuilder {
         return *this;
     }
 
-    ExpectUnregisteredFileBuilder &fd_dup(int fd_dup)
+    ExpectUnregisteredFileBuilder &open_fd(int fd)
     {
-        m_fd_dup = fd_dup;
+        m_open_fd = fd;
         return *this;
     }
 
-    ExpectUnregisteredFileBuilder &expect_fd_dup_flags(int flags)
+    ExpectUnregisteredFileBuilder &open_flags(int flags)
     {
-        m_fd_dup_flags = flags;
+        m_open_flags = flags;
         return *this;
     }
 
@@ -107,22 +107,15 @@ struct ExpectUnregisteredFile {
             EXPECT_CALL(builder.m_mlibmounthelper, getMountInfo);
         }
 
-        if (builder.m_fd_dup) {
-            EXPECT_CALL(builder.m_msys, fcntl(_, F_DUPFD_CLOEXEC, _))
-                .WillOnce(Return(builder.m_fd_dup.value()));
-        }
-        else {
-            EXPECT_CALL(builder.m_msys, fcntl(_, F_DUPFD_CLOEXEC, _)).WillOnce(Return(-1));
-        }
+        EXPECT_CALL(builder.m_msys, readlink);
 
-        if (builder.m_fd_dup_flags) {
-            EXPECT_CALL(builder.m_msys, fcntl(builder.m_fd_dup ? builder.m_fd_dup.value() : -1, F_SETFL,
-                                              static_cast<unsigned long>(builder.m_fd_dup_flags.value())))
-                .Times(1);
+        if (builder.m_open_flags) {
+            EXPECT_CALL(builder.m_msys, open(_, builder.m_open_flags.value()))
+                .WillOnce(Return(builder.m_open_fd ? builder.m_open_fd.value() : -1));
         }
         else {
-            EXPECT_CALL(builder.m_msys, fcntl(builder.m_fd_dup ? builder.m_fd_dup.value() : -1, F_SETFL, _))
-                .Times(1);
+            EXPECT_CALL(builder.m_msys, open(_, _))
+                .WillOnce(Return(builder.m_open_fd ? builder.m_open_fd.value() : -1));
         }
     }
 };
@@ -162,8 +155,8 @@ TEST_F(HipFileHandle, file_initialization)
     // In this test, the registered file is destroyed _after_ the mocks are
     // destroyed. Use an eventfd so that when FileDescriptor calls close, it
     // has a valid file descriptor to close.
-    int fd_dup{eventfd(0, 0)};
-    ASSERT_NE(fd_dup, -1);
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
 
     MountInfo mountinfo;
     mountinfo.type                         = FilesystemType::ext4;
@@ -173,7 +166,7 @@ TEST_F(HipFileHandle, file_initialization)
         .statx(stxbuf)
         .fd_flags(fd_flags)
         .mountinfo(mountinfo)
-        .fd_dup(fd_dup)
+        .open_fd(open_fd)
         .build();
     auto fh{Context<DriverState>::get()->registerFile(fd)};
     auto file{Context<DriverState>::get()->getFile(fh)};
@@ -181,7 +174,7 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_EQ(fh, file->getHandle());
     EXPECT_EQ(fd, file->getClientFd());
     EXPECT_EQ(fd, file->getBufferedFd());
-    EXPECT_EQ(fd_dup, file->getUnbufferedFd());
+    EXPECT_EQ(open_fd, file->getUnbufferedFd());
     auto file_stx{file->getStatx()};
     EXPECT_EQ(0, memcmp(&file_stx, &stxbuf, sizeof(stxbuf)));
     EXPECT_EQ(fd_flags, file->getStatusFlags());
@@ -352,42 +345,72 @@ TEST_F(HipFileHandle, deregister_handle_fails_when_operations_are_oustanding)
     hipFileHandleDeregister(fh);
 }
 
-TEST_F(HipFileHandle, UnregisteredFileUnsetsODirectOnFdDupWhenInstantiatedWithUnbufferedFile)
+TEST_F(HipFileHandle, UnregisteredFileCreatesOpensBufferedIfClientFdIsUnbuffered)
 {
-    int fd_dup{888888};
+    int open_fd{888888};
 
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
         .fd_flags(~0) // All flags, including O_DIRECT, set
-        .fd_dup(fd_dup)
-        .expect_fd_dup_flags(~O_DIRECT) // All flags, excluding O_DIRECT, set
+        .open_fd(open_fd)
+        .open_flags(~O_DIRECT) // All flags, excluding O_DIRECT, set
         .build();
 
     UnregisteredFile uf{777777};
 
-    EXPECT_CALL(msys, close(fd_dup));
+    EXPECT_CALL(msys, close(open_fd));
 }
 
-TEST_F(HipFileHandle, UnregisteredFileSetsODirectOnFdDupWhenInstantiatedWithBufferedFile)
+TEST_F(HipFileHandle, UnregisteredFileSetsCloseOnExecOnOpenedFile)
 {
-    int fd_dup{888888};
+    int open_fd{888888};
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(0)
+        .open_fd(open_fd)
+        .open_flags(O_DIRECT | O_CLOEXEC)
+        .build();
+
+    UnregisteredFile uf{777777};
+
+    EXPECT_CALL(msys, close(open_fd));
+}
+
+TEST_F(HipFileHandle, UnregisteredFileMaintainsCloseOnExecOnOpenedFile)
+{
+    int open_fd{888888};
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT | O_CLOEXEC)
+        .open_fd(open_fd)
+        .open_flags(O_CLOEXEC)
+        .build();
+
+    UnregisteredFile uf{777777};
+
+    EXPECT_CALL(msys, close(open_fd));
+}
+
+TEST_F(HipFileHandle, UnregisteredFileOpensUnbufferedIfClientFdIsBuffered)
+{
+    int open_fd{888888};
 
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
         .fd_flags(~O_DIRECT) // All flags, excluding O_DIRECT, set
-        .fd_dup(fd_dup)
-        .expect_fd_dup_flags(~0) // All flags, including O_DIRECT, set
+        .open_fd(open_fd)
+        .open_flags(~0) // All flags, including O_DIRECT, set
         .build();
 
     UnregisteredFile uf{777777};
 
-    EXPECT_CALL(msys, close(fd_dup));
+    EXPECT_CALL(msys, close(open_fd));
 }
 
-TEST_F(HipFileHandle, UnregistgeredFileClosesDupedFileDescriptorWhenDestroyed)
+TEST_F(HipFileHandle, UnregistgeredFileClosesOpenedFileWhenDestroyed)
 {
-    int fd_dup{888888};
-    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).fd_dup(fd_dup).build();
+    int open_fd{888888};
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).open_fd(open_fd).build();
     UnregisteredFile uf{777777};
-    EXPECT_CALL(msys, close(fd_dup));
+    EXPECT_CALL(msys, close(open_fd));
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -26,26 +26,84 @@
 
 using namespace hipFile;
 using namespace testing;
+using namespace std;
 
 // Put tests inside the macros to suppress the global constructor
 // warnings
 HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
 
-void
-expect_file_registration(MSys &msys, MLibMountHelper &mlibmounthelper)
+struct ExpectUnregisteredFile;
+
+struct ExpectUnregisteredFileBuilder {
+    MSys                  &m_msys;
+    MLibMountHelper       &m_mlibmounthelper;
+    optional<struct statx> m_statx;
+    optional<int>          m_fd_flags;
+    optional<MountInfo>    m_mountinfo;
+
+    ExpectUnregisteredFileBuilder(MSys &msys, MLibMountHelper &mlibmounthelper)
+        : m_msys(msys), m_mlibmounthelper(mlibmounthelper)
+    {
+    }
+
+    ExpectUnregisteredFileBuilder &statx(const struct statx &statxbuf)
+    {
+        m_statx = statxbuf;
+        return *this;
+    }
+
+    ExpectUnregisteredFileBuilder &fd_flags(int flags)
+    {
+        m_fd_flags = flags;
+        return *this;
+    }
+
+    ExpectUnregisteredFileBuilder &mountinfo(const MountInfo &mountinfo)
+    {
+        m_mountinfo = mountinfo;
+        return *this;
+    }
+
+    ExpectUnregisteredFile build();
+};
+
+struct ExpectUnregisteredFile {
+    ExpectUnregisteredFile(const ExpectUnregisteredFileBuilder &builder)
+    {
+        if (builder.m_statx) {
+            EXPECT_CALL(builder.m_msys, statx).WillOnce(Return(builder.m_statx.value()));
+        }
+        else {
+            EXPECT_CALL(builder.m_msys, statx);
+        }
+
+        if (builder.m_fd_flags) {
+            EXPECT_CALL(builder.m_msys, fcntl(_, F_GETFL, 0)).WillOnce(Return(builder.m_fd_flags.value()));
+        }
+        else {
+            EXPECT_CALL(builder.m_msys, fcntl(_, F_GETFL, 0));
+        }
+
+        if (builder.m_mountinfo) {
+            EXPECT_CALL(builder.m_mlibmounthelper, getMountInfo)
+                .WillOnce(Return(builder.m_mountinfo.value()));
+        }
+        else {
+            EXPECT_CALL(builder.m_mlibmounthelper, getMountInfo);
+        }
+    }
+};
+
+ExpectUnregisteredFile
+ExpectUnregisteredFileBuilder::build()
 {
-    EXPECT_CALL(msys, statx);
-    EXPECT_CALL(msys, fcntl(_, F_GETFL, 0));
-    EXPECT_CALL(mlibmounthelper, getMountInfo);
+    return ExpectUnregisteredFile(*this);
 }
 
 void
-expect_file_registration(MSys &msys, MLibMountHelper &mlibmounthelper, struct statx stxbuf, int fcntl_flags,
-                         MountInfo mountinfo)
+expect_file_registration(MSys &msys, MLibMountHelper &mlibmounthelper)
 {
-    EXPECT_CALL(msys, statx).WillOnce(Return(stxbuf));
-    EXPECT_CALL(msys, fcntl(_, F_GETFL, 0)).WillOnce(Return(fcntl_flags));
-    EXPECT_CALL(mlibmounthelper, getMountInfo).WillOnce(Return(mountinfo));
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
 }
 
 struct HipFileHandle : public HipFileOpened {
@@ -57,14 +115,14 @@ TEST_F(HipFileHandle, register_handle_internal_linux_fd)
 {
     int fd{0xBADF00D};
 
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_NE(Context<DriverState>::get()->registerFile(fd), nullptr);
 }
 
 TEST_F(HipFileHandle, file_initialization)
 {
     int          fd{0x12345678};
-    int          status_flags{0x789ABCDE};
+    int          fd_flags{0x789ABCDE};
     struct statx stxbuf;
     memset(&stxbuf, 0xA5, sizeof(stxbuf));
 
@@ -72,7 +130,11 @@ TEST_F(HipFileHandle, file_initialization)
     mountinfo.type                         = FilesystemType::ext4;
     mountinfo.options.ext4.journaling_mode = ExtJournalingMode::ordered;
 
-    expect_file_registration(msys, mlibmounthelper, stxbuf, status_flags, mountinfo);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .statx(stxbuf)
+        .fd_flags(fd_flags)
+        .mountinfo(mountinfo)
+        .build();
     auto fh{Context<DriverState>::get()->registerFile(fd)};
     auto file{Context<DriverState>::get()->getFile(fh)};
 
@@ -80,7 +142,7 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_EQ(fd, file->getFd());
     auto file_stx{file->getStatx()};
     EXPECT_EQ(0, memcmp(&file_stx, &stxbuf, sizeof(stxbuf)));
-    EXPECT_EQ(status_flags, file->getStatusFlags());
+    EXPECT_EQ(fd_flags, file->getStatusFlags());
     EXPECT_EQ(mountinfo.type, file->getMountInfo().value().type);
     EXPECT_EQ(mountinfo.options.ext4.journaling_mode,
               file->getMountInfo().value().options.ext4.journaling_mode);
@@ -89,9 +151,9 @@ TEST_F(HipFileHandle, file_initialization)
 TEST_F(HipFileHandle, register_handle_internal_linux_fd_already_registered)
 {
     int fd{0xBADF00D};
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_NE(Context<DriverState>::get()->registerFile(fd), nullptr);
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_THROW(Context<DriverState>::get()->registerFile(fd), FileAlreadyRegistered);
 }
 
@@ -103,7 +165,7 @@ TEST_F(HipFileHandle, register_handle_linux_fd)
     rfd.type      = hipFileHandleTypeOpaqueFD;
     rfd.handle.fd = 0xBADF00D;
 
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HIPFILE_SUCCESS);
     ASSERT_NE(fh, nullptr);
 }
@@ -158,10 +220,10 @@ TEST_F(HipFileHandle, register_handle_linux_fd_already_registered)
     rfd.type      = hipFileHandleTypeOpaqueFD;
     rfd.handle.fd = 0xBADF00D;
 
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HIPFILE_SUCCESS);
     ASSERT_NE(fh, nullptr);
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HipFileOpError(hipFileHandleAlreadyRegistered));
 }
 
@@ -200,7 +262,7 @@ TEST_F(HipFileHandle, deregister_handle_doesnt_throw_if_not_registered)
 
 TEST_F(HipFileHandle, deregister_handle_internal)
 {
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     auto fh = Context<DriverState>::get()->registerFile(0xBADF00D);
     Context<DriverState>::get()->deregisterFile(fh);
     ASSERT_THROW(Context<DriverState>::get()->deregisterFile(fh), FileNotRegistered);
@@ -214,7 +276,7 @@ TEST_F(HipFileHandle, deregister_handle)
     rfd.type      = hipFileHandleTypeOpaqueFD;
     rfd.handle.fd = 0xBADF00D;
 
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HIPFILE_SUCCESS);
     hipFileHandleDeregister(fh);
     hipFileHandleDeregister(fh);
@@ -222,7 +284,7 @@ TEST_F(HipFileHandle, deregister_handle)
 
 TEST_F(HipFileHandle, deregister_handle_internal_fails_when_operations_are_oustanding)
 {
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     auto fh = Context<DriverState>::get()->registerFile(0xBADF00D);
     {
         auto file = Context<DriverState>::get()->getFile(fh);
@@ -239,7 +301,7 @@ TEST_F(HipFileHandle, deregister_handle_fails_when_operations_are_oustanding)
     rfd.type      = hipFileHandleTypeOpaqueFD;
     rfd.handle.fd = 0xBADF00D;
 
-    expect_file_registration(msys, mlibmounthelper);
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HIPFILE_SUCCESS);
     {
         auto file = Context<DriverState>::get()->getFile(fh);

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <optional>
 #include <stdexcept>
+#include <sys/eventfd.h>
 
 using namespace hipFile;
 using namespace testing;
@@ -40,6 +41,8 @@ struct ExpectUnregisteredFileBuilder {
     optional<struct statx> m_statx;
     optional<int>          m_fd_flags;
     optional<MountInfo>    m_mountinfo;
+    optional<int>          m_fd_dup;
+    optional<int>          m_fd_dup_flags;
 
     ExpectUnregisteredFileBuilder(MSys &msys, MLibMountHelper &mlibmounthelper)
         : m_msys(msys), m_mlibmounthelper(mlibmounthelper)
@@ -61,6 +64,18 @@ struct ExpectUnregisteredFileBuilder {
     ExpectUnregisteredFileBuilder &mountinfo(const MountInfo &mountinfo)
     {
         m_mountinfo = mountinfo;
+        return *this;
+    }
+
+    ExpectUnregisteredFileBuilder &fd_dup(int fd_dup)
+    {
+        m_fd_dup = fd_dup;
+        return *this;
+    }
+
+    ExpectUnregisteredFileBuilder &expect_fd_dup_flags(int flags)
+    {
+        m_fd_dup_flags = flags;
         return *this;
     }
 
@@ -90,6 +105,24 @@ struct ExpectUnregisteredFile {
         }
         else {
             EXPECT_CALL(builder.m_mlibmounthelper, getMountInfo);
+        }
+
+        if (builder.m_fd_dup) {
+            EXPECT_CALL(builder.m_msys, fcntl(_, F_DUPFD_CLOEXEC, _))
+                .WillOnce(Return(builder.m_fd_dup.value()));
+        }
+        else {
+            EXPECT_CALL(builder.m_msys, fcntl(_, F_DUPFD_CLOEXEC, _)).WillOnce(Return(-1));
+        }
+
+        if (builder.m_fd_dup_flags) {
+            EXPECT_CALL(builder.m_msys, fcntl(builder.m_fd_dup ? builder.m_fd_dup.value() : -1, F_SETFL,
+                                              static_cast<unsigned long>(builder.m_fd_dup_flags.value())))
+                .Times(1);
+        }
+        else {
+            EXPECT_CALL(builder.m_msys, fcntl(builder.m_fd_dup ? builder.m_fd_dup.value() : -1, F_SETFL, _))
+                .Times(1);
         }
     }
 };
@@ -122,9 +155,15 @@ TEST_F(HipFileHandle, register_handle_internal_linux_fd)
 TEST_F(HipFileHandle, file_initialization)
 {
     int          fd{0x12345678};
-    int          fd_flags{0x789ABCDE};
+    int          fd_flags{~O_DIRECT}; // All flags, except O_DIRECT, set
     struct statx stxbuf;
     memset(&stxbuf, 0xA5, sizeof(stxbuf));
+
+    // In this test, the registered file is destroyed _after_ the mocks are
+    // destroyed. Use an eventfd so that when FileDescriptor calls close, it
+    // has a valid file descriptor to close.
+    int fd_dup{eventfd(0, 0)};
+    ASSERT_NE(fd_dup, -1);
 
     MountInfo mountinfo;
     mountinfo.type                         = FilesystemType::ext4;
@@ -134,12 +173,15 @@ TEST_F(HipFileHandle, file_initialization)
         .statx(stxbuf)
         .fd_flags(fd_flags)
         .mountinfo(mountinfo)
+        .fd_dup(fd_dup)
         .build();
     auto fh{Context<DriverState>::get()->registerFile(fd)};
     auto file{Context<DriverState>::get()->getFile(fh)};
 
     EXPECT_EQ(fh, file->getHandle());
     EXPECT_EQ(fd, file->getClientFd());
+    EXPECT_EQ(fd, file->getBufferedFd());
+    EXPECT_EQ(fd_dup, file->getUnbufferedFd());
     auto file_stx{file->getStatx()};
     EXPECT_EQ(0, memcmp(&file_stx, &stxbuf, sizeof(stxbuf)));
     EXPECT_EQ(fd_flags, file->getStatusFlags());
@@ -308,6 +350,44 @@ TEST_F(HipFileHandle, deregister_handle_fails_when_operations_are_oustanding)
         hipFileHandleDeregister(fh);
     }
     hipFileHandleDeregister(fh);
+}
+
+TEST_F(HipFileHandle, UnregisteredFileUnsetsODirectOnFdDupWhenInstantiatedWithUnbufferedFile)
+{
+    int fd_dup{888888};
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(~0) // All flags, including O_DIRECT, set
+        .fd_dup(fd_dup)
+        .expect_fd_dup_flags(~O_DIRECT) // All flags, excluding O_DIRECT, set
+        .build();
+
+    UnregisteredFile uf{777777};
+
+    EXPECT_CALL(msys, close(fd_dup));
+}
+
+TEST_F(HipFileHandle, UnregisteredFileSetsODirectOnFdDupWhenInstantiatedWithBufferedFile)
+{
+    int fd_dup{888888};
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(~O_DIRECT) // All flags, excluding O_DIRECT, set
+        .fd_dup(fd_dup)
+        .expect_fd_dup_flags(~0) // All flags, including O_DIRECT, set
+        .build();
+
+    UnregisteredFile uf{777777};
+
+    EXPECT_CALL(msys, close(fd_dup));
+}
+
+TEST_F(HipFileHandle, UnregistgeredFileClosesDupedFileDescriptorWhenDestroyed)
+{
+    int fd_dup{888888};
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).fd_dup(fd_dup).build();
+    UnregisteredFile uf{777777};
+    EXPECT_CALL(msys, close(fd_dup));
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -20,6 +20,8 @@ class MFile : public IFile {
 public:
     MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
     MOCK_METHOD(int, getClientFd, (), (const, override));
+    MOCK_METHOD(int, getBufferedFd, (), (const, override));
+    MOCK_METHOD(int, getUnbufferedFd, (), (const, override));
     MOCK_METHOD(const struct statx &, getStatx, (), (const, noexcept, override));
     MOCK_METHOD(int, getStatusFlags, (), (const, override));
     MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -30,7 +30,7 @@ public:
     MFileMap()
     {
     }
-    MOCK_METHOD(hipFileHandle_t, registerFile, (const UnregisteredFile &uf), (override));
+    MOCK_METHOD(hipFileHandle_t, registerFile, (UnregisteredFile && uf), (override));
     MOCK_METHOD(void, deregisterFile, (hipFileHandle_t fh), (override));
     MOCK_METHOD(std::shared_ptr<IFile>, getFile, (hipFileHandle_t), (override));
     MOCK_METHOD(void, clear, (), (override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -19,7 +19,7 @@ namespace hipFile {
 class MFile : public IFile {
 public:
     MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
-    MOCK_METHOD(int, getFd, (), (const, override));
+    MOCK_METHOD(int, getClientFd, (), (const, override));
     MOCK_METHOD(const struct statx &, getStatx, (), (const, noexcept, override));
     MOCK_METHOD(int, getStatusFlags, (), (const, override));
     MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));

--- a/test/amd_detail/mstate.h
+++ b/test/amd_detail/mstate.h
@@ -34,7 +34,7 @@ public:
     MOCK_METHOD(void, deregisterBuffer, (const void *buf), (override));
     MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *buf), (override));
     MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *buf, size_t length, int flags), (override));
-    MOCK_METHOD(hipFileHandle_t, registerFile, (const UnregisteredFile &uf), (override));
+    MOCK_METHOD(hipFileHandle_t, registerFile, (UnregisteredFile && uf), (override));
     MOCK_METHOD(void, deregisterFile, (hipFileHandle_t fh), (override));
     MOCK_METHOD(std::shared_ptr<IFile>, getFile, (hipFileHandle_t fh), (override));
     MOCK_METHOD(file_buffer_pair, getFileAndBuffer,

--- a/test/amd_detail/msys.h
+++ b/test/amd_detail/msys.h
@@ -28,6 +28,8 @@ struct MSys : Sys {
     MOCK_METHOD(ssize_t, pread, (int fd, void *buf, size_t count, off_t offset), (const, override));
     MOCK_METHOD(ssize_t, pwrite, (int fd, void *buf, size_t count, off_t offset), (const, override));
 
+    MOCK_METHOD(ssize_t, readlink, (const char *, char *, size_t));
+
     MOCK_METHOD(void, syslog, (int priority, const char *msg), (const, override));
 
     MOCK_METHOD(struct stat, fstat, (int fd), (const, override));

--- a/test/amd_detail/msys.h
+++ b/test/amd_detail/msys.h
@@ -18,6 +18,8 @@ struct MSys : Sys {
     MSys() : co{this}
     {
     }
+    MOCK_METHOD(int, open, (const char *, int));
+    MOCK_METHOD(int, open, (const char *, int, mode_t));
     MOCK_METHOD(void, close, (int), (const, override));
     MOCK_METHOD(void *, mmap, (void *addr, size_t length, int prot, int flags, int fd, off_t offset),
                 (const, override));

--- a/test/amd_detail/msys.h
+++ b/test/amd_detail/msys.h
@@ -21,6 +21,7 @@ struct MSys : Sys {
     MOCK_METHOD(int, open, (const char *, int), (const, override));
     MOCK_METHOD(int, open, (const char *, int, mode_t), (const, override));
     MOCK_METHOD(void, close, (int), (const, override));
+    MOCK_METHOD(void, fdatasync, (int), (const, override));
     MOCK_METHOD(void *, mmap, (void *addr, size_t length, int prot, int flags, int fd, off_t offset),
                 (const, override));
     MOCK_METHOD(void, munmap, (void *addr, size_t length), (const, override));

--- a/test/amd_detail/msys.h
+++ b/test/amd_detail/msys.h
@@ -18,8 +18,8 @@ struct MSys : Sys {
     MSys() : co{this}
     {
     }
-    MOCK_METHOD(int, open, (const char *, int));
-    MOCK_METHOD(int, open, (const char *, int, mode_t));
+    MOCK_METHOD(int, open, (const char *, int), (const, override));
+    MOCK_METHOD(int, open, (const char *, int, mode_t), (const, override));
     MOCK_METHOD(void, close, (int), (const, override));
     MOCK_METHOD(void *, mmap, (void *addr, size_t length, int prot, int flags, int fd, off_t offset),
                 (const, override));
@@ -28,7 +28,7 @@ struct MSys : Sys {
     MOCK_METHOD(ssize_t, pread, (int fd, void *buf, size_t count, off_t offset), (const, override));
     MOCK_METHOD(ssize_t, pwrite, (int fd, void *buf, size_t count, off_t offset), (const, override));
 
-    MOCK_METHOD(ssize_t, readlink, (const char *, char *, size_t));
+    MOCK_METHOD(ssize_t, readlink, (const char *, char *, size_t), (const, override));
 
     MOCK_METHOD(void, syslog, (int priority, const char *msg), (const, override));
 

--- a/test/amd_detail/msys.h
+++ b/test/amd_detail/msys.h
@@ -18,6 +18,7 @@ struct MSys : Sys {
     MSys() : co{this}
     {
     }
+    MOCK_METHOD(void, close, (int), (const, override));
     MOCK_METHOD(void *, mmap, (void *addr, size_t length, int prot, int flags, int fd, off_t offset),
                 (const, override));
     MOCK_METHOD(void, munmap, (void *addr, size_t length), (const, override));

--- a/test/amd_detail/state_mt.cpp
+++ b/test/amd_detail/state_mt.cpp
@@ -384,11 +384,12 @@ main()
 
     // hipfile makes an additional file descriptor when a file is registered.
     // Ensure that we do not exceed the allowed number of open file descriptors
-    if (nofile.rlim_cur <= n_file_reserved + (N_THREADS * n_files_per_thread * 2)) {
+    unsigned n_fds_per_registered_file = 2;
+    if (nofile.rlim_cur <= n_file_reserved + (N_THREADS * n_files_per_thread * n_fds_per_registered_file)) {
         cerr << "RLIMIT_NOFILE (ulimit -n) is to low" << endl;
         exit(EXIT_FAILURE);
     }
-    n_free_files = (nofile.rlim_cur - n_file_reserved) / 3;
+    n_free_files = (nofile.rlim_cur - n_file_reserved) / n_fds_per_registered_file;
 
     array<thread, N_THREADS> threads;
 

--- a/test/amd_detail/state_mt.cpp
+++ b/test/amd_detail/state_mt.cpp
@@ -382,11 +382,13 @@ main()
     // Each thread should be able to create about 10 files
     const unsigned n_files_per_thread = 10;
 
-    if (nofile.rlim_cur <= n_file_reserved + (N_THREADS * n_files_per_thread)) {
+    // hipfile makes an additional file descriptor when a file is registered.
+    // Ensure that we do not exceed the allowed number of open file descriptors
+    if (nofile.rlim_cur <= n_file_reserved + (N_THREADS * n_files_per_thread * 2)) {
         cerr << "RLIMIT_NOFILE (ulimit -n) is to low" << endl;
         exit(EXIT_FAILURE);
     }
-    n_free_files = nofile.rlim_cur - n_file_reserved;
+    n_free_files = (nofile.rlim_cur - n_file_reserved) / 3;
 
     array<thread, N_THREADS> threads;
 

--- a/util/fio/write-read-verify.fio
+++ b/util/fio/write-read-verify.fio
@@ -2,7 +2,6 @@
 [global]
 ioengine=libhipfile
 rocm_io=hipfile
-direct=1
 gpu_dev_ids=0
 filename=fio.dat
 size=1G


### PR DESCRIPTION
## Motivation

No longer require files to have the O_DIRECT flag set when they are registered with hipFile. This change will enable hipFile to eventually handle unaligned IO.

## Technical Details

When a file is registered with hipfile, duplicate the file descriptor and set/unset the O_DIRECT flag on the duplicate.