### PR TITLE
CI: Resolve CodeQL concerns

### DIFF
--- a/.github/workflows/build-ais-ci-image.yml
+++ b/.github/workflows/build-ais-ci-image.yml
@@ -1,6 +1,7 @@
 name: new_CI_image
 run-name: Build the Docker image for AIS CI.
 env:
+  AIS_CI_IMAGE_NAME: ais_ci_${{ inputs.platform }}
   AIS_DOCKER_REGISTRY: ghcr.io/rocm/hipfile
   AIS_PR_BASE_URL: https://github.com/ROCm/hipFile/pull
 on:
@@ -51,8 +52,6 @@ permissions:
 jobs:
   build_AIS_image:
     if: ${{ inputs.dockerfile_changed }}
-    env:
-      AIS_CI_IMAGE_NAME: ais_ci_${{ inputs.platform }}
     runs-on: [ubuntu-24.04]
     container: docker:28.5
     outputs:

--- a/.github/workflows/build-ais-ci-image.yml
+++ b/.github/workflows/build-ais-ci-image.yml
@@ -64,9 +64,9 @@ jobs:
       - name: Set target AIS CI Image
         id: ci-image
         run: |
-          echo "AIS_CI_IMAGE=${{ env.AIS_DOCKER_REGISTRY }}/${{ env.AIS_CI_IMAGE_NAME}}:${AIS_CI_IMAGE_TAG}" \
+          echo "AIS_CI_IMAGE=${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:${AIS_CI_IMAGE_TAG}" \
             >> "${GITHUB_OUTPUT}"
-          echo "AIS_CI_LATEST_CACHE=${{ env.AIS_DOCKER_REGISTRY }}/${{ env.AIS_CI_IMAGE_NAME}}:latest-cache" \
+          echo "AIS_CI_LATEST_CACHE=${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-cache" \
             >> "${GITHUB_OUTPUT}"
       - name: Fetching code repository...
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
@@ -85,11 +85,11 @@ jobs:
       - name: Build base image for AIS CI
         run: |
           docker buildx build \
-            -f ${GITHUB_WORKSPACE}/util/docker/DOCKERFILE.${{ env.AIS_CI_IMAGE_NAME }} \
+            -f ${GITHUB_WORKSPACE}/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME} \
             --label "org.opencontainers.image.description= \
-              ${{ env.AIS_CI_IMAGE_NAME }} Development Image for AIS CI using branch \
+              ${AIS_CI_IMAGE_NAME} Development Image for AIS CI using branch \
               ${{ github.head_ref }} for PR #${AIS_PR_NUMBER}. \
-              PR URL: ${{ env.AIS_PR_BASE_URL }}/${AIS_PR_NUMBER}" \
+              PR URL: ${AIS_PR_BASE_URL}/${AIS_PR_NUMBER}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from=type=registry,ref=${{ steps.ci-image.outputs.AIS_CI_IMAGE }} \
             --cache-from=type=registry,ref=${{ steps.ci-image.outputs.AIS_CI_LATEST_CACHE }} \

--- a/.github/workflows/build-ais-ci-image.yml
+++ b/.github/workflows/build-ais-ci-image.yml
@@ -85,14 +85,14 @@ jobs:
       - name: Build base image for AIS CI
         run: |
           docker buildx build \
