### PR TITLE
CI: Reuse cached manifest when installing hipFile packages.

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -224,8 +224,8 @@ jobs:
               ${{
                 format(
                   env.AIS_PKG_MGR == 'apt' && 'apt install -y ./{0} ./{1}' ||
-                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y ./{0} ./{1}' ||
-                    env.AIS_PKG_MGR == 'zypper' && 'zypper install -y --allow-unsigned-rpm ./{0} ./{1}' ||
+                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y --cacheonly ./{0} ./{1}' ||
+                    env.AIS_PKG_MGR == 'zypper' && 'zypper --no-refresh install -y --allow-unsigned-rpm ./{0} ./{1}' ||
                     'echo "Unknown platform."; exit 1',
                   steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME,
                   steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -112,8 +112,8 @@ jobs:
               ${{
                 format(
                   env.AIS_PKG_MGR == 'apt' && 'apt install -y ./{0} ./{1}' ||
-                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y ./{0} ./{1}' ||
-                    env.AIS_PKG_MGR == 'zypper' && 'zypper install -y --allow-unsigned-rpm ./{0} ./{1}' ||
+                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y --cacheonly ./{0} ./{1}' ||
+                    env.AIS_PKG_MGR == 'zypper' && 'zypper --no-refresh install -y --allow-unsigned-rpm ./{0} ./{1}' ||
                     'echo "Unknown platform."; exit 1',
                   inputs.ais_hipfile_pkg_filename,
                   inputs.ais_hipfile_pkg_dev_filename


### PR DESCRIPTION
DNF & Zypper automatically update the package manifest when executing a command if the current package manifest is old. We don't need to worry about an old manifest because the Docker container should already have all the needed dependencies.