### PR TITLE
CI: Fix build_AIS workflow for non-PR triggers.

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -65,8 +65,9 @@ jobs:
           echo "AIS_SAFE_COMPILER_NAME=$(echo ${AIS_INPUT_CXX_COMPILER} | sed 's|[\+]|plus|g')" >> "${GITHUB_ENV}"
       - name: Set AIS CI container name
         # We should expect that there are multiple instances of this job with different cxx_compilers.
+        # On non-pull_request triggering workflows, AIS_PR_NUMBER may be empty.
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${AIS_INPUT_PLATFORM}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER:=${{ github.run_id }}}_${{ github.job }}_${AIS_INPUT_PLATFORM}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
       - name: Fetching code repository...
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
         with:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,10 +1,12 @@
 name: nightly-release
 run-name: Create a nightly release of hipFile
-
 on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
build_AIS was written with the assumption only PRs would trigger the workflow to be run. This is no longer the case with our nightly release workflow. As such, ${AIS_PR_NUMBER} resolves to an empty string which makes ${AIS_CONTAINER_NAME} invalid as it starts with a '_' character.

To fix this, we will now provide a fallback when ${AIS_PR_NUMBER} is empty. This is set the workflow Run ID which is unique to the triggering event. If the workflow is re-run, this ID is reused. To cover this, we add a concurrency tag to only allow one single instance of the nightly release workflow to run at a time.

I'll test this by trying to trigger a manual workflow.