-            -f ${GITHUB_WORKSPACE}/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME} \
+            -f "${GITHUB_WORKSPACE}/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
             --label "org.opencontainers.image.description= \
               ${AIS_CI_IMAGE_NAME} Development Image for AIS CI using branch \
               ${{ github.head_ref }} for PR #${AIS_PR_NUMBER}. \
               PR URL: ${AIS_PR_BASE_URL}/${AIS_PR_NUMBER}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from=type=registry,ref=${{ steps.ci-image.outputs.AIS_CI_IMAGE }} \
-            --cache-from=type=registry,ref=${{ steps.ci-image.outputs.AIS_CI_LATEST_CACHE }} \
+            --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
+            --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_LATEST_CACHE }}" \
             --push \
-            -t ${{ steps.ci-image.outputs.AIS_CI_IMAGE }} \
+            -t "${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
             ${GITHUB_WORKSPACE}

--- a/.github/workflows/build-ais-nvidia.yml
+++ b/.github/workflows/build-ais-nvidia.yml
@@ -1,6 +1,8 @@
 name: build_ais_nvidia
 run-name: Build AIS for Nvidia platforms
 env:
+  AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_INPUT_PLATFORM: ${{ inputs.platform }}
   AIS_MOUNT_PATH: /mnt/ais/ext4
 on:
   workflow_call:
@@ -16,6 +18,8 @@ permissions:
   packages: read
 jobs:
   compile_on_NVIDIA:
+    env:
+      AIS_INPUT_CXX_COMPILER: ${{ matrix.supported_compilers }}
     runs-on: [ubuntu-24.04]
     strategy:
       fail-fast: false
@@ -27,10 +31,10 @@ jobs:
       - name: Set early AIS CI environment variables
         run: |
           echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
-          echo "AIS_SAFE_COMPILER_NAME=$(echo ${{ matrix.supported_compilers }} | sed 's|[\+]|plus|g')" >> "${GITHUB_ENV}"
+          echo "AIS_SAFE_COMPILER_NAME=$(echo ${AIS_INPUT_CXX_COMPILER} | sed 's|[\+]|plus|g')" >> "${GITHUB_ENV}"
       - name: Set AIS CI container name
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${AIS_INPUT_PLATFORM}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
       - name: Fetching code repository...
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
         with:
@@ -51,9 +55,9 @@ jobs:
             --rm \
             --pull always \
             -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
-            -v ${{ env.AIS_MOUNT_PATH }}:/mnt/ais-fs \
+            -v ${AIS_MOUNT_PATH}:/mnt/ais-fs \
             --name ${AIS_CONTAINER_NAME} \
-            ${{ inputs.ci_image }}
+            ${AIS_INPUT_CI_IMAGE}
       - name: Make copy of the code repository and create build directories
         run: |
           docker exec \
@@ -66,12 +70,13 @@ jobs:
       - name: Generate build files for hipFile targeting the NVIDIA platform (${{ matrix.supported_compilers }})
         run: |
           docker exec \
+            -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
             -t \
             -w /ais/hipFile/build \
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
               cmake \
-                -DCMAKE_CXX_COMPILER=${{ matrix.supported_compilers }} \
+                -DCMAKE_CXX_COMPILER=${_AIS_INPUT_CXX_COMPILER} \
                 -DCMAKE_CXX_FLAGS="-Werror" \
                 -DCMAKE_HIP_PLATFORM=nvidia \
                 -DAIS_BUILD_DOCS=ON \
@@ -104,4 +109,4 @@ jobs:
 #    uses: ./.github/workflows/hipfile-nvidia.yml
 #    needs: build_AIS_image
 #    with:
-#      platform: ${{inputs.platform}}
+#      platform: ${AIS_INPUT_PLATFORM}

--- a/.github/workflows/build-ais-nvidia.yml
+++ b/.github/workflows/build-ais-nvidia.yml
@@ -55,14 +55,14 @@ jobs:
             --rm \
             --pull always \
             -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
-            -v ${AIS_MOUNT_PATH}:/mnt/ais-fs \
-            --name ${AIS_CONTAINER_NAME} \
-            ${AIS_INPUT_CI_IMAGE}
+            -v "${AIS_MOUNT_PATH}:/mnt/ais-fs" \
+            --name "${AIS_CONTAINER_NAME}" \
+            "${AIS_INPUT_CI_IMAGE}"
       - name: Make copy of the code repository and create build directories
         run: |
           docker exec \
             -t \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               cp -R /mnt/ais /ais
               mkdir /ais/hipFile/build
@@ -73,10 +73,10 @@ jobs:
             -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               cmake \
-                -DCMAKE_CXX_COMPILER=${_AIS_INPUT_CXX_COMPILER} \
+                -DCMAKE_CXX_COMPILER="${_AIS_INPUT_CXX_COMPILER}" \
                 -DCMAKE_CXX_FLAGS="-Werror" \
                 -DCMAKE_HIP_PLATFORM=nvidia \
                 -DAIS_BUILD_DOCS=ON \
@@ -87,7 +87,7 @@ jobs:
           docker exec \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               cmake --build . --parallel
             '
@@ -96,14 +96,14 @@ jobs:
           docker exec \
             -t \
             -w /ais/hipFile \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               rm -rf build/*
             '
       - name: Cleanup & Stop the Docker container
         if: ${{ always() }}
         run: |
-          docker stop ${AIS_CONTAINER_NAME}
+          docker stop "${AIS_CONTAINER_NAME}"
 ### Disable until NVIDIA runners come back
 #  Run_hipFile_NVIDIA:
 #    uses: ./.github/workflows/hipfile-nvidia.yml

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -2,6 +2,10 @@ name: build_and_test
 run-name: Build, Test, and Analyze AIS
 env:
   AIS_GHA_CMD_FILES_DOCKER_DIR: /root/github
+  AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_INPUT_CXX_COMPILER: ${{ inputs.cxx_compiler }}
+  AIS_INPUT_PLATFORM: ${{ inputs.platform }}
+  AIS_INPUT_UPLOAD_ARTIFACTS: ${{ inputs.upload_artifacts }}
   AIS_MOUNT_PATH: /mnt/ais/ext4
   AIS_PKG_MGR: >-
     ${{
@@ -57,11 +61,11 @@ jobs:
         run: |
           echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
           echo "AIS_GHA_CMD_FILES_DIR=${GITHUB_ENV%/*}" >> "${GITHUB_ENV}"
-          echo "AIS_SAFE_COMPILER_NAME=$(echo ${{ inputs.cxx_compiler}} | sed 's|[\+]|plus|g')" >> "${GITHUB_ENV}"
+          echo "AIS_SAFE_COMPILER_NAME=$(echo ${AIS_INPUT_CXX_COMPILER} | sed 's|[\+]|plus|g')" >> "${GITHUB_ENV}"
       - name: Set AIS CI container name
         # We should expect that there are multiple instances of this job with different cxx_compilers.
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${AIS_INPUT_PLATFORM}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
       - name: Fetching code repository...
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
         with:
@@ -82,10 +86,10 @@ jobs:
             --rm \
             --pull always \
             -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
-            -v "${AIS_GHA_CMD_FILES_DIR}:${{ env.AIS_GHA_CMD_FILES_DOCKER_DIR }}" \
-            -v ${{ env.AIS_MOUNT_PATH }}:/mnt/ais-fs \
+            -v "${AIS_GHA_CMD_FILES_DIR}:${AIS_GHA_CMD_FILES_DOCKER_DIR}" \
+            -v ${AIS_MOUNT_PATH}:/mnt/ais-fs \
             --name ${AIS_CONTAINER_NAME} \
-            ${{ inputs.ci_image }}
+            ${AIS_INPUTS_CI_IMAGE}
       - name: Make copy of the code repository and create build directories
         # Single quotes necessary to ensure string/command substitutions happen
         # in the container and not on the host.
@@ -100,12 +104,13 @@ jobs:
       - name: Generate build files for hipFile targeting the AMD platform (${{ inputs.cxx_compiler }})
         run: |
           docker exec \
+            -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
             -t \
             -w /ais/hipFile/build \
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
               cmake \
-                -DCMAKE_CXX_COMPILER=${{ inputs.cxx_compiler }} \
+                -DCMAKE_CXX_COMPILER=${_AIS_INPUT_CXX_COMPILER} \
                 -DCMAKE_CXX_FLAGS="-Werror" \
                 -DCMAKE_HIP_PLATFORM=amd \
                 -DAIS_BUILD_DOCS=ON \
@@ -148,11 +153,12 @@ jobs:
       - name: Create hipFile package
         run: |
           docker exec \
+            -e "_AIS_PKG_TYPE=${AIS_PKG_TYPE}" \
             -t \
             -w /ais/hipFile/build \
             ${AIS_CONTAINER_NAME} \
             /bin/bash -c '
-              cpack -G ${{ env.AIS_PKG_TYPE }}
+              cpack -G ${_AIS_PKG_TYPE}
             '
       # CI is unable to peer into CMake to capture this data ahead of time.
       # We should only produce a single package so we can use a glob pattern

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -87,16 +87,16 @@ jobs:
             --pull always \
             -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
             -v "${AIS_GHA_CMD_FILES_DIR}:${AIS_GHA_CMD_FILES_DOCKER_DIR}" \
-            -v ${AIS_MOUNT_PATH}:/mnt/ais-fs \
-            --name ${AIS_CONTAINER_NAME} \
-            ${AIS_INPUTS_CI_IMAGE}
+            -v "${AIS_MOUNT_PATH}:/mnt/ais-fs" \
+            --name "${AIS_CONTAINER_NAME}" \
+            "${AIS_INPUT_CI_IMAGE}"
       - name: Make copy of the code repository and create build directories
         # Single quotes necessary to ensure string/command substitutions happen
         # in the container and not on the host.
         run: |
           docker exec \
             -t \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               cp -R /mnt/ais /ais
               mkdir /ais/hipFile/build
@@ -107,10 +107,10 @@ jobs:
             -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               cmake \
-                -DCMAKE_CXX_COMPILER=${_AIS_INPUT_CXX_COMPILER} \
+                -DCMAKE_CXX_COMPILER="${_AIS_INPUT_CXX_COMPILER}" \
                 -DCMAKE_CXX_FLAGS="-Werror" \
                 -DCMAKE_HIP_PLATFORM=amd \
                 -DAIS_BUILD_DOCS=ON \
@@ -122,7 +122,7 @@ jobs:
           docker exec \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               cmake --build . --parallel
             '
@@ -131,7 +131,7 @@ jobs:
           docker exec \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               ctest -V -L "unit" --parallel
             '
@@ -141,7 +141,7 @@ jobs:
           docker exec \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               export PATH="/opt/rocm/llvm/bin:${PATH}"
               ../util/llvm-coverage.sh
@@ -156,9 +156,9 @@ jobs:
             -e "_AIS_PKG_TYPE=${AIS_PKG_TYPE}" \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              cpack -G ${_AIS_PKG_TYPE}
+              cpack -G "${_AIS_PKG_TYPE}"
             '
       # CI is unable to peer into CMake to capture this data ahead of time.
       # We should only produce a single package so we can use a glob pattern
@@ -172,7 +172,7 @@ jobs:
             -e "AIS_GITHUB_OUTPUT=${{ env.AIS_GHA_CMD_FILES_DOCKER_DIR }}/${GITHUB_OUTPUT##*/}" \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               shopt -s nullglob
               AIS_HIPFILE_PKG_DEV_FILENAME="$(echo hipfile-de{v,vel}{-,_}[0-9]*.{deb,rpm})"
