### PR TITLE
CI: Create a nightly release workflow

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -10,6 +10,7 @@ env:
       inputs.platform == 'ubuntu' && 'apt'
     }}
   AIS_PKG_TYPE: ${{ inputs.platform == 'ubuntu' && 'DEB' || 'RPM' }}
+  AIS_ROCM_VERSION: 6.4.2
   # Code coverage report only vetted to work for amdclang++ on Ubuntu
   AIS_USE_CODE_COVERAGE: ${{ inputs.cxx_compiler == 'amdclang++' && inputs.platform == 'ubuntu' }}
 on:
@@ -100,6 +101,7 @@ jobs:
       - name: Generate build files for hipFile targeting the AMD platform (${{ inputs.cxx_compiler }})
         run: |
           docker exec \
+            -e "_AIS_ROCM_VERSION=${AIS_ROCM_VERSION}" \
             -t \
             -w /ais/hipFile/build \
             ${AIS_CONTAINER_NAME} \
@@ -110,6 +112,7 @@ jobs:
                 -DCMAKE_HIP_PLATFORM=amd \
                 -DAIS_BUILD_DOCS=ON \
                 -DAIS_USE_CODE_COVERAGE=${{ env.AIS_USE_CODE_COVERAGE == 'true' && 'ON' || 'OFF' }} \
+                -DROCM_PATH="/opt/rocm-${_AIS_ROCM_VERSION}" \
                 ..
             '
       - name: Build hipFile for the AMD platform (${{ inputs.cxx_compiler }})

--- a/.github/workflows/nightly-build-ais.yml
+++ b/.github/workflows/nightly-build-ais.yml
@@ -1,0 +1,34 @@
+name: AIS_nightly_build
+run-name: Create a nightly build of hipFile
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+    outputs:
+      ais_hipfile_pkg_dev_filename:
+        description: "Filename for the hipFile development DEB/RPM package."
+        value: ${{ jobs.build_hipFile.outputs.ais_hipfile_pkg_dev_filename }}
+      ais_hipfile_pkg_filename:
+        description: "Filename for the hipFile runtime DEB/RPM package."
+        value: ${{ jobs.build_hipFile.outputs.ais_hipfile_pkg_filename }}
+permissions:
+  contents: read
+  packages: write
+jobs:
+  get_AIS_CI_image:
+    # This runs on develop so will always use latest.
+    uses: ./.github/workflows/build-ais-ci-image.yml
+    with:
+      dockerfile_changed: false
+      platform: ${{ inputs.platform }}
+  build_hipFile:
+    if: ${{ !cancelled() && needs.get_AIS_CI_image.outputs.ci_image_build_satisfied == 'true' }}
+    needs: [get_AIS_CI_image]
+    uses: ./.github/workflows/build-ais.yml
+    with:
+      ci_image: ${{ needs.get_AIS_CI_image.outputs.ci_image }}
+      cxx_compiler: amdclang++
+      platform: ${{ inputs.platform }}
+      upload_artifacts: true

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -22,3 +22,36 @@ jobs:
     uses: ./.github/workflows/nightly-build-ais.yml
     with:
       platform: ubuntu
