### PR TITLE
CMake: Only build static OR shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ project("hipfile"
     LANGUAGES C CXX HIP
 )
 
+# Switch between building static and shared libraries
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
 # Use position-independent code everywhere
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -122,11 +125,6 @@ include(AISAddLibraries)
 #-----------------------------------------------------------------------------
 # Options
 #-----------------------------------------------------------------------------
-
-# rocm_create_package makes decisions on what type of package to produce
-# based on BUILD_SHARED_LIBS. If we don't set this here we will only get
-# a dev package.
-set(BUILD_SHARED_LIBS ON)
 
 #-----------------------------------------------------------------------------
 # Code coverage (via llvm-cov)

--- a/cmake/AISAddLibraries.cmake
+++ b/cmake/AISAddLibraries.cmake
@@ -5,7 +5,9 @@
 include(AISCompilerOptions)
 include(CheckLinkerFlag)
 
-# Add static and shared libraries using AIS build conventions
+# Add a library using AIS build conventions. Shared vs. static
+# is decided by the BUILD_SHARED_LIBS option and only one can
+# be built at a time (like the rest of ROCm).
 #
 # Parameters:
 #   NAME     <name>                             The name of the libraries to create
@@ -22,23 +24,14 @@ function(ais_add_libraries)
     set(multiValueArgs SRCS SYSINCLS LIBS)
     cmake_parse_arguments(arg "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    # Convenience names
-    set(object_name "${arg_NAME}_object")
-    set(static_name "${arg_NAME}_static")
-    set(shared_name "${arg_NAME}_shared")
-
-    # Add the object, shared, and static library targets
-    #
-    # The static and shared libraries are both built from the
-    # same compiled objects (with -fPIC, etc.)
-    add_library(${object_name} OBJECT ${arg_SRCS})
-    add_library(${static_name} STATIC $<TARGET_OBJECTS:${object_name}>)
-    add_library(${shared_name} SHARED $<TARGET_OBJECTS:${object_name}>)
+    # Add the library target
+    add_library(${arg_NAME} ${arg_SRCS})
 
     # Add version numbers
-    set_target_properties(${static_name} PROPERTIES VERSION ${AIS_LIBRARY_VERSION})
-    set_target_properties(${shared_name} PROPERTIES VERSION ${AIS_LIBRARY_VERSION})
-    set_target_properties(${shared_name} PROPERTIES SOVERSION ${AIS_LIBRARY_SOVERSION})
+    set_target_properties(${arg_NAME} PROPERTIES VERSION ${AIS_LIBRARY_VERSION})
+    if(BUILD_SHARED_LIBS)
+        set_target_properties(${arg_NAME} PROPERTIES SOVERSION ${AIS_LIBRARY_SOVERSION})
+    endif()
 
     # Add dependencies on external libraries
     foreach(lib IN LISTS arg_LIBS)
@@ -46,59 +39,55 @@ function(ais_add_libraries)
         if(NOT LIBRARY_PATH)
             message(FATAL_ERROR "lib${lib} not found")
         endif()
-        target_link_libraries(${static_name} PRIVATE ${LIBRARY_PATH})
-        target_link_libraries(${shared_name} PRIVATE ${LIBRARY_PATH})
+        target_link_libraries(${arg_NAME} PRIVATE ${LIBRARY_PATH})
     endforeach()
 
-    foreach(target "${object_name}" "${static_name}" "${shared_name}")
+    if(BUILD_TESTING)
+        target_compile_definitions(${arg_NAME} PRIVATE AIS_TESTING)
+    endif()
 
-        if(BUILD_TESTING)
-            target_compile_definitions(${target} PRIVATE AIS_TESTING)
-        endif()
+    if(arg_DETAIL STREQUAL "nvidia")
+        target_compile_definitions(${arg_NAME} PRIVATE __HIP_PLATFORM_NVIDIA__)
+    else()
+        target_compile_definitions(${arg_NAME} PRIVATE __HIP_PLATFORM_AMD__)
+    endif()
 
-        if(arg_DETAIL STREQUAL "nvidia")
-            target_compile_definitions(${target} PRIVATE __HIP_PLATFORM_NVIDIA__)
-        else()
-            target_compile_definitions(${target} PRIVATE __HIP_PLATFORM_AMD__)
-        endif()
+    # Set the library name, minus the .a, .so, or whatever
+    set_target_properties(${arg_NAME} PROPERTIES OUTPUT_NAME ${arg_NAME})
 
-        # Set the library name, minus the .a, .so, or whatever
-        set_target_properties(${target} PROPERTIES OUTPUT_NAME ${arg_NAME})
+    # Set the public include paths (these are installed libraries)
+    target_include_directories(${arg_NAME}
+        PUBLIC
+        $<BUILD_INTERFACE:${arg_LIBINCL}>
+        $<INSTALL_INTERFACE:include>
+    )
 
-        # Set the public include paths (these are installed libraries)
-        target_include_directories(${target}
-            PUBLIC
-            $<BUILD_INTERFACE:${arg_LIBINCL}>
-            $<INSTALL_INTERFACE:include>
+    # Add other include paths
+    foreach(incl IN LISTS arg_SYSINCLS)
+        target_include_directories(${arg_NAME} SYSTEM PRIVATE ${incl})
+    endforeach()
+
+    # Add libraries and headers for NVIDIA targets
+    if(arg_DETAIL STREQUAL "nvidia")
+        target_include_directories(${arg_NAME}
+            SYSTEM
+            PRIVATE
+            ${HIP_INCLUDE_DIRS}
+            ${CUDAToolkit_INCLUDE_DIRS}
         )
+        target_link_libraries(${arg_NAME} PRIVATE ${CUFILE_LIBRARY})
+    endif()
+    target_link_libraries(${arg_NAME} PRIVATE hip::host)
 
-        # Add other include paths
-        foreach(incl IN LISTS arg_SYSINCLS)
-            target_include_directories(${target} SYSTEM PRIVATE ${incl})
-        endforeach()
+    # Add link options (mainly for hardening)
+    check_linker_flag(CXX "-Wl,-z,noexecstack" LINKER_SUPPORTS_NOEXECSTACK)
+    if(LINKER_SUPPORTS_NOEXECSTACK)
+        target_link_options(${arg_NAME} PRIVATE "-Wl,-z,noexecstack")
+    endif()
 
-        # Add libraries and headers for NVIDIA targets
-        if(arg_DETAIL STREQUAL "nvidia")
-            target_include_directories(${target}
-                SYSTEM
-                PRIVATE
-                ${HIP_INCLUDE_DIRS}
-                ${CUDAToolkit_INCLUDE_DIRS}
-            )
-            target_link_libraries(${target} PRIVATE ${CUFILE_LIBRARY})
-        endif()
-        target_link_libraries(${target} PRIVATE hip::host)
+    # Add the common include path
+    target_include_directories(${arg_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/shared")
 
-        # Add link options (mainly for hardening)
-        check_linker_flag(CXX "-Wl,-z,noexecstack" LINKER_SUPPORTS_NOEXECSTACK)
-        if(LINKER_SUPPORTS_NOEXECSTACK)
-            target_link_options(${target} PRIVATE "-Wl,-z,noexecstack")
-        endif()
-
-        # Add the common include path
-        target_include_directories(${target} PRIVATE "${CMAKE_SOURCE_DIR}/shared")
-
-        # Set compiler flags
-        ais_set_compiler_flags(${target})
-    endforeach()
+    # Set compiler flags
+    ais_set_compiler_flags(${arg_NAME})
 endfunction()

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -9,8 +9,7 @@ include(ROCMInstallTargets)
 include(ROCMCreatePackage)
 
 # Install the package
-rocm_install(TARGETS hipfile_static)
-rocm_install(TARGETS hipfile_shared)
+rocm_install(TARGETS hipfile)
 
 # Install the headers
 rocm_install(
@@ -56,7 +55,7 @@ if(CMAKE_HIP_PLATFORM STREQUAL "nvidia")
 endif()
 
 # Export the targets
-set(target_list ${target_list} roc::hipfile_shared roc::hipfile_static)
+set(target_list ${target_list} roc::hipfile)
 
 rocm_export_targets(
     TARGETS ${target_list}
@@ -67,7 +66,16 @@ rocm_export_targets(
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.md")
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 
+# rocm-cmake sets CPACK_SET_DESTDIR on Linux, which conflicts with
+# asking for relocatable packages
+set(CPACK_PACKAGE_RELOCATABLE OFF)
+set(CPACK_RPM_PACKAGE_RELOCATABLE OFF)
+set(CPACK_DEB_PACKAGE_RELOCATABLE OFF)
+
 # Create the package
+#
+# Note that you will just get a dev package if you have BUILD_SHARED_LIBS
+# set to off (since there are no shared libraries to install).
 rocm_create_package(
     NAME "hipFile"
     DESCRIPTION "The hipFile library"

--- a/examples/aiscp/CMakeLists.txt
+++ b/examples/aiscp/CMakeLists.txt
@@ -6,7 +6,7 @@ include(AISAddExecutable)
 
 ais_add_executable(
     NAME aiscp
-    DEPS hipfile_static
+    DEPS hipfile
     SRCS "aiscp.cpp"
     SYSINCLS ${HIPFILE_INCLUDE_PATH}
 )

--- a/src/amd_detail/CMakeLists.txt
+++ b/src/amd_detail/CMakeLists.txt
@@ -25,7 +25,7 @@ set(HIPFILE_SOURCES
     sys.cpp
 )
 
-# Will create hipfile_(static|shared)
+# Create hipfile target
 ais_add_libraries(
     NAME     hipfile
     DETAIL   amd

--- a/src/nvidia_detail/CMakeLists.txt
+++ b/src/nvidia_detail/CMakeLists.txt
@@ -10,7 +10,7 @@ set(HIPFILE_SOURCES
     hipfile-cufile.cpp
 )
 
-# Will create hipfile_(static|shared)
+# Create hipfile target
 ais_add_libraries(
     NAME    hipfile
     DETAIL  nvidia

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 
 ais_add_executable(
     NAME hipfile_tests
-    DEPS hipfile_shared
+    DEPS hipfile
     SRCS ${UNIT_TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
     SYSINCLS ${TEST_SYSINCLS}
 )
@@ -58,7 +58,7 @@ ais_gtest_discover_tests(
 
 ais_add_executable(
     NAME hipfile_system_tests
-    DEPS hipfile_shared
+    DEPS hipfile
     SRCS ${SYSTEM_TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
     SYSINCLS ${TEST_SYSINCLS}
 )
@@ -79,12 +79,12 @@ ais_gtest_discover_tests(
 ais_add_executable(
     NAME test_hipfile_basic
     SRCS legacy/test-hipfile.cpp
-    DEPS hipfile_shared
+    DEPS hipfile
 )
 ais_add_executable(
     NAME test_hipfile_batch
     SRCS legacy/test-hipfile-batch.cpp
-    DEPS hipfile_shared
+    DEPS hipfile
 )
 # ----------------------------------------
 

--- a/test/amd_detail/CMakeLists.txt
+++ b/test/amd_detail/CMakeLists.txt
@@ -38,7 +38,7 @@ set(TEST_SYSINCLS
 
 ais_add_executable(
     NAME internal_tests
-    DEPS hipfile_shared
+    DEPS hipfile
     SRCS ${TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
     SYSINCLS ${TEST_SYSINCLS}
 )
@@ -63,7 +63,7 @@ ais_gtest_discover_tests(
 
 ais_add_executable(
     NAME state_mt
-    DEPS hipfile_shared
+    DEPS hipfile
     SRCS "state_mt.cpp"
     SYSINCLS ${HIPFILE_AMD_SOURCE_PATH} ${HIPFILE_INCLUDE_PATH}
 )
@@ -75,7 +75,7 @@ set_tests_properties(state_mt_test PROPERTIES LABELS "stress;internal")
 
 ais_add_executable(
     NAME batch_mt
-    DEPS hipfile_shared
+    DEPS hipfile
     SRCS "batch/batch_mt.cpp"
     SYSINCLS ${HIPFILE_AMD_SOURCE_PATH} ${HIPFILE_INCLUDE_PATH}
 )


### PR DESCRIPTION
* Make `BUILD_SHARED_LIBS` an option
* Switch from building static and shared to just one (based on `BUILD_SHARED_LIBS` value)
* Quiet RPM warnings about asking for relocatable packages with fixed paths. We now only build with fixed paths, like the rest of ROCm.

This brings the install behaviour in line with the rest of ROCm