### PR TITLE
hipFile: IWYU cleanup

### DIFF
--- a/src/amd_detail/buffer.cpp
+++ b/src/amd_detail/buffer.cpp
@@ -9,19 +9,13 @@
 #include "passkey.h"
 #include "sys.h"
 
-#include <algorithm>
 #include <cstdint>
-#include <cstdlib>
 #include <hip/hip_runtime_api.h>
-#include <iterator>
 #include <stdexcept>
 #include <syslog.h>
 #include <utility>
-#include <vector>
 
-using std::shared_ptr;
-using std::transform;
-using std::vector;
+using namespace std;
 
 namespace hipFile {
 

--- a/src/amd_detail/buffer.h
+++ b/src/amd_detail/buffer.h
@@ -5,13 +5,13 @@
 
 #pragma once
 
-#include "passkey.h"
-
 #include <cstddef>
 #include <hip/hip_runtime_api.h>
 #include <memory>
 #include <stdexcept>
 #include <unordered_map>
+
+template <typename T> class PassKey;
 
 namespace hipFile {
 

--- a/src/amd_detail/configuration.cpp
+++ b/src/amd_detail/configuration.cpp
@@ -7,6 +7,8 @@
 #include "environment.h"
 #include "hip.h"
 
+#include <optional>
+
 using namespace hipFile;
 
 Configuration::Configuration() : m_fastpath(true), m_fallback(true)

--- a/src/amd_detail/environment.cpp
+++ b/src/amd_detail/environment.cpp
@@ -2,7 +2,12 @@
  *
  * SPDX-License-Identifier: MIT
  */
+
+#include "context.h"
 #include "environment.h"
+#include "sys.h"
+
+#include <strings.h>
 
 using namespace hipFile;
 using namespace std;

--- a/src/amd_detail/environment.h
+++ b/src/amd_detail/environment.h
@@ -5,10 +5,6 @@
 
 #pragma once
 
-#include "context.h"
-#include "sys.h"
-
-#include <cstring>
 #include <optional>
 
 namespace hipFile {

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -10,20 +10,13 @@
 #include "passkey.h"
 #include "sys.h"
 
-#include <algorithm>
-#include <climits>
-#include <cstdlib>
 #include <fcntl.h>
-#include <iterator>
 #include <utility>
+#include <string>
 #include <sys/sysmacros.h>
 #include <syslog.h>
-#include <vector>
 
-using std::optional;
-using std::shared_ptr;
-using std::transform;
-using std::vector;
+using namespace std;
 
 namespace hipFile {
 

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -8,13 +8,14 @@
 #include "file-descriptor.h"
 #include "hipfile.h"
 #include "mountinfo.h"
-#include "passkey.h"
 
 #include <linux/stat.h>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <unordered_map>
+
+template <typename T> class PassKey;
 
 namespace hipFile {
 

--- a/src/amd_detail/hipfile.cpp
+++ b/src/amd_detail/hipfile.cpp
@@ -21,6 +21,7 @@
 #include <hip/hip_runtime_api.h>
 #include <memory>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 #include <sys/types.h>
 #include <system_error>

--- a/src/amd_detail/state.cpp
+++ b/src/amd_detail/state.cpp
@@ -17,11 +17,9 @@
 #include <mutex>
 #include <shared_mutex>
 #include <stdexcept>
+#include <utility>
 
-using std::shared_lock;
-using std::shared_mutex;
-using std::shared_ptr;
-using std::unique_lock;
+using namespace std;
 
 namespace hipFile {
 struct Backend;

--- a/src/amd_detail/stream.h
+++ b/src/amd_detail/stream.h
@@ -4,12 +4,12 @@
  */
 #pragma once
 
-#include "passkey.h"
-
 #include <cstdint>
 #include <hip/hip_runtime_api.h>
 #include <memory>
 #include <unordered_map>
+
+template <typename T> class PassKey;
 
 namespace hipFile {
 

--- a/src/amd_detail/sys.cpp
+++ b/src/amd_detail/sys.cpp
@@ -5,9 +5,10 @@
 
 #include "sys.h"
 
-#include <bits/statx-generic.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/mman.h>
+#include <sys/stat.h> // IWYU pragma: keep
 #include <syslog.h>
 #include <unistd.h>
 

--- a/src/amd_detail/sys.h
+++ b/src/amd_detail/sys.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <cerrno>
-#include <cstddef>
 #include <cstdint>
 #include <linux/stat.h>
 #include <stdexcept>

--- a/test/amd_detail/configuration.cpp
+++ b/test/amd_detail/configuration.cpp
@@ -9,7 +9,10 @@
 #include "mhip.h"
 #include "msys.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <optional>
+#include <string>
 
 using namespace hipFile;
 using namespace testing;

--- a/test/amd_detail/environment.cpp
+++ b/test/amd_detail/environment.cpp
@@ -4,9 +4,12 @@
  */
 
 #include "environment.h"
+#include "hipfile-warnings.h"
 #include "msys.h"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <memory>
 
 using namespace hipFile;
 using namespace testing;

--- a/test/amd_detail/fallback.cpp
+++ b/test/amd_detail/fallback.cpp
@@ -7,6 +7,7 @@
 #include "backend/fallback.h"
 #include "buffer.h"
 #include "context.h"
+#include "file.h"
 #include "hip.h"
 #include "hipfile.h"
 #include "hipfile-test.h"
@@ -40,14 +41,7 @@
 
 using namespace hipFile;
 using namespace testing;
-
-using std::shared_ptr;
-using ::testing::Return;
-using ::testing::StrictMock;
-
-namespace hipFile {
-class IFile;
-}
+using namespace std;
 
 // Put tests inside the macros to suppress the global constructor
 // warnings

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -5,6 +5,7 @@
 
 #include "backend/fastpath.h"
 #include "hip.h"
+#include "hipfile.h"
 #include "hipfile-test.h"
 #include "hipfile-warnings.h"
 #include "io.h"

--- a/test/amd_detail/file-descriptor.cpp
+++ b/test/amd_detail/file-descriptor.cpp
@@ -4,9 +4,13 @@
  */
 
 #include "file-descriptor.h"
+#include "hipfile-warnings.h"
 #include "msys.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <memory>
+#include <utility>
 
 using namespace hipFile;
 using namespace testing;

--- a/test/amd_detail/hipfile-api.cpp
+++ b/test/amd_detail/hipfile-api.cpp
@@ -13,6 +13,7 @@
 
 #include "batch/batch.h"
 #include "context.h"
+#include "file.h"
 #include "hip.h"
 #include "hipfile.h"
 #include "hipfile-private.h"

--- a/test/amd_detail/main.cpp
+++ b/test/amd_detail/main.cpp
@@ -6,7 +6,8 @@
 #include "hipfile-warnings.h"
 #include "test-options.h"
 
-#include <chrono>
+#include <chrono> // IWYU pragma: keep
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <thread>
 

--- a/test/amd_detail/state_mt.cpp
+++ b/test/amd_detail/state_mt.cpp
@@ -8,6 +8,7 @@
 // Just run the program. It takes no special arguments.
 
 #include "context.h"
+#include "file.h"
 #include "hipfile.h"
 #include "state.h"
 

--- a/test/amd_detail/stream.cpp
+++ b/test/amd_detail/stream.cpp
@@ -10,8 +10,8 @@
 #include "msys.h"
 #include "stream.h"
 
-#include <algorithm>
 #include <cstdint>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
 #include <memory>

--- a/test/system/main.cpp
+++ b/test/system/main.cpp
@@ -6,7 +6,8 @@
 #include "hipfile-warnings.h"
 #include "test-options.h"
 
-#include <chrono>
+#include <chrono> // IWYU pragma: keep
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <thread>
 


### PR DESCRIPTION
Quiet include-what-you-use output but prefer public headers instead of private.