### PR TITLE
CI: Avoid recompiling hipFile in later stages of CI.

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -427,29 +427,6 @@ jobs:
           docker cp \
             ${GITHUB_WORKSPACE}/hipfile-build-dir/. \
             "${AIS_CONTAINER_NAME}:/ais/hipFile/build"
-      - name: Generate build files for hipFile targeting the AMD platform (amdclang++)
-        run: |
-          docker exec \
-            -t \
-            -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
-            /bin/bash -c '
-              cmake \
-                -DCMAKE_CXX_COMPILER=amdclang++ \
-                -DCMAKE_CXX_FLAGS="-Werror" \
-                -DCMAKE_HIP_PLATFORM=amd \
-                -DAIS_BUILD_DOCS=ON \
-                ..
-            '
-      - name: Build hipFile for the AMD platform (amdclang++)
-        run: |
-          docker exec \
-            -t \
-            -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
-            /bin/bash -c '
-              cmake --build . --parallel
-            '
       - name: Run hipFile system tests for the AMD platform (amdclang++)
         run: |
           docker exec \

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -220,6 +220,22 @@ jobs:
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
+      # CTestTestfiles.cmake hardcodes the absolute path of the GTest executables
+      # in the build directory. CTest relies on this metadata for execution. It is not
+      # trivial to modify this metadata, otherwise an installable test package could be
+      # used. For now, reuse the build directory.
+      - name: Copy hipFile build directory out of the container
+        run: |
+          docker cp \
+            "${AIS_CONTAINER_NAME}:/ais/hipFile/build" \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir
+      - name: Upload runtime hipFile Package as an Artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6.0.0
+        with:
+          name: hipfile-build-dir-${{ inputs.platform }}
+          path: ${{ github.workspace }}/hipfile-build-dir
+          if-no-files-found: error
+          retention-days: 1
       - name: Clean CMake build directories
         run: |
           docker exec \
@@ -324,6 +340,11 @@ jobs:
           repository: ROCm/fio
           ref: hipFile
           path: fio
+      - name: Download hipFile build directory
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        with:
+          name: hipfile-build-dir-${{ inputs.platform }}
+          path: ${{ github.workspace }}/hipfile-build-dir
       - name: Authenticating to GitHub Container Registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
         with:

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -340,6 +340,14 @@ jobs:
           repository: ROCm/fio
           ref: hipFile
           path: fio
+      - name: Download hipFile runtime package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        with:
+          name: ${{ needs.compile_on_AMD.outputs.ais_hipfile_pkg_filename }}
+      - name: Download hipFile development package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        with:
+          name: ${{ needs.compile_on_AMD.outputs.ais_hipfile_pkg_dev_filename }}
       - name: Download hipFile build directory
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
         with:
@@ -379,6 +387,32 @@ jobs:
               cp -R /mnt/ais /ais
               mkdir /ais/hipFile/build
               mkdir /ais/fio/build
+            '
+      - name: Copy the hipFile packages into the container
+        run: |
+          docker cp \
+            ${GITHUB_WORKSPACE}/${{ needs.compile_on_AMD.outputs.ais_hipfile_pkg_filename }} \
+            "${AIS_CONTAINER_NAME}:/root"
+          docker cp \
+            ${GITHUB_WORKSPACE}/${{ needs.compile_on_AMD.outputs.ais_hipfile_pkg_dev_filename }} \
+            "${AIS_CONTAINER_NAME}:/root"
+      - name: Install the hipFile packages
+        run: |
+          docker exec \
+            -t \
+            -w /root \
+            ${AIS_CONTAINER_NAME} \
+            /bin/bash -c '
+              ${{
+                format(
+                  inputs.platform == 'ubuntu' && 'apt install -y ./{0} ./{1}' ||
+                    inputs.platform == 'rocky' && 'dnf install -y ./{0} ./{1}' ||
+                    inputs.platform == 'suse' && 'zypper install -y --allow-unsigned-rpm ./{0} ./{1}' ||
+                    'echo "Unknown platform."; exit 1',
+                  needs.compile_on_AMD.outputs.ais_hipfile_pkg_filename,
+                  needs.compile_on_AMD.outputs.ais_hipfile_pkg_dev_filename
+                )
+              }}
             '
       - name: Generate build files for hipFile targeting the AMD platform (amdclang++)
         run: |

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -414,6 +414,19 @@ jobs:
                 )
               }}
             '
