### PR TITLE
hipfile: Handle filesystems without O_DIRECT support

### DIFF
--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -131,6 +131,9 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
 
     accept_io &= buffer->getType() == hipMemoryTypeDevice;
 
+    accept_io &= 0 <= file_offset;
+    accept_io &= 0 <= buffer_offset;
+
 #if defined(STATX_DIOALIGN)
     const struct statx &stx{file->getStatx()};
     accept_io &= !!(stx.stx_mask & STATX_DIOALIGN);

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -127,7 +127,7 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
 {
     bool accept_io{true};
 
-    accept_io &= !!(file->getStatusFlags() & O_DIRECT);
+    accept_io &= file->getUnbufferedFd().has_value();
 
     accept_io &= buffer->getType() == hipMemoryTypeDevice;
 
@@ -159,7 +159,7 @@ Fastpath::io(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, si
     size_t             nbytes{};
     size_t             buflen{buffer->getLength()};
 
-    handle.fd = file->getUnbufferedFd();
+    handle.fd = file->getUnbufferedFd().value();
 
     if (file_offset < 0) {
         throw std::invalid_argument("Negative file offset");

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -47,9 +47,10 @@ UnregisteredFile::UnregisteredFile(int fd)
                 Context<Sys>::get()->open(path.c_str(), (flags | O_CLOEXEC) | O_DIRECT));
         }
         catch (const std::system_error &e) {
-            if (e.code().value() == EINVAL) {
-                unbuffered_fd = nullopt;
+            if (e.code().value() != EINVAL) {
+                throw;
             }
+            unbuffered_fd = nullopt;
         }
     }
 }

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <sys/sysmacros.h>
 #include <syslog.h>
+#include <system_error>
 
 using namespace std;
 
@@ -40,9 +41,16 @@ UnregisteredFile::UnregisteredFile(int fd)
             Context<Sys>::get()->open(path.c_str(), (flags | O_CLOEXEC) & ~O_DIRECT));
     }
     else {
-        buffered_fd   = FileDescriptor::make_unmanaged(fd);
-        unbuffered_fd = FileDescriptor::make_managed(
-            Context<Sys>::get()->open(path.c_str(), (flags | O_CLOEXEC) | O_DIRECT));
+        buffered_fd = FileDescriptor::make_unmanaged(fd);
+        try {
+            unbuffered_fd = FileDescriptor::make_managed(
+                Context<Sys>::get()->open(path.c_str(), (flags | O_CLOEXEC) | O_DIRECT));
+        }
+        catch (const std::system_error &e) {
+            if (e.code().value() == EINVAL) {
+                unbuffered_fd = nullopt;
+            }
+        }
     }
 }
 

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -70,10 +70,13 @@ File::getBufferedFd() const
     return buffered_fd.get();
 }
 
-int
+optional<int>
 File::getUnbufferedFd() const
 {
-    return unbuffered_fd.get();
+    if (unbuffered_fd) {
+        return unbuffered_fd.value().get();
+    }
+    return nullopt;
 }
 
 const struct statx &

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -57,7 +57,7 @@ public:
     FileDescriptor buffered_fd;
 
     /// @brief Unbuffered file descriptor (O_DIRECT)
-    FileDescriptor unbuffered_fd;
+    std::optional<FileDescriptor> unbuffered_fd;
 
     /// @brief Information provided by statx (2)
     struct statx stx;
@@ -79,7 +79,7 @@ public:
 
     virtual int                      getClientFd() const       = 0;
     virtual int                      getBufferedFd() const     = 0;
-    virtual int                      getUnbufferedFd() const   = 0;
+    virtual std::optional<int>       getUnbufferedFd() const   = 0;
     virtual const struct statx      &getStatx() const noexcept = 0;
     virtual int                      getStatusFlags() const    = 0;
     virtual std::optional<MountInfo> getMountInfo() const      = 0;
@@ -102,7 +102,7 @@ public:
 
     virtual int                      getClientFd() const override;
     virtual int                      getBufferedFd() const override;
-    virtual int                      getUnbufferedFd() const override;
+    virtual std::optional<int>       getUnbufferedFd() const override;
     virtual const struct statx      &getStatx() const noexcept override;
     virtual int                      getStatusFlags() const override;
     virtual std::optional<MountInfo> getMountInfo() const override;
