### PR TITLE
Rename hipFileOpStatusError()

### DIFF
--- a/docs/cuFile_API_supported_by_HIP.md
+++ b/docs/cuFile_API_supported_by_HIP.md
@@ -174,5 +174,5 @@
 |`cuFileUseCount`|15.0| | | |`hipFileUseCount`|8.0.0| |8.0.0| | | |
 |`cuFileWrite`|15.0| | | |`hipFileWrite`|8.0.0| |8.0.0| | | |
 |`cuFileWriteAsync`|15.0| | | |`hipFileWriteAsync`|8.0.0| |8.0.0| | | |
-|`cufileop_status_error`|15.0| | | |`hipFileOpStatusError`|8.0.0| | | | | |
+|`cufileop_status_error`|15.0| | | |`hipFileGetOpErrorString`|8.0.0| | | | | |
 

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -58,5 +58,5 @@ via the ``hipFileError_t`` struct.
 
 Other functions
 ---------------
-* ``hipFileOpStatusError()`` returns a string that corresponds to a ``hipFileOpError_t`` value. It cannot fail.
+* ``hipFileGetOpErrorString()`` returns a string that corresponds to a ``hipFileOpError_t`` value. It cannot fail.
 * ``hipFileUseCount()`` returns the reference count of the library. It returns -1 on errors.

--- a/examples/aiscp/aiscp.cpp
+++ b/examples/aiscp/aiscp.cpp
@@ -46,7 +46,7 @@ open_file(const char *path, int flags, mode_t mode, int *fd, hipFileHandle_t *ha
 
     hipfile_err = hipFileHandleRegister(handle, &descr);
     if (hipFileSuccess != hipfile_err.err) {
-        fprintf(stderr, "Could not register %s (%s)\n", path, hipFileOpStatusError(hipfile_err.err));
+        fprintf(stderr, "Could not register %s (%s)\n", path, hipFileGetOpErrorString(hipfile_err.err));
         close(*fd);
         return 1;
     }

--- a/include/hipfile.h
+++ b/include/hipfile.h
@@ -182,7 +182,7 @@ typedef enum hipFileOpError {
  * @return Description of the error encountered
  */
 HIPFILE_API
-const char *hipFileOpStatusError(hipFileOpError_t status);
+const char *hipFileGetOpErrorString(hipFileOpError_t status);
 
 // Ignoring return values from hipFile APIs is discouraged.
 // In C++17 and C23 and up, we can make that emit a warning.
@@ -230,7 +230,7 @@ typedef struct __HIPFILE_NODISCARD hipFileError {
  *
  * @return A string description of a hipFile error
  */
-#define HIPFILE_ERRSTR(hip_op_err) hipFileOpStatusError((hipFileOpError_t)abs(hip_op_err))
+#define HIPFILE_ERRSTR(hip_op_err) hipFileGetOpErrorString((hipFileOpError_t)abs(hip_op_err))
 
 /*!
  * @brief Determine if an error is a hipFile driver error

--- a/src/common/hipfile-common.cpp
+++ b/src/common/hipfile-common.cpp
@@ -8,7 +8,7 @@
 #include <hip/hip_runtime_api.h>
 
 const char *
-hipFileOpStatusError(hipFileOpError_t status)
+hipFileGetOpErrorString(hipFileOpError_t status)
 {
     switch (status) {
         case hipFileSuccess:


### PR DESCRIPTION
To hipFileGetOpErrorString() to better align with HIP, which uses hipGetErrorString() with hipError_t values.