### PR TITLE
CI: Avoid rebuilding hipFile for System Tests

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -220,6 +220,18 @@ jobs:
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
+      - name: Copy hipFile build directory out of the container
+        run: |
+          docker cp \
+            "${AIS_CONTAINER_NAME}:/ais/hipFile/build" \
+            ${GITHUB_WORKSPACE}/hipfile-build
+      - name: Upload hipFile build directory as an Artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6.0.0
+        with:
+          name: hipfile-build-${{ inputs.platform }}
+          path: ${{ github.workspace }}/hipfile-build
+          if-no-files-found: error
+          retention-days: 1
       - name: Clean CMake build directories
         run: |
           docker exec \

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -336,6 +336,11 @@ jobs:
           repository: ROCm/fio
           ref: hipFile
           path: fio
+      - name: Fetch hipFile build directory
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        with:
+          name: hipfile-build-${{ inputs.platform }}
+          path: ${{ github.workspace }}/hipfile-build
       - name: Authenticating to GitHub Container Registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
         with:
@@ -371,6 +376,11 @@ jobs:
               mkdir /ais/hipFile/build
               mkdir /ais/fio/build
             '
+      - name: Copy hipFile build directory into the container
+        run: |
+          docker cp \
+            ${GITHUB_WORKSPACE}/hipfile-build \
+            ${AIS_CONTAINER_NAME}:/ais/hipfile-build
       - name: Generate build files for hipFile targeting the AMD platform (amdclang++)
         run: |
           docker exec \

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -386,7 +386,7 @@ jobs:
         run: |
           ls -al ${GITHUB_WORKSPACE}/hipfile-build
           echo "---------------------------------------"
-          docker exec -t -w /ais/hipfile-build ${AIS_CONTAINER_NAME} /bin/bash -c 'ls -al .'
+          docker exec -t -w /ais/hipfile-build ${AIS_CONTAINER_NAME} /bin/bash -c 'ls -al .; ls -al /ais/hipfile-build/examples/aiscp'
       - name: Generate build files for hipFile targeting the AMD platform (amdclang++)
         if: false
         run: |

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -381,6 +381,11 @@ jobs:
           docker cp \
             ${GITHUB_WORKSPACE}/hipfile-build \
             ${AIS_CONTAINER_NAME}:/ais/hipfile-build
+      - name: DEBUG - Check build dir contents
+        run: |
+          ls -al ${GITHUB_WORKSPACE}/hipfile-build
+          echo "---------------------------------------"
+          docker exec -t -w /ais/hipfile-build ${AIS_CONTAINER_NAME} /bin/bash -c 'ls -al .'
       - name: Generate build files for hipFile targeting the AMD platform (amdclang++)
         run: |
           docker exec \

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -441,6 +441,23 @@ jobs:
                 /ais/hipFile/util/ci-aiscp-test.sh \
                 /ais/hipfile-build/examples/aiscp/aiscp
             '
+      - name: Install the hipFile package
+        run: |
+          docker exec \
+            -t \
+            -w /ais/hipfile-build \
+            ${AIS_CONTAINER_NAME} \
+            /bin/bash -c '
+              ${{
+                format(
+                  inputs.platform == 'ubuntu' && 'apt install -y ./{0}' ||
+                    inputs.platform == 'rocky' && 'dnf install -y ./{0}' ||
+                    inputs.platform == 'suse' && 'zypper install -y --allow-unsigned-rpm ./{0}' ||
+                    'echo "Unknown platform."; exit 1',
+                  needs.compile_on_AMD.outputs.ais_hipfile_pkg_filename
+                )
+              }}
+            '
       - name: Configure fio
         run: |
           docker exec \
@@ -449,10 +466,9 @@ jobs:
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
               ROCM=/opt/rocm \
-              HIPFILE=/ais/hipfile-build \
-              HIPFILELIB=${HIPFILE}/src/amd_detail/ \
+              HIPFILELIB=/usr/local/lib \
               HIP_PLATFORM=amd \