+      # GitHub Build Artifacts do not preserve file permissions, namely the executable bit.
+      - name: Fix file permissions on GTest executables
+        run: |
+          chmod a+x \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/test/hipfile_system_tests \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/test/amd_detail/batch_mt \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/test/amd_detail/state_mt \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/aiscp/aiscp
+      - name: Copy the hipFile build directory into the container
+        run: |
+          docker cp \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/. \
+            "${AIS_CONTAINER_NAME}:/ais/hipFile/build"
       - name: Generate build files for hipFile targeting the AMD platform (amdclang++)
         run: |
           docker exec \

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -160,14 +160,16 @@ jobs:
               echo "Runtime Package:"
               ${{
                 format(
-                  inputs.platform == 'ubuntu' && 'dpkg-deb -I {0}' || 'rpm -qpi --requires {0}',
+                  inputs.platform == 'ubuntu' && 'dpkg-deb -I {0} && dpkg-deb -c {0}' ||
+                    'rpm -qpil --requires {0}',
                   steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME
                 )
               }}
               echo -e "\n\nDevelopment Package:"
               ${{
                 format(
-                  inputs.platform == 'ubuntu' && 'dpkg-deb -I {0}' || 'rpm -qpi --requires {0}',
+                  inputs.platform == 'ubuntu' && 'dpkg-deb -I {0} && dpkg-deb -c {0}' ||
+                    'rpm -qpil --requires {0}',
                   steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME
                 )
               }}

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -469,8 +469,8 @@ jobs:
               HIPFILE=/ais/hipFile \
               HIPFILELIB=${HIPFILE}/build/src/amd_detail/ \
               HIP_PLATFORM=amd \
-              CFLAGS="-I${ROCM}/include -I${HIPFILE}/include" \
-              LDFLAGS="-L${ROCM}/lib -L${HIPFILELIB} -Wl,-rpath,${HIPFILELIB}" \
+              CFLAGS="-I${ROCM}/include" \
+              LDFLAGS="-L${ROCM}/lib -Wl,-rpath,${ROCM}/lib" \
               ../configure --enable-libhipfile
             '
       - name: Build fio

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -454,6 +454,9 @@ jobs:
         if: ${{ always() }}
         run: |
           docker stop ${AIS_CONTAINER_NAME}
+      - name: Cleanup self-hosted runner workspace
+        if: ${{ always() }}
+        run: rm -rf ${GITHUB_WORKSPACE}/* ${GITHUB_WORKSPACE}/.*
   compile_on_NVIDIA:
     runs-on: [ubuntu-24.04]
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,17 @@ list(APPEND CMAKE_PREFIX_PATH
     /opt/rocm/hip
 )
 
+# Set hipFile Install Path to the ROCm directory
+# Note: CMAKE_INSTALL_PREFIX is set to a default by project().
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${ROCM_PATH}" CACHE PATH "The path where hipFile should be installed" FORCE)
+endif()
+
+# Fix library install directory to "lib" to be inline with the rest of ROCm
+# Note: If testing is enabled, installing GTest calls GNUInstallDirs which will
+#       set this before ROCMInstallTargets can set it.
+set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Directory name for installed ROCm libraries")
+
 #-----------------------------------------------------------------------------
 # Import useful things for later
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Replaces #141.

This PR removes redundantly compiling hipFile during later stages in the CI workflow, namely for system tests.

Where possible, the installed hipFile library from the DEB/RPM package should be used. This is already the case for FIO. However, for system tests executed via CTest we currently need to reuse the entire build directory. Removing this build-time dependency would be ideal, but is out of scope for this PR.

This PR also sets the hipFile package install path to the non-versioned ROCm directory (`/opt/rocm`).

AIROCFILE-97