@@ -182,8 +182,8 @@ jobs:
               echo "AIS_HIPFILE_PKG_VERSION=$(
                 ${{
                   env.AIS_PKG_TYPE == 'DEB' &&
-                  'dpkg-deb -f ${AIS_HIPFILE_PKG_FILENAME} "Version"' ||
-                  'rpm -qp --qf "%{VERSION}" ${AIS_HIPFILE_PKG_FILENAME}'
+                  'dpkg-deb -f "${AIS_HIPFILE_PKG_FILENAME}" "Version"' ||
+                  'rpm -qp --qf "%{VERSION}" "${AIS_HIPFILE_PKG_FILENAME}"'
                 }}
               )" >> "${AIS_GITHUB_OUTPUT}"
             '
@@ -193,14 +193,14 @@ jobs:
           docker exec \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               echo "Runtime Package:"
               ${{
                 format(
                   env.AIS_PKG_TYPE == 'DEB' &&
-                    'dpkg-deb -I {0} && dpkg-deb -c {0}' ||
-                    'rpm -qpil --requires {0}',
+                    'dpkg-deb -I "{0}" && dpkg-deb -c "{0}"' ||
+                    'rpm -qpil --requires "{0}"',
                   steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME
                 )
               }}
@@ -208,8 +208,8 @@ jobs:
               ${{
                 format(
                   env.AIS_PKG_TYPE == 'DEB' &&
-                    'dpkg-deb -I {0} && dpkg-deb -c {0}' ||
-                    'rpm -qpil --requires {0}',
+                    'dpkg-deb -I "{0}" && dpkg-deb -c "{0}"' ||
+                    'rpm -qpil --requires "{0}"',
                   steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME
                 )
               }}
