### PR TITLE
CI: Update CI images to use ROCm 7.2.

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -14,7 +14,7 @@ env:
       inputs.platform == 'ubuntu' && 'apt'
     }}
   AIS_PKG_TYPE: ${{ inputs.platform == 'ubuntu' && 'DEB' || 'RPM' }}
-  AIS_ROCM_VERSION: 7.1.1
+  AIS_ROCM_VERSION: 7.2.0
   # Code coverage report only vetted to work for amdclang++ on Ubuntu
   AIS_USE_CODE_COVERAGE: ${{ inputs.cxx_compiler == 'amdclang++' && inputs.platform == 'ubuntu' }}
 on:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -67,7 +67,7 @@ jobs:
               Nightly Build as of: $(date)
 
               The packages contained here are not suitable for production workloads.
-              These packages are currently tied to the current version of our CI (7.1.1).
+              These packages are currently tied to the current version of our CI (7.2).
             " \
             --prerelease \
             --target develop \

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -201,6 +201,17 @@ jobs:
                 /ais/fio/build/fio \
                 /ais/hipFile/util/fio/write-read-verify.fio
             '
+      - name: hipFile AIS IO test using fio
+        run: |
+          docker exec \
+            -t \
+            -w /mnt/ais-fs/${AIS_CONTAINER_NAME} \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              HIPFILE_FORCE_COMPAT_MODE=false \
+                /ais/fio/build/fio \
+                /ais/hipFile/util/fio/write-read-verify.fio
+            '
       - name: Destroy hipfile IO test directory
         if: ${{ always() }}
         run: |

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -208,7 +208,7 @@ jobs:
             -w /mnt/ais-fs/${AIS_CONTAINER_NAME} \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              HIPFILE_FORCE_COMPAT_MODE=false \
+              HIPFILE_ALLOW_COMPAT_MODE=false \
                 /ais/fio/build/fio \
                 /ais/hipFile/util/fio/write-read-verify.fio
             '

--- a/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/util/docker/DOCKERFILE.ais_ci_rocky
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
 ARG ROCKY_MAJOR_VERSION
 ARG ROCKY_VERSION
-ARG ROCm_VERSION=7.1.1
+ARG ROCm_VERSION=7.2
 
 # Update repo and install program dependencies.
 # microdnf is too stripped down, install full dnf.

--- a/util/docker/DOCKERFILE.ais_ci_suse
+++ b/util/docker/DOCKERFILE.ais_ci_suse
@@ -8,7 +8,7 @@ FROM opensuse/leap:${SUSE_VERSION}
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG SUSE_MAJOR_VERSION
 ARG SUSE_VERSION
-ARG ROCm_VERSION=7.1.1
+ARG ROCm_VERSION=7.2
 
 # The initial pull takes some time. Expect ~2.5 minutes to complete.
 RUN zypper refresh

--- a/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG UBUNTU_CODENAME
 ARG UBUNTU_MAJOR_VERSION=24
 ARG UBUNTU_MINOR_VERSION=04
-ARG ROCm_VERSION=7.1.1
+ARG ROCm_VERSION=7.2
 
 RUN apt update && \
     apt install -y \


### PR DESCRIPTION
All lower-level features that hipFile needs for AIS are contained within ROCm 7.2.