@@ -120,7 +120,7 @@ private:
     FileDescriptor buffered_fd;
 
     /// @brief Unbuffered file descriptor (O_DIRECT)
-    FileDescriptor unbuffered_fd;
+    std::optional<FileDescriptor> unbuffered_fd;
 
     /// @brief File status information obtained from statx (2)
     struct statx stx;

--- a/src/amd_detail/sys.cpp
+++ b/src/amd_detail/sys.cpp
@@ -28,15 +28,14 @@ throwOn(const L throw_value, R value)
 }
 
 int
-Sys::open(const char *pathname, int flags) const
-{
-    return throwOn(-1, ::open(pathname, flags));
-}
-
-int
 Sys::open(const char *pathname, int flags, mode_t mode) const
 {
-    return throwOn(-1, ::open(pathname, flags, mode));
+    if (flags & O_CREAT) {
+        return throwOn(-1, ::open(pathname, flags, mode));
+    }
+    else {
+        return throwOn(-1, ::open(pathname, flags));
+    }
 }
 
 void

--- a/src/amd_detail/sys.h
+++ b/src/amd_detail/sys.h
@@ -22,8 +22,7 @@ namespace hipFile {
 struct Sys {
     virtual ~Sys() = default;
 
-    virtual int  open(const char *pathname, int flags) const;
-    virtual int  open(const char *pathname, int flags, mode_t mode) const;
+    virtual int  open(const char *pathname, int flags, mode_t mode = 0) const;
     virtual void close(int fd) const;
 
     virtual void fdatasync(int fd) const;

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -102,7 +102,7 @@ TEST_F(FastpathTest, BufferedFile)
 
 TEST_F(FastpathTest, ScoreRejectsNegativeAlignedFileOffset)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS & ~O_DIRECT));
+    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -113,7 +113,7 @@ TEST_F(FastpathTest, ScoreRejectsNegativeAlignedFileOffset)
 
 TEST_F(FastpathTest, ScoreRejectsNegativeAlignedBufferOffset)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS & ~O_DIRECT));