@@ -225,13 +225,13 @@ jobs:
           docker exec \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               ${{
                 format(
-                  env.AIS_PKG_MGR == 'apt' && 'apt install -y ./{0} ./{1}' ||
-                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y ./{0} ./{1}' ||
-                    env.AIS_PKG_MGR == 'zypper' && 'zypper install -y --allow-unsigned-rpm ./{0} ./{1}' ||
+                  env.AIS_PKG_MGR == 'apt' && 'apt install -y "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'zypper' && 'zypper install -y --allow-unsigned-rpm "./{0}" "./{1}"' ||
                     'echo "Unknown platform."; exit 1',
                   steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME,
                   steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME
@@ -288,11 +288,11 @@ jobs:
           docker exec \
             -t \
             -w /ais/hipFile \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               rm -rf build/*
             '
       - name: Cleanup & Stop the Docker container
         if: ${{ always() }}
         run: |
-          docker stop ${AIS_CONTAINER_NAME}
+          docker stop "${AIS_CONTAINER_NAME}"

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -82,17 +82,17 @@ jobs:
             --security-opt seccomp=unconfined \
             --pull always \
             -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
-            -v ${AIS_MOUNT_PATH}:/mnt/ais-fs \
-            --name ${AIS_CONTAINER_NAME} \
-            ${AIS_INPUT_CI_IMAGE}
+            -v "${AIS_MOUNT_PATH}:/mnt/ais-fs" \
+            --name "${AIS_CONTAINER_NAME}" \
+            "${AIS_INPUT_CI_IMAGE}"
       - name: Create hipfile IO test directory
         run: |
-          docker exec -t ${AIS_CONTAINER_NAME} /bin/bash -c "mkdir -p /mnt/ais-fs/${AIS_CONTAINER_NAME}"
+          docker exec -t "${AIS_CONTAINER_NAME}" /bin/bash -c "mkdir -p /mnt/ais-fs/${AIS_CONTAINER_NAME}"
       - name: Make copy of the code repository and create build directories
         run: |
           docker exec \
             -t \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               cp -R /mnt/ais /ais
               mkdir /ais/hipFile/build
@@ -101,23 +101,23 @@ jobs:
       - name: Copy the hipFile packages into the container
         run: |
           docker cp \
-            ${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_FILENAME} \
+            "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_FILENAME}" \
             "${AIS_CONTAINER_NAME}:/root"
           docker cp \
-            ${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_DEV_FILENAME} \
+            "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_DEV_FILENAME}" \
             "${AIS_CONTAINER_NAME}:/root"
       - name: Install the hipFile packages
         run: |
           docker exec \
             -t \
             -w /root \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               ${{
                 format(
-                  env.AIS_PKG_MGR == 'apt' && 'apt install -y ./{0} ./{1}' ||
-                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y ./{0} ./{1}' ||
-                    env.AIS_PKG_MGR == 'zypper' && 'zypper install -y --allow-unsigned-rpm ./{0} ./{1}' ||
+                  env.AIS_PKG_MGR == 'apt' && 'apt install -y "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'zypper' && 'zypper install -y --allow-unsigned-rpm "./{0}" "./{1}"' ||
                     'echo "Unknown platform."; exit 1',
                   inputs.ais_hipfile_pkg_filename,
                   inputs.ais_hipfile_pkg_dev_filename
@@ -142,7 +142,7 @@ jobs:
           docker exec \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               ctest -V -L "system" --parallel
             '
@@ -151,7 +151,7 @@ jobs:
           docker exec \
             -t \
             -w /ais/hipFile/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               ctest -V -L "stress" --parallel
             '
@@ -159,8 +159,8 @@ jobs:
         run: |
           docker exec \
             -t \
-            -w /mnt/ais-fs/${AIS_CONTAINER_NAME} \
-            ${AIS_CONTAINER_NAME} \
+            -w "/mnt/ais-fs/${AIS_CONTAINER_NAME}" \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               HIPFILE_FORCE_COMPAT_MODE=true
                 /ais/hipFile/util/ci-aiscp-test.sh \
@@ -171,7 +171,7 @@ jobs:
           docker exec \
             -t \
             -w /ais/fio/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               ROCM=/opt/rocm \
               HIPFILE=/ais/hipFile \
@@ -186,7 +186,7 @@ jobs:
           docker exec \
             -t \
             -w /ais/fio/build \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               make -j
             '
@@ -195,7 +195,7 @@ jobs:
           docker exec \
             -t \
             -w /mnt/ais-fs/${AIS_CONTAINER_NAME} \
-            ${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               HIPFILE_FORCE_COMPAT_MODE=true \
                 /ais/fio/build/fio \
@@ -204,11 +204,11 @@ jobs:
       - name: Destroy hipfile IO test directory
         if: ${{ always() }}
         run: |
-          docker exec -t ${AIS_CONTAINER_NAME} /bin/bash -c "rm -fr /mnt/ais-fs/${AIS_CONTAINER_NAME}"
+          docker exec -t "${AIS_CONTAINER_NAME}" /bin/bash -c "rm -fr /mnt/ais-fs/${AIS_CONTAINER_NAME}"
       - name: Cleanup & Stop the Docker container
         if: ${{ always() }}
         run: |
-          docker stop ${AIS_CONTAINER_NAME}
+          docker stop "${AIS_CONTAINER_NAME}"
       - name: Cleanup self-hosted runner workspace
         if: ${{ always() }}
         run: rm -rf ${GITHUB_WORKSPACE}/* ${GITHUB_WORKSPACE}/.*

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -2,6 +2,10 @@ name: ais-system-tests
 run-name: Run AIS System Tests
 env:
   AIS_GHA_CMD_FILES_DOCKER_DIR: /root/github
+  AIS_INPUT_HIPFILE_PKG_DEV_FILENAME: ${{ inputs.ais_hipfile_pkg_dev_filename }}
+  AIS_INPUT_HIPFILE_PKG_FILENAME: ${{ inputs.ais_hipfile_pkg_filename }}
+  AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_INPUT_PLATFORM: ${{ inputs.platform }}
   AIS_MOUNT_PATH: /mnt/ais/ext4
   AIS_PKG_MGR: >-
     ${{
@@ -35,7 +39,7 @@ jobs:
         run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
       - name: Set AIS CI container name
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${{ inputs.platform }}" >> "${GITHUB_ENV}"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${AIS_INPUT_PLATFORM}" >> "${GITHUB_ENV}"
       - name: Fetching hipFile repository...
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
         with:
@@ -78,9 +82,9 @@ jobs:
             --security-opt seccomp=unconfined \
             --pull always \
             -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
-            -v ${{ env.AIS_MOUNT_PATH }}:/mnt/ais-fs \
+            -v ${AIS_MOUNT_PATH}:/mnt/ais-fs \
             --name ${AIS_CONTAINER_NAME} \
-            ${{ inputs.ci_image }}
+            ${AIS_INPUT_CI_IMAGE}
       - name: Create hipfile IO test directory
         run: |
           docker exec -t ${AIS_CONTAINER_NAME} /bin/bash -c "mkdir -p /mnt/ais-fs/${AIS_CONTAINER_NAME}"
@@ -97,10 +101,10 @@ jobs:
       - name: Copy the hipFile packages into the container
         run: |
           docker cp \
-            ${GITHUB_WORKSPACE}/${{ inputs.ais_hipfile_pkg_filename }} \
+            ${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_FILENAME} \
             "${AIS_CONTAINER_NAME}:/root"
           docker cp \
-            ${GITHUB_WORKSPACE}/${{ inputs.ais_hipfile_pkg_dev_filename }} \
+            ${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_DEV_FILENAME} \
             "${AIS_CONTAINER_NAME}:/root"
       - name: Install the hipFile packages
         run: |

--- a/.github/workflows/update-ais-ci-image.yml
+++ b/.github/workflows/update-ais-ci-image.yml
@@ -26,6 +26,7 @@ jobs:
   update_AIS_CI_image:
     env:
       AIS_CI_IMAGE_NAME: ais_ci_${{ matrix.supported_platforms }}
+      AIS_INPUT_PLATFORM: ${{ matrix.supported_platforms }}
     if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
     runs-on: [ubuntu-24.04]
     container: docker:28.5
@@ -47,7 +48,7 @@ jobs:
       - name: Set target AIS CI Image
         id: ci-image
         run: |
-          echo "AIS_CI_IMAGE=${{ env.AIS_DOCKER_REGISTRY }}/${{ env.AIS_CI_IMAGE_NAME}}:latest" \
+          echo "AIS_CI_IMAGE=${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest" \
             >> "${GITHUB_OUTPUT}"
       - name: Set Docker Cache Instruction
         id: use-cache
@@ -71,9 +72,9 @@ jobs:
       - name: Build & Push latest image for AIS CI
         run: |
           docker buildx build \
-            -f ${GITHUB_WORKSPACE}/util/docker/DOCKERFILE.${{ env.AIS_CI_IMAGE_NAME }} \
+            -f ${GITHUB_WORKSPACE}/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME} \
             --label "org.opencontainers.image.description= \
-              Latest AIS CI Image for ${{ matrix.supported_platforms }}." \
+              Latest AIS CI Image for ${AIS_INPUT_PLATFORM}." \
             --cache-to=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE }}-cache" \
             ${{ steps.use-cache.outputs.CACHE_FROM_CMD }} \
             --push \

--- a/.github/workflows/update-ais-ci-image.yml
+++ b/.github/workflows/update-ais-ci-image.yml
@@ -1,5 +1,7 @@
 name: update_CI_image
 run-name: Update latest CI image
+env:
+  AIS_DOCKER_REGISTRY: ghcr.io/rocm/hipfile
 on:
   pull_request_target: # A.K.A. This is a privileged action. See `pull_request`.
     types:
@@ -23,7 +25,6 @@ permissions:
 jobs:
   update_AIS_CI_image:
     env:
-      AIS_DOCKER_REGISTRY: ghcr.io/rocm/hipfile
       AIS_CI_IMAGE_NAME: ais_ci_${{ matrix.supported_platforms }}
     if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
     runs-on: [ubuntu-24.04]

--- a/.github/workflows/update-ais-ci-image.yml
+++ b/.github/workflows/update-ais-ci-image.yml
@@ -72,11 +72,11 @@ jobs:
       - name: Build & Push latest image for AIS CI
         run: |
           docker buildx build \
-            -f ${GITHUB_WORKSPACE}/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME} \
+            -f "${GITHUB_WORKSPACE}/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
             --label "org.opencontainers.image.description= \
               Latest AIS CI Image for ${AIS_INPUT_PLATFORM}." \
             --cache-to=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE }}-cache" \
             ${{ steps.use-cache.outputs.CACHE_FROM_CMD }} \
             --push \
-            -t ${{ steps.ci-image.outputs.AIS_CI_IMAGE }} \
+            -t "${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
             ${GITHUB_WORKSPACE}


### PR DESCRIPTION
This resolves some CodeQL signals that could be considered false positives since our CI variables are not provided by external workflows. There concerns in particular are regarding potential shell injection should our callable workflows ever take in input from an external user. It recommends storing inputs in the environment rather than referencing them directly within a Bash step. We also encapsulate these instances within quotes to further try to prevent injections via substitutions.

AIHIPFILE-97