-              CFLAGS="-I${ROCM}/include -I${HIPFILE}/include" \
+              CFLAGS="-I${ROCM}/include" \
               LDFLAGS="-L${ROCM}/lib -L${HIPFILELIB} -Wl,-rpath,${HIPFILELIB}" \
               ../configure --enable-libhipfile
             '

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -449,8 +449,8 @@ jobs:
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
               ROCM=/opt/rocm \
-              HIPFILE=/ais/hipFile \
-              HIPFILELIB=${HIPFILE}/build/src/amd_detail/ \
+              HIPFILE=/ais/hipfile-build \
+              HIPFILELIB=${HIPFILE}/src/amd_detail/ \
               HIP_PLATFORM=amd \
               CFLAGS="-I${ROCM}/include -I${HIPFILE}/include" \
               LDFLAGS="-L${ROCM}/lib -L${HIPFILELIB} -Wl,-rpath,${HIPFILELIB}" \

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -378,6 +378,7 @@ jobs:
             '
       - name: Copy hipFile build directory into the container
         run: |
+          chmod a+x ${GITHUB_WORKSPACE}/hipfile-build/examples/aiscp/aiscp
           docker cp \
             ${GITHUB_WORKSPACE}/hipfile-build \
             ${AIS_CONTAINER_NAME}:/ais/hipfile-build
@@ -387,6 +388,7 @@ jobs:
           echo "---------------------------------------"
           docker exec -t -w /ais/hipfile-build ${AIS_CONTAINER_NAME} /bin/bash -c 'ls -al .'
       - name: Generate build files for hipFile targeting the AMD platform (amdclang++)
+        if: false
         run: |
           docker exec \
             -t \
@@ -401,6 +403,7 @@ jobs:
                 ..
             '
       - name: Build hipFile for the AMD platform (amdclang++)
+        if: false
         run: |
           docker exec \
             -t \
@@ -413,7 +416,7 @@ jobs:
         run: |
           docker exec \
             -t \
-            -w /ais/hipFile/build \
+            -w /ais/hipfile-build \
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
               ctest -V -L "system" --parallel
@@ -422,7 +425,7 @@ jobs:
         run: |
           docker exec \
             -t \
-            -w /ais/hipFile/build \
+            -w /ais/hipfile-build \
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
               ctest -V -L "stress" --parallel
@@ -436,7 +439,7 @@ jobs:
             /bin/bash -c '
               HIPFILE_FORCE_COMPAT_MODE=true
                 /ais/hipFile/util/ci-aiscp-test.sh \
-                /ais/hipFile/build/examples/aiscp/aiscp
+                /ais/hipfile-build/examples/aiscp/aiscp
             '
       - name: Configure fio
         run: |

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -458,6 +458,11 @@ jobs:
                 )
               }}
             '
+      # The hipFile packaging process has issues; notably:
+      # - Has a static lib but not shared lib.
+      # - Installs to /usr/local rather than /opt/rocm
+      # Leaving -Wl arg for now, but /usr/local is typically
+      # included by default by the compiler.
       - name: Configure fio
         run: |
           docker exec \
@@ -465,11 +470,12 @@ jobs:
             -w /ais/fio/build \
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
+              sed -i 's|-lhipfile|-lhipfile -lstdc++ -lmount|g' ../configure
               ROCM=/opt/rocm \
               HIPFILELIB=/usr/local/lib \
               HIP_PLATFORM=amd \
               CFLAGS="-I${ROCM}/include" \
-              LDFLAGS="-L${ROCM}/lib -L${HIPFILELIB} -Wl,-rpath,${HIPFILELIB}" \
+              LDFLAGS="-L${ROCM}/lib -Wl,-rpath,${HIPFILELIB}" \
               ../configure --enable-libhipfile
             '
       - name: Build fio


### PR DESCRIPTION
This PR is an attempt to remove re-building hipFile during the system test stage. ctest requires that the CMake build directory is available to run tests, so it is not enough to simply just install the hipFile package.

AIROCFILE-97