+  publish_release:
+    needs: [build_rocky, build_suse, build_ubuntu]
+    runs-on: [ubuntu-24.04]
+    permissions:
+      contents: write
+    steps:
+      - name: Fetch hipFile Repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
+      - name: Download hipFile packages
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        with:
+          merge-multiple: true
+          # Currently only vetted for ubuntu, suse, and rocky.
+          # Best effort to only match runtime and development packages while
+          # avoiding any extras/testing packages.
+          pattern: hipfile{[-_][0-9],-dev_[0-9],-devel-[0-9]}*.{deb,rpm}
+      - name: List Releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release list
+      - name: Create a release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          shopt -s nullglob
+          gh release create \
+            --notes "$(date)" \
+            --prerelease \
+            --target develop \
+            --title Nightly \
+            nightly \
+            hipfile{[-_][0-9],-dev_[0-9],-devel-[0-9]}*.{deb,rpm}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -43,6 +43,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release list
+      - name: Test if 'nightly' already exists.
+        id: nightly-exists
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view nightly
+      - name: Delete 'nightly' if it already exists.
+        if: ${{ steps.nightly-exists.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete nightly --yes
       - name: Create a release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -67,8 +67,7 @@ jobs:
               Nightly Build as of: $(date)
 
               The packages contained here are not suitable for production workloads.
-              These packages are also not targeted to a particular ROCm version. Some caution
-              is needed if managing multiple ROCm versions on a system.
+              These packages are currently tied to the current version of our CI (6.4.2).
             " \
             --prerelease \
             --target develop \

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -9,22 +9,22 @@ permissions:
   contents: read
   packages: write
 jobs:
-  # Can't use a matrix to avoid clobbering outputs.
-  # Could consider a more complex way of passing matrix outputs around via build artifacts.
-  build_rocky:
+  # We can use a matrix job if we don't need to reference the outputs
+  # of each individual job within the matrix.
+  # This relies on using a glob pattern to reference the build artifacts.
+  build_nightly_hipFile:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - rocky
+          - suse
+          - ubuntu
     uses: ./.github/workflows/nightly-build-ais.yml
     with:
-      platform: rocky
-  build_suse:
-    uses: ./.github/workflows/nightly-build-ais.yml
-    with:
-      platform: suse
-  build_ubuntu:
-    uses: ./.github/workflows/nightly-build-ais.yml
-    with:
-      platform: ubuntu
+      platform: ${{ matrix.platform }}
   publish_release:
-    needs: [build_rocky, build_suse, build_ubuntu]
+    needs: [build_nightly_hipFile]
     runs-on: [ubuntu-24.04]
     permissions:
       contents: write

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -4,6 +4,7 @@ run-name: Create a nightly release of hipFile
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -62,7 +62,13 @@ jobs:
         run: |
           shopt -s nullglob
           gh release create \
-            --notes "$(date)" \
+            --notes "
+              Nightly Build as of: $(date)
+
+              The packages contained here are not suitable for production workloads.
+              These packages are also not targeted to a particular ROCm version. Some caution
+              is needed if managing multiple ROCm versions on a system.
+            " \
             --prerelease \
             --target develop \
             --title Nightly \

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,24 @@
+name: nightly-release
+run-name: Create a nightly release of hipFile
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+permissions:
+  contents: read
+  packages: write
+jobs:
+  # Can't use a matrix to avoid clobbering outputs.
+  # Could consider a more complex way of passing matrix outputs around via build artifacts.
+  build_rocky:
+    uses: ./.github/workflows/nightly-build-ais.yml
+    with:
+      platform: rocky
+  build_suse:
+    uses: ./.github/workflows/nightly-build-ais.yml
+    with:
+      platform: suse
+  build_ubuntu:
+    uses: ./.github/workflows/nightly-build-ais.yml
+    with:
+      platform: ubuntu


### PR DESCRIPTION
## Motivation

We would like to produce a nightly release of hipFile.

## Technical Details

Uses GH CLI for creating the release and uploading the packages to GitHub. There used to be a 1st party action to do this but has since been deprecated a few years ago.

Uses a glob pattern to fetch and reference the built hipFile packages. Best effort is used to only match runtime and development libraries, but we will need to verify this as we produce additional packages. This glob pattern will need to be updated/tested if a new platform is added to the support matrix or if the package filename changes.

## Test Plan

Does this pass the existing build workflow and are packages uploaded to the nightly release?

## Test Result

Ran the CI on my personal fork while the new nightly workflow had an added trigger of running on a `pull_request`.
https://github.com/riley-dixon/hipFile-test/actions/runs/21042360478?pr=14

AIHIPFILE-97
