### PR TITLE
CI: Remove rocthrust development package from CI images.

### DIFF
--- a/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/util/docker/DOCKERFILE.ais_ci_rocky
@@ -48,7 +48,6 @@ EOF
 # clang version == 19
 # libssl-dev == openssl-devel
 # llvm-dev == llvm-devel
-# librocthrust-dev == rocthrust-devel
 # Defaults to gcc11. On 9.6 gcc14 seems to be present.
 #   Use gcc13 to match Ubuntu24.
 RUN dnf makecache && \
@@ -64,7 +63,6 @@ RUN dnf makecache && \
         libmount-devel \
         llvm-devel \
         openssl-devel \
-        rocthrust-devel \
         rpm-build
 
 # Configure system linker for ROCm

--- a/util/docker/DOCKERFILE.ais_ci_suse
+++ b/util/docker/DOCKERFILE.ais_ci_suse
@@ -61,7 +61,6 @@ RUN zypper install -y \
         libopenssl-devel \
         llvm19-devel \
         rocm-device-libs \
-        rocthrust-devel \
         rpm-build
 
 # Configure system linker for ROCm

--- a/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -41,7 +41,6 @@ RUN apt update && \
         hip-dev \
         libboost-program-options-dev \
         libmount-dev \
-        librocthrust-dev \
         libssl-dev \
         llvm-dev \
         rocm-llvm-dev


### PR DESCRIPTION
We are not currently using this package for any testing.  On Ubuntu, this was causing runtime issues, as we were accidentally selecting librocthrust-dev (instead of rocthrust-dev).  This is an older Ubuntu supplied version of the library that installed some older HIP libraries with it.