### PR TITLE
CI: Fix CMake config to produce a "runtime" package.

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -157,17 +157,24 @@ jobs:
             -w /ais/hipFile/build \
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
-              echo "$(
-                ${{
-                  format(
-                    inputs.platform == 'ubuntu' && 'dpkg-deb -I {0}' || 'rpm -qpi --requires {0}',
-                    steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME
-                  )
-                }}
-              )"
+              echo "Runtime Package:"
+              ${{
+                format(
+                  inputs.platform == 'ubuntu' && 'dpkg-deb -I {0}' || 'rpm -qpi --requires {0}',
+                  steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME
+                )
+              }}
+              echo -e "\n\nDevelopment Package:"
+              ${{
+                format(
+                  inputs.platform == 'ubuntu' && 'dpkg-deb -I {0}' || 'rpm -qpi --requires {0}',
+                  steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME
+                )
+              }}
             '
       - name: Validate Metadata stored correctly
         run: |
+          echo "hipFile package dev filename: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME }}"
           echo "hipFile package filename: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME }}"
           echo "hipFile package version: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_VERSION }}"
           if [[ -z "${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_VERSION }}" ]]; then exit 1; fi

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   compile_on_AMD:
     outputs:
+      ais_hipfile_pkg_dev_filename: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME }}
       ais_hipfile_pkg_filename: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME }}
       ais_hipfile_pkg_version: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_VERSION }}
     runs-on: [ubuntu-24.04]
@@ -135,7 +136,10 @@ jobs:
             -w /ais/hipFile/build \
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
-              AIS_HIPFILE_PKG_FILENAME="$(echo hipfile-dev*.${{ inputs.platform == 'ubuntu' && 'deb' || 'rpm' }})"
+              shopt -s nullglob
+              AIS_HIPFILE_PKG_DEV_FILENAME="$(echo hipfile-de{v,vel}{-,_}[0-9]*.{deb,rpm})"
+              AIS_HIPFILE_PKG_FILENAME="$(echo hipfile{-,_}[0-9]*.{deb,rpm})"
+              echo "AIS_HIPFILE_PKG_DEV_FILENAME=${AIS_HIPFILE_PKG_DEV_FILENAME}" >> "${AIS_GITHUB_OUTPUT}"
               echo "AIS_HIPFILE_PKG_FILENAME=${AIS_HIPFILE_PKG_FILENAME}" >> "${AIS_GITHUB_OUTPUT}"
               echo "AIS_HIPFILE_PKG_VERSION=$(
                 ${{

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -187,20 +187,32 @@ jobs:
             /bin/bash -c '
               ${{
                 format(
-                  inputs.platform == 'ubuntu' && 'apt install -y ./{0}' ||
-                    inputs.platform == 'rocky' && 'dnf install -y ./{0}' ||
-                    inputs.platform == 'suse' && 'zypper install -y --allow-unsigned-rpm ./{0}' ||
+                  inputs.platform == 'ubuntu' && 'apt install -y ./{0} ./{1}' ||
+                    inputs.platform == 'rocky' && 'dnf install -y ./{0} ./{1}' ||
+                    inputs.platform == 'suse' && 'zypper install -y --allow-unsigned-rpm ./{0} ./{1}' ||
                     'echo "Unknown platform."; exit 1',
+                  steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME,
                   steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME
                 )
               }}
             '
-      - name: Copy hipFile package out of the container
+      - name: Copy hipFile packages out of the container
         run: |
+          docker cp \
+            "${AIS_CONTAINER_NAME}:/ais/hipFile/build/${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME }}" \
+            ${GITHUB_WORKSPACE}
           docker cp \
             "${AIS_CONTAINER_NAME}:/ais/hipFile/build/${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME }}" \
             ${GITHUB_WORKSPACE}
-      - name: Upload hipFile Package as an Artifact
+      - name: Upload development hipFile Package as an Artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6.0.0
+        with:
+          name: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME }}
+          path: ${{ format('{0}/{1}', github.workspace, steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME) }}
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+      - name: Upload runtime hipFile Package as an Artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6.0.0
         with:
           name: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,11 @@ include(AISAddLibraries)
 # Options
 #-----------------------------------------------------------------------------
 
+# rocm_create_package makes decisions on what type of package to produce
+# based on BUILD_SHARED_LIBS. If we don't set this here we will only get
+# a dev package.
+set(BUILD_SHARED_LIBS ON)
+
 #-----------------------------------------------------------------------------
 # Code coverage (via llvm-cov)
 #

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -68,6 +68,10 @@ set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.md")
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 
 # Create the package
+# rocm_create_package makes decisions on what type of package to produce
+# based on BUILD_SHARED_LIBS. If we don't set this here we will only get
+# a dev package.
+set(BUILD_SHARED_LIBS ON)
 rocm_create_package(
     NAME "hipFile"
     DESCRIPTION "The hipFile library"

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -68,10 +68,6 @@ set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.md")
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 
 # Create the package
-# rocm_create_package makes decisions on what type of package to produce
-# based on BUILD_SHARED_LIBS. If we don't set this here we will only get
-# a dev package.
-set(BUILD_SHARED_LIBS ON)
 rocm_create_package(
     NAME "hipFile"
     DESCRIPTION "The hipFile library"


### PR DESCRIPTION
`rocm_create_package` will not produce a runtime package unless the `BUILD_SHARED_LIBS` option is enabled.

This PR fixes that, and then uploads the runtime package as a build artifact as well.

AIROCFILE-97