### PR TITLE
Updated the CHANGELOG to note rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 ### Changed
+* Renamed `hipFileOpStatusError()` to `hipFileGetOpErrorString()`
 
 ### Removed
 * The rocFile library has been completely removed and the code is now a part of hipFile.


### PR DESCRIPTION
`hipFileOpStatusError()` to `hipFileGetOpErrorString()`