+    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -58,8 +58,7 @@ struct FastpathTestBase {
     const off_t         DEFAULT_BUFFER_OFFSET{512};
     const size_t        DEFAULT_BUFFER_LENGTH{DEFAULT_IO_SIZE + static_cast<size_t>(DEFAULT_BUFFER_OFFSET)};
     const hipMemoryType DEFAULT_BUFFER_TYPE{hipMemoryTypeDevice};
-    const int           DEFAULT_FILE_DESCRIPTOR{7};
-    const int           DEFAULT_FILE_FLAGS{O_DIRECT};
+    const optional<int> DEFAULT_UNBUFFERED_FD{7};
     const off_t         DEFAULT_FILE_OFFSET{8192};
     const struct statx  DEFAULT_STATX {
         []() {
@@ -80,9 +79,9 @@ struct FastpathTestBase {
 
 struct FastpathTest : public FastpathTestBase, public Test {};
 
-TEST_F(FastpathTest, DefaultExpecations)
+TEST_F(FastpathTest, UnbufferedFdAvailable)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -90,9 +89,9 @@ TEST_F(FastpathTest, DefaultExpecations)
               SCORE_ACCEPT);
 }
 
-TEST_F(FastpathTest, BufferedFile)
+TEST_F(FastpathTest, UnbufferedFdNotAvailable)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS & ~O_DIRECT));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(nullopt));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -102,7 +101,7 @@ TEST_F(FastpathTest, BufferedFile)
 
 TEST_F(FastpathTest, ScoreRejectsNegativeAlignedFileOffset)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -113,7 +112,7 @@ TEST_F(FastpathTest, ScoreRejectsNegativeAlignedFileOffset)
 
 TEST_F(FastpathTest, ScoreRejectsNegativeAlignedBufferOffset)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -126,7 +125,7 @@ struct FastpathSupportedHipMemoryParam : public FastpathTestBase, public TestWit
 
 TEST_P(FastpathSupportedHipMemoryParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(GetParam()));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -140,7 +139,7 @@ struct FastpathUnsupportedHipMemoryParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathUnsupportedHipMemoryParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(GetParam()));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -155,7 +154,7 @@ struct FastpathAlignedIoSizesParam : public FastpathTestBase, public TestWithPar
 
 TEST_P(FastpathAlignedIoSizesParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -170,7 +169,7 @@ struct FastpathUnalignedIoSizesParam : public FastpathTestBase, public TestWithP
 
 TEST_P(FastpathUnalignedIoSizesParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -185,7 +184,7 @@ struct FastpathAlignedFileOffsetsParam : public FastpathTestBase, public TestWit
 
 TEST_P(FastpathAlignedFileOffsetsParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -200,7 +199,7 @@ struct FastpathUnalignedFileOffsetsParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathUnalignedFileOffsetsParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -215,7 +214,7 @@ struct FastpathAlignedBufferOffsetsParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathAlignedBufferOffsetsParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -231,7 +230,7 @@ struct FastpathUnalignedBufferOffsetsParam : public FastpathTestBase, public Tes
 
 TEST_P(FastpathUnalignedBufferOffsetsParam, Score)
 {
-    EXPECT_CALL(*mfile, getStatusFlags).WillOnce(Return(DEFAULT_FILE_FLAGS));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 
@@ -248,10 +247,10 @@ struct FastpathIoParam : public FastpathTestBase, public TestWithParam<IoType> {
     {
         EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-        EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_FILE_DESCRIPTOR));
+        EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     }
 
-    void expect_io(int fd, void *bufptr, size_t buflen)
+    void expect_io(optional<int> fd, void *bufptr, size_t buflen)
     {
         EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(bufptr));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(buflen));
@@ -298,7 +297,7 @@ TEST_P(FastpathIoParam, IoConfiguresHandle)
     StrictMock<MHip> mhip;
 
     hipAmdFileHandle_t handle{};
-    handle.fd = DEFAULT_FILE_DESCRIPTOR;
+    handle.fd = DEFAULT_UNBUFFERED_FD.value();
 
     expect_io();
     switch (GetParam()) {
@@ -323,7 +322,7 @@ TEST_P(FastpathIoParam, IoCalculatesCorrectDevicePointer)
     void *buffer_addr{reinterpret_cast<void *>(0x20000)};
     void *expected_device_ptr{reinterpret_cast<void *>(0x21000)};
 
-    expect_io(DEFAULT_FILE_DESCRIPTOR, buffer_addr, static_cast<size_t>(buffer_offset) + DEFAULT_IO_SIZE);
+    expect_io(DEFAULT_UNBUFFERED_FD, buffer_addr, static_cast<size_t>(buffer_offset) + DEFAULT_IO_SIZE);
     switch (GetParam()) {
         case IoType::Read:
             EXPECT_CALL(mhip, hipAmdFileRead(_, expected_device_ptr, _, _));

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -43,6 +43,7 @@ struct ExpectUnregisteredFileBuilder {
     optional<MountInfo>    m_mountinfo;
     optional<int>          m_open_fd;
     optional<int>          m_open_flags;
+    optional<int>          m_open_throws;
 
     ExpectUnregisteredFileBuilder(MSys &msys, MLibMountHelper &mlibmounthelper)
         : m_msys(msys), m_mlibmounthelper(mlibmounthelper)
@@ -69,6 +70,9 @@ struct ExpectUnregisteredFileBuilder {
 
     ExpectUnregisteredFileBuilder &open_fd(int fd)
     {
+        if (m_open_throws) {
+            throw "Cannot specify both open_throws(...) and open_fd(...)";
+        }
         m_open_fd = fd;
         return *this;
     }
@@ -76,6 +80,15 @@ struct ExpectUnregisteredFileBuilder {
     ExpectUnregisteredFileBuilder &open_flags(int flags)
     {
         m_open_flags = flags;
+        return *this;
+    }
+
+    ExpectUnregisteredFileBuilder &open_throws(int errno_)
+    {
+        if (m_open_fd) {
+            throw "Cannot specify both open_throws(...) and open_fd(...)";
+        }
+        m_open_throws = errno_;
         return *this;
     }
 
@@ -107,12 +120,20 @@ struct ExpectUnregisteredFile {
             EXPECT_CALL(builder.m_mlibmounthelper, getMountInfo);
         }
 
-        if (builder.m_open_flags) {
+        if (builder.m_open_throws && builder.m_open_flags) {
+            EXPECT_CALL(builder.m_msys, open(_, builder.m_open_flags.value(), _))
+                .WillOnce(Throw(std::system_error(builder.m_open_throws.value(), std::generic_category())));
+        }
+        else if (builder.m_open_throws) {
+            EXPECT_CALL(builder.m_msys, open)
+                .WillOnce(Throw(std::system_error(builder.m_open_throws.value(), std::generic_category())));
+        }
+        else if (builder.m_open_flags) {
             EXPECT_CALL(builder.m_msys, open(_, builder.m_open_flags.value(), _))
                 .WillOnce(Return(builder.m_open_fd ? builder.m_open_fd.value() : -1));
         }
         else {
-            EXPECT_CALL(builder.m_msys, open(_, _, _))
+            EXPECT_CALL(builder.m_msys, open)
                 .WillOnce(Return(builder.m_open_fd ? builder.m_open_fd.value() : -1));
         }
     }
@@ -409,6 +430,13 @@ TEST_F(HipFileHandle, UnregisteredFileClosesOpenedFileWhenDestroyed)
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).open_fd(open_fd).build();
     UnregisteredFile uf{777777};
     EXPECT_CALL(msys, close(open_fd));
+}
+
+TEST_F(HipFileHandle, UnregisteredFilesUnbufferedFdIsNulloptIfOpenThrowsEinval)
+{
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).fd_flags(~O_DIRECT).open_throws(EINVAL).build();
+    UnregisteredFile uf{777777};
+    ASSERT_EQ(uf.unbuffered_fd, nullopt);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -439,4 +439,10 @@ TEST_F(HipFileHandle, UnregisteredFilesUnbufferedFdIsNulloptIfOpenThrowsEinval)
     ASSERT_EQ(uf.unbuffered_fd, nullopt);
 }
 
+TEST_F(HipFileHandle, UnregisteredFileConstructorThrowsOnErrOtherThanEinval)
+{
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).fd_flags(~O_DIRECT).open_throws(EPERM).build();
+    ASSERT_THROW(UnregisteredFile{777777}, std::system_error);
+}
+
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -108,11 +108,11 @@ struct ExpectUnregisteredFile {
         }
 
         if (builder.m_open_flags) {
-            EXPECT_CALL(builder.m_msys, open(_, builder.m_open_flags.value()))
+            EXPECT_CALL(builder.m_msys, open(_, builder.m_open_flags.value(), _))
                 .WillOnce(Return(builder.m_open_fd ? builder.m_open_fd.value() : -1));
         }
         else {
-            EXPECT_CALL(builder.m_msys, open(_, _))
+            EXPECT_CALL(builder.m_msys, open(_, _, _))
                 .WillOnce(Return(builder.m_open_fd ? builder.m_open_fd.value() : -1));
         }
     }

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -21,7 +21,7 @@ public:
     MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
     MOCK_METHOD(int, getClientFd, (), (const, override));
     MOCK_METHOD(int, getBufferedFd, (), (const, override));
-    MOCK_METHOD(int, getUnbufferedFd, (), (const, override));
+    MOCK_METHOD(std::optional<int>, getUnbufferedFd, (), (const, override));
     MOCK_METHOD(const struct statx &, getStatx, (), (const, noexcept, override));
     MOCK_METHOD(int, getStatusFlags, (), (const, override));
     MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));

--- a/test/amd_detail/msys.h
+++ b/test/amd_detail/msys.h
@@ -18,7 +18,6 @@ struct MSys : Sys {
     MSys() : co{this}
     {
     }
-    MOCK_METHOD(int, open, (const char *, int), (const, override));
     MOCK_METHOD(int, open, (const char *, int, mode_t), (const, override));
     MOCK_METHOD(void, close, (int), (const, override));
     MOCK_METHOD(void, fdatasync, (int), (const, override));


### PR DESCRIPTION
Allow files to be registered even if opening the file with O_DIRECT fails with EINVAL. When hipfile cannot create a unbuffered file descriptor IO to the file will use the fallback/POSIX path.
