### PR TITLE
CI: Update CI images to use ROCm 7.1.1

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -14,7 +14,7 @@ env:
       inputs.platform == 'ubuntu' && 'apt'
     }}
   AIS_PKG_TYPE: ${{ inputs.platform == 'ubuntu' && 'DEB' || 'RPM' }}
-  AIS_ROCM_VERSION: 6.4.2
+  AIS_ROCM_VERSION: 7.1.1
   # Code coverage report only vetted to work for amdclang++ on Ubuntu
   AIS_USE_CODE_COVERAGE: ${{ inputs.cxx_compiler == 'amdclang++' && inputs.platform == 'ubuntu' }}
 on:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -67,7 +67,7 @@ jobs:
               Nightly Build as of: $(date)
 
               The packages contained here are not suitable for production workloads.
-              These packages are currently tied to the current version of our CI (6.4.2).
+              These packages are currently tied to the current version of our CI (7.1.1).
             " \
             --prerelease \
             --target develop \

--- a/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/util/docker/DOCKERFILE.ais_ci_rocky
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
 ARG ROCKY_MAJOR_VERSION
 ARG ROCKY_VERSION
-ARG ROCm_VERSION=6.4.2
+ARG ROCm_VERSION=7.1.1
 
 # Update repo and install program dependencies.
 # microdnf is too stripped down, install full dnf.
@@ -38,16 +38,6 @@ RUN cat <<EOF > /etc/yum.repos.d/rocm.repo
 [ROCm-${ROCm_VERSION}]
 name=ROCm${ROCm_VERSION}
 baseurl=https://repo.radeon.com/rocm/el${ROCKY_MAJOR_VERSION}/${ROCm_VERSION}/main
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-
-RUN cat <<EOF > /etc/yum.repos.d/amdgpu.repo
-[amdgpu-${ROCm_VERSION}]
-name=amdgpu${ROCm_VERSION}
-baseurl=https://repo.radeon.com/amdgpu/${ROCm_VERSION}/rhel/${ROCKY_VERSION}/main/$(uname -m)
 enabled=1
 priority=50
 gpgcheck=1

--- a/util/docker/DOCKERFILE.ais_ci_suse
+++ b/util/docker/DOCKERFILE.ais_ci_suse
@@ -8,7 +8,7 @@ FROM opensuse/leap:${SUSE_VERSION}
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG SUSE_MAJOR_VERSION
 ARG SUSE_VERSION
-ARG ROCm_VERSION=6.4.2
+ARG ROCm_VERSION=7.1.1
 
 # The initial pull takes some time. Expect ~2.5 minutes to complete.
 RUN zypper refresh
@@ -33,16 +33,6 @@ RUN cat <<EOF > /etc/zypp/repos.d/rocm.repo
 [ROCm-${ROCm_VERSION}]
 name=ROCm${ROCm_VERSION}
 baseurl=https://repo.radeon.com/rocm/zyp/${ROCm_VERSION}/main
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-
-RUN cat <<EOF > /etc/zypp/repos.d/amdgpu.repo
-[amdgpu-${ROCm_VERSION}]
-name=amdgpu${ROCm_VERSION}
-baseurl=https://repo.radeon.com/amdgpu/${ROCm_VERSION}/sle/${SUSE_VERSION}/main/$(uname -m)
 enabled=1
 priority=50
 gpgcheck=1

--- a/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG UBUNTU_CODENAME
 ARG UBUNTU_MAJOR_VERSION=24
 ARG UBUNTU_MINOR_VERSION=04
-ARG ROCm_VERSION=6.4.2
+ARG ROCm_VERSION=7.1.1
 
 RUN apt update && \
     apt install -y \
@@ -22,7 +22,6 @@ RUN curl https://repo.radeon.com/rocm/rocm.gpg.key | \
 # Manually setup ROCm Package Repos
 RUN cat <<EOF > /etc/apt/sources.list.d/rocm.list
 deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCm_VERSION} ${UBUNTU_CODENAME} main
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/${ROCm_VERSION}/ubuntu ${UBUNTU_CODENAME} main
 EOF
 
 RUN cat <<EOF > /etc/apt/preferences.d/rocm-pin-600


### PR DESCRIPTION
Updates ROCm version used in the CI container to 7.1.1

AMDGPU repo removed as we don't need any packages from that repository (mostly kernel packages).