### PR TITLE
CI/CMake: Add ROCm build environment variables to the build process.

### DIFF
--- a/.github/workflows/ais-ci.yml
+++ b/.github/workflows/ais-ci.yml
@@ -6,6 +6,10 @@ on:
       platform:
         required: true
         type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version."
+        required: true
+        type: string
 permissions:
   contents: read
   packages: read
@@ -32,6 +36,7 @@ jobs:
     with:
       dockerfile_changed: ${{ needs.AIS_CI_Pre-check.outputs.changed_dockerfile == '1' }}
       platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}
   build_and_test:
     # cancelled() needed. Otherwise success() implicitly added and fails if build_AIS_CI_image skipped.
     if: ${{ !cancelled() && needs.build_AIS_CI_image.outputs.ci_image_build_satisfied == 'true' }}
@@ -41,6 +46,7 @@ jobs:
       ci_image: ${{ needs.build_AIS_CI_image.outputs.ci_image }}
       cxx_compiler: amdclang++
       platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}
       upload_artifacts: true
   build_and_test_other_compilers:
     # Try building on other compilers, but keep as separate job.
@@ -59,6 +65,7 @@ jobs:
       ci_image: ${{ needs.build_AIS_CI_image.outputs.ci_image }}
       cxx_compiler: ${{ matrix.cxx_compiler }}
       platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}
   AIS_system_tests:
     # cancelled() needed. Otherwise success() implicitly added and fails if the chained
     # dependency build_AIS_CI_image is skipped.
@@ -70,6 +77,7 @@ jobs:
       ais_hipfile_pkg_filename: ${{ needs.build_and_test.outputs.ais_hipfile_pkg_filename }}
       ci_image: ${{ needs.build_and_test.outputs.ci_image }}
       platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}
   build_and_test_Nvidia:
     if: ${{ !cancelled() && needs.build_AIS_CI_image.outputs.ci_image_build_satisfied == 'true' }}
     needs: [AIS_CI_Pre-check, build_AIS_CI_image]
@@ -77,3 +85,4 @@ jobs:
     with:
       ci_image: ${{ needs.build_AIS_CI_image.outputs.ci_image }}
       platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/build-ais-ci-image.yml
+++ b/.github/workflows/build-ais-ci-image.yml
@@ -3,6 +3,7 @@ run-name: Build the Docker image for AIS CI.
 env:
   AIS_CI_IMAGE_NAME: ais_ci_${{ inputs.platform }}
   AIS_DOCKER_REGISTRY: ghcr.io/rocm/hipfile
+  AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
   AIS_PR_BASE_URL: https://github.com/ROCm/hipFile/pull
 on:
   workflow_call:
@@ -18,6 +19,10 @@ on:
       platform:
         required: true
         type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version."
+        required: true
+        type: string
     outputs:
       ci_image:
         description: |
@@ -26,7 +31,7 @@ on:
           Otherwise, returns the current CI image name & tag.
         value: >-
           ${{ 
-            jobs.build_AIS_image.result == 'skipped' && format('ghcr.io/rocm/hipfile/ais_ci_{0}:latest', inputs.platform) ||
+            jobs.build_AIS_image.result == 'skipped' && format('ghcr.io/rocm/hipfile/ais_ci_{0}:latest-rocm{1}', inputs.platform, inputs.rocm_version) ||
             jobs.build_AIS_image.result == 'success' && jobs.build_AIS_image.outputs.new_ci_image ||
             null
           }}
@@ -59,14 +64,14 @@ jobs:
     steps:
       - name: Set CI environment variables
         run: |
-          echo "AIS_CI_IMAGE_TAG=$(echo ${{ github.ref }} | sed 's|[^a-zA-Z0-9]|-|g')" >> "${GITHUB_ENV}"
+          echo "AIS_CI_IMAGE_TAG=$(echo ${{ github.ref }} | sed 's|[^a-zA-Z0-9]|-|g')-rocm${AIS_INPUT_ROCM_VERSION}" >> "${GITHUB_ENV}"
           echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
       - name: Set target AIS CI Image
         id: ci-image
         run: |
           echo "AIS_CI_IMAGE=${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:${AIS_CI_IMAGE_TAG}" \
             >> "${GITHUB_OUTPUT}"
-          echo "AIS_CI_LATEST_CACHE=${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-cache" \
+          echo "AIS_CI_LATEST_CACHE=${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${AIS_INPUT_ROCM_VERSION}-cache" \
             >> "${GITHUB_OUTPUT}"
       - name: Fetching code repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
@@ -91,6 +96,7 @@ jobs:
               ${{ github.head_ref }} for PR #${AIS_PR_NUMBER}. \
               PR URL: ${AIS_PR_BASE_URL}/${AIS_PR_NUMBER}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg ROCM_VERSION=${AIS_INPUT_ROCM_VERSION} \
             --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
             --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_LATEST_CACHE }}" \
             --push \

--- a/.github/workflows/build-ais-nvidia.yml
+++ b/.github/workflows/build-ais-nvidia.yml
@@ -3,6 +3,7 @@ run-name: Build AIS for Nvidia platforms
 env:
   AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
   AIS_INPUT_PLATFORM: ${{ inputs.platform }}
+  AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
   AIS_MOUNT_PATH: /mnt/ais/ext4
 on:
   workflow_call:
@@ -11,6 +12,10 @@ on:
         required: true
         type: string
       platform:
+        required: true
+        type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version."
         required: true
         type: string
 permissions:
@@ -34,7 +39,7 @@ jobs:
           echo "AIS_SAFE_COMPILER_NAME=$(echo ${AIS_INPUT_CXX_COMPILER} | sed 's|[\+]|plus|g')" >> "${GITHUB_ENV}"
       - name: Set AIS CI container name
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${AIS_INPUT_PLATFORM}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
       - name: Fetching code repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -126,6 +126,7 @@ jobs:
               mkdir /ais/hipFile/build
             '
       - name: Generate build files for hipFile targeting the AMD platform (${{ inputs.cxx_compiler }})
+        # ${SLES_BUILD_ID} is mentioned for all platforms to match current ROCm build implementation.
         run: |
           docker exec \
             -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -16,7 +16,7 @@ env:
       inputs.platform == 'ubuntu' && 'apt'
     }}
   AIS_PKG_TYPE: ${{ inputs.platform == 'ubuntu' && 'DEB' || 'RPM' }}
-  AIS_ROCM_VERSION: 7.2.0
+  AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
   # Code coverage report only vetted to work for amdclang++ on Ubuntu
   AIS_USE_CODE_COVERAGE: ${{ inputs.cxx_compiler == 'amdclang++' && inputs.platform == 'ubuntu' }}
 on:
@@ -38,6 +38,10 @@ on:
         required: false
         type: string
       platform:
+        required: true
+        type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version."
         required: true
         type: string
       upload_artifacts:
@@ -75,6 +79,7 @@ jobs:
         # - BUILD_ID
         # - SLES_BUILD_ID_PREFIX (will be instead be set in SUSE based DOCKERFILE's)
         # - CPACK_<TYPE>_PACKAGE_RELEASE (made up of the above)
+        # - ROCM_VERSION (set in DOCKERFILE)
         # See: https://github.com/ROCm/ROCm/blob/8aa43d132f0d541eb5303dc532f5931cb80ad87a/tools/rocm-build/envsetup.sh#L25-L42
         run: |
           echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
@@ -84,7 +89,7 @@ jobs:
         # We should expect that there are multiple instances of this job with different cxx_compilers.
         # On non-pull_request triggering workflows, AIS_PR_NUMBER may be empty.
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER:=${{ github.run_id }}}_${{ github.job }}_${AIS_INPUT_PLATFORM}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER:=${{ github.run_id }}}_${{ github.job }}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}_${AIS_SAFE_COMPILER_NAME}" >> "${GITHUB_ENV}"
       - name: Fetching code repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
@@ -124,7 +129,6 @@ jobs:
         run: |
           docker exec \
             -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
-            -e "_AIS_ROCM_VERSION=${AIS_ROCM_VERSION}" \
             -e "BUILD_ID=${AIS_INPUT_BUILD_ID}" \
             -e "JOB_DESIGNATOR=${AIS_INPUT_JOB_DESIGNATOR}" \
             -t \
@@ -139,7 +143,7 @@ jobs:
                 -DCMAKE_HIP_PLATFORM=amd \
                 -DAIS_BUILD_DOCS=ON \
                 -DAIS_USE_CODE_COVERAGE=${{ env.AIS_USE_CODE_COVERAGE == 'true' && 'ON' || 'OFF' }} \
-                -DROCM_PATH="/opt/rocm-${_AIS_ROCM_VERSION}" \
+                -DROCM_VERSION="${ROCM_VERSION}" \
                 ..
             '
       - name: Build hipFile for the AMD platform (${{ inputs.cxx_compiler }})

--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -2,8 +2,10 @@ name: build_and_test
 run-name: Build, Test, and Analyze AIS
 env:
   AIS_GHA_CMD_FILES_DOCKER_DIR: /root/github
+  AIS_INPUT_BUILD_ID: ${{ inputs.build_id }}
   AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
   AIS_INPUT_CXX_COMPILER: ${{ inputs.cxx_compiler }}
+  AIS_INPUT_JOB_DESIGNATOR: ${{ inputs.job_designator }}
   AIS_INPUT_PLATFORM: ${{ inputs.platform }}
   AIS_INPUT_UPLOAD_ARTIFACTS: ${{ inputs.upload_artifacts }}
   AIS_MOUNT_PATH: /mnt/ais/ext4
@@ -20,11 +22,20 @@ env:
 on:
   workflow_call:
     inputs:
+      build_id:
+        default: 9999
+        description: "Number assigned by the build orchestrator."
+        required: false
+        type: number
       ci_image:
         required: true
         type: string
       cxx_compiler:
         required: true
+        type: string
+      job_designator:
+        description: "Qualifies the type of job building hipFile."
+        required: false
         type: string
       platform:
         required: true
@@ -59,6 +70,12 @@ jobs:
     runs-on: [ubuntu-24.04]
     steps:
       - name: Set early AIS CI environment variables
+        # ROCm Build Environment Args
+        # - JOB_DESIGNATOR
+        # - BUILD_ID
+        # - SLES_BUILD_ID_PREFIX (will be instead be set in SUSE based DOCKERFILE's)
+        # - CPACK_<TYPE>_PACKAGE_RELEASE (made up of the above)
+        # See: https://github.com/ROCm/ROCm/blob/8aa43d132f0d541eb5303dc532f5931cb80ad87a/tools/rocm-build/envsetup.sh#L25-L42
         run: |
           echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
           echo "AIS_GHA_CMD_FILES_DIR=${GITHUB_ENV%/*}" >> "${GITHUB_ENV}"
@@ -108,10 +125,14 @@ jobs:
           docker exec \
             -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
             -e "_AIS_ROCM_VERSION=${AIS_ROCM_VERSION}" \
+            -e "BUILD_ID=${AIS_INPUT_BUILD_ID}" \
+            -e "JOB_DESIGNATOR=${AIS_INPUT_JOB_DESIGNATOR}" \
             -t \
             -w /ais/hipFile/build \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
+              export CPACK_DEBIAN_PACKAGE_RELEASE="${JOB_DESIGNATOR}${SLES_BUILD_ID_PREFIX}${BUILD_ID}~$(source /etc/os-release && echo ${VERSION_ID})"
+              export CPACK_RPM_PACKAGE_RELEASE="${JOB_DESIGNATOR}${SLES_BUILD_ID_PREFIX}${BUILD_ID}"
               cmake \
                 -DCMAKE_CXX_COMPILER="${_AIS_INPUT_CXX_COMPILER}" \
                 -DCMAKE_CXX_FLAGS="-Werror" \

--- a/.github/workflows/nightly-build-ais.yml
+++ b/.github/workflows/nightly-build-ais.yml
@@ -6,6 +6,10 @@ on:
       platform:
         required: true
         type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version."
+        required: true
+        type: string
     outputs:
       ais_hipfile_pkg_dev_filename:
         description: "Filename for the hipFile development DEB/RPM package."
@@ -23,6 +27,7 @@ jobs:
     with:
       dockerfile_changed: false
       platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}
   build_hipFile:
     if: ${{ !cancelled() && needs.get_AIS_CI_image.outputs.ci_image_build_satisfied == 'true' }}
     needs: [get_AIS_CI_image]
@@ -32,3 +37,4 @@ jobs:
       cxx_compiler: amdclang++
       platform: ${{ inputs.platform }}
       upload_artifacts: true
+      rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/nightly-build-ais.yml
+++ b/.github/workflows/nightly-build-ais.yml
@@ -35,6 +35,7 @@ jobs:
     with:
       ci_image: ${{ needs.get_AIS_CI_image.outputs.ci_image }}
       cxx_compiler: amdclang++
+      job_designator: "nightly."
       platform: ${{ inputs.platform }}
       upload_artifacts: true
       rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -22,9 +22,12 @@ jobs:
           - rocky
           - suse
           - ubuntu
+        rocm_versions:
+          - 7.2.0
     uses: ./.github/workflows/nightly-build-ais.yml
     with:
       platform: ${{ matrix.platform }}
+      rocm_version: ${{ matrix.rocm_versions }}
   publish_release:
     needs: [build_nightly_hipFile]
     runs-on: [ubuntu-24.04]
@@ -69,7 +72,7 @@ jobs:
               Nightly Build as of: $(date)
 
               The packages contained here are not suitable for production workloads.
-              These packages are currently tied to the current version of our CI (7.2).
+              Please see the filename for which version of ROCm the hipFile package belongs to.
             " \
             --prerelease \
             --target develop \

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -28,6 +28,9 @@ jobs:
           - rocky
           - suse
           - ubuntu
+        rocm_versions:
+          - 7.2.0
     uses: ./.github/workflows/ais-ci.yml
     with:
       platform: ${{ matrix.supported_platforms }}
+      rocm_version: ${{ matrix.rocm_versions }}

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -6,6 +6,7 @@ env:
   AIS_INPUT_HIPFILE_PKG_FILENAME: ${{ inputs.ais_hipfile_pkg_filename }}
   AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
   AIS_INPUT_PLATFORM: ${{ inputs.platform }}
+  AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
   AIS_MOUNT_PATH: /mnt/ais/ext4
   AIS_PKG_MGR: >-
     ${{
@@ -28,6 +29,10 @@ on:
       platform:
         required: true
         type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version."
+        required: true
+        type: string
 permissions:
   contents: read
   packages: read
@@ -39,7 +44,7 @@ jobs:
         run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
       - name: Set AIS CI container name
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${AIS_INPUT_PLATFORM}" >> "${GITHUB_ENV}"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}" >> "${GITHUB_ENV}"
       - name: Fetching hipFile repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
@@ -184,7 +189,7 @@ jobs:
             -w /ais/fio/build \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              ROCM=/opt/rocm \
+              ROCM=/opt/rocm-${ROCM_VERSION} \
               HIPFILE=/ais/hipFile \
               HIPFILELIB=${HIPFILE}/build/src/amd_detail/ \
               HIP_PLATFORM=amd \

--- a/.github/workflows/update-ais-ci-image.yml
+++ b/.github/workflows/update-ais-ci-image.yml
@@ -36,6 +36,8 @@ jobs:
           - rocky
           - suse
           - ubuntu
+        rocm_versions:
+          - 7.2.0
     steps:
       - name: Fetching code repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
@@ -48,7 +50,7 @@ jobs:
       - name: Set target AIS CI Image
         id: ci-image
         run: |
-          echo "AIS_CI_IMAGE=${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest" \
+          echo "AIS_CI_IMAGE=${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${{ matrix.rocm_versions }}" \
             >> "${GITHUB_OUTPUT}"
       - name: Set Docker Cache Instruction
         id: use-cache
@@ -74,7 +76,8 @@ jobs:
           docker buildx build \
             -f "${GITHUB_WORKSPACE}/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
             --label "org.opencontainers.image.description= \
-              Latest AIS CI Image for ${AIS_INPUT_PLATFORM}." \
+              Latest AIS CI Image for ${AIS_INPUT_PLATFORM} using ROCm ${{ matrix.rocm_versions }}." \
+            --build-arg ROCM_VERSION=${{ matrix.rocm_versions }} \
             --cache-to=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE }}-cache" \
             ${{ steps.use-cache.outputs.CACHE_FROM_CMD }} \
             --push \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,15 +97,43 @@ endif()
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 #-----------------------------------------------------------------------------
-# Set the path to ROCm
+# Set ROCm Version and Install Path
+#
+# Values are set with the following prioritization in case of redundant declarations:
+# 1) CMake Argument
+# 2) Environment Variables
+# 3) Default Values
+#
+# Note: project(... LANGUAGES HIP) only looks at $ENV{ROCM_PATH} and will ignore
+#       ROCM_PATH set as a CMake Argument.
 #-----------------------------------------------------------------------------
+# If ROCM_VERSION was set in the environment, seed it with that
+if(NOT DEFINED ROCM_VERSION AND DEFINED ENV{ROCM_VERSION})
+    set(ROCM_VERSION "$ENV{ROCM_VERSION}")
+endif()
+
 # If ROCM_PATH was set in the environment, seed it with that
 if(DEFINED ENV{ROCM_PATH})
     set(ROCM_INITIAL_PATH "$ENV{ROCM_PATH}")
+elseif(DEFINED ROCM_VERSION)
+    # Infer default based on ROCM_VERSION
+    set(ROCM_INITIAL_PATH "/opt/rocm-${ROCM_VERSION}")
 else()
+    # Default install location symlink
     set(ROCM_INITIAL_PATH "/opt/rocm")
 endif()
 set(ROCM_PATH "${ROCM_INITIAL_PATH}" CACHE PATH "The path to the ROCm installation")
+
+# Fallback if ROCM_VERSION not specified. Get from version file in ROCM_PATH
+if(NOT DEFINED ROCM_VERSION)
+    file(READ "${ROCM_PATH}/.info/version" _rocm_version_file)
+    string(REGEX MATCH "^([0-9]+\\.[0-9]+\\.[0-9]+)" _matched_rocm_version "${_rocm_version_file}")
+    set(ROCM_VERSION "${_matched_rocm_version}")
+endif()
+set(ROCM_VERSION "${ROCM_VERSION}" CACHE STRING "The version of ROCm to build with")
+
+message(STATUS "Using ROCM_VERSION: ${ROCM_VERSION}")
+message(STATUS "ROCM_PATH set to: ${ROCM_PATH}")
 
 # Add ROCm search paths
 list(APPEND CMAKE_PREFIX_PATH

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -75,6 +75,27 @@ set(CPACK_PACKAGE_RELOCATABLE OFF)
 set(CPACK_RPM_PACKAGE_RELOCATABLE OFF)
 set(CPACK_DEB_PACKAGE_RELOCATABLE OFF)
 
+# Set DEB/RPM Release Information
+# rocm_create_package checks if following variables are defined in the environment:
+#   - CPACK_DEBIAN_PACKAGE_RELEASE
+#   - CPACK_RPM_PACKAGE_RELEASE
+#   - ROCM_LIBPATCH_VERSION
+# If ENV{CPACK_*_PACKAGE_RELEASE} is not defined, it will fallback to use ${PROJECT_VERSION_TWEAK}.
+# See https://github.com/ROCm/ROCm/blob/8aa43d132f0d541eb5303dc532f5931cb80ad87a/tools/rocm-build/envsetup.sh#L77-L78
+# If ENV{ROCM_LIBPATCH_VERSION} is not defined, the ROCm version will not be appended to the project version.
+# ROCM_LIBPATCH_VERSION is ROCM_VERSION with '.' replaced by '0'.
+# See: https://github.com/ROCm/ROCm/blob/8aa43d132f0d541eb5303dc532f5931cb80ad87a/tools/rocm-build/envsetup.sh#L94
+
+if(NOT DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE} AND NOT DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
+    set(PROJECT_VERSION_TWEAK "local")
+endif()
+
+# Let's prefer to include the ROCm Version even on a non-release build.
+if(NOT DEFINED ENV{ROCM_LIBPATCH_VERSION})
+    string(REPLACE "." "0" _rocm_libpatch_version "${ROCM_VERSION}")
+    set(ENV{ROCM_LIBPATCH_VERSION} "${_rocm_libpatch_version}")
+endif()
+
 # Create the package
 #
 # Note that you will just get a dev package if you have BUILD_SHARED_LIBS

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -90,7 +90,7 @@ if(NOT DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE} AND NOT DEFINED ENV{CPACK_RPM_P
     set(PROJECT_VERSION_TWEAK "local")
 endif()
 
-# Let's prefer to include the ROCm Version even on a non-release build.
+# Prefer to include the ROCm libpatch version even on a non-release build.
 if(NOT DEFINED ENV{ROCM_LIBPATCH_VERSION})
     string(REPLACE "." "0" _rocm_libpatch_version "${ROCM_VERSION}")
     set(ENV{ROCM_LIBPATCH_VERSION} "${_rocm_libpatch_version}")

--- a/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/util/docker/DOCKERFILE.ais_ci_rocky
@@ -40,7 +40,9 @@ RUN microdnf install -y \
 #     dnf install -y ./amdgpu_install.rpm
 # Method 2: Manually create repo file.
 
-# ROCM_PKG_REPO_VERSION removes the version PATCH if it equals 0.
+# ROCM_PKG_REPO_VERSION normalizes the ROCm version used in the package repo URL.
+# If the PATCH component is 0, the PATCH of the version is dropped. Otherwise no
+# modification is made.
 RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
     cat <<EOF > /etc/yum.repos.d/rocm.repo
 [ROCm-${ROCM_VERSION}]

--- a/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/util/docker/DOCKERFILE.ais_ci_rocky
@@ -9,7 +9,12 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
 ARG ROCKY_MAJOR_VERSION
 ARG ROCKY_VERSION
-ARG ROCm_VERSION=7.2
+ARG ROCM_VERSION=7.2.0
+
+# If the target ROCm Version on the package repository is non-standard, you can forcibly
+# set the ROCm version used in the package repo URL.
+# Ex. Package 7.0_alpha installs 7.0.0
+ARG ROCM_PKG_REPO_OVERRIDE
 
 # Update repo and install program dependencies.
 # microdnf is too stripped down, install full dnf.
@@ -34,10 +39,13 @@ RUN microdnf install -y \
 #         -o amdgpu_install.rpm && \
 #     dnf install -y ./amdgpu_install.rpm
 # Method 2: Manually create repo file.
-RUN cat <<EOF > /etc/yum.repos.d/rocm.repo
-[ROCm-${ROCm_VERSION}]
-name=ROCm${ROCm_VERSION}
-baseurl=https://repo.radeon.com/rocm/el${ROCKY_MAJOR_VERSION}/${ROCm_VERSION}/main
+
+# ROCM_PKG_REPO_VERSION removes the version PATCH if it equals 0.
+RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
+    cat <<EOF > /etc/yum.repos.d/rocm.repo
+[ROCm-${ROCM_VERSION}]
+name=ROCm${ROCM_VERSION}
+baseurl=https://repo.radeon.com/rocm/el${ROCKY_MAJOR_VERSION}/${ROCM_PKG_REPO_VERSION}/main
 enabled=1
 priority=50
 gpgcheck=1
@@ -93,6 +101,9 @@ RUN dnf module enable -y nvidia-driver:570-open && \
 
 # Add ROCm and CUDA bin directories to the path
 ENV PATH=/usr/local/cuda/bin:/opt/rocm/bin:${PATH}
+
+# Environment Build Arg for ROCm
+ENV ROCM_VERSION="${ROCM_VERSION}"
 
 # .rc and .profile files are not automatically read on non-login,
 # non-interactive shells. Tell Bash to read a minimal .profile

--- a/util/docker/DOCKERFILE.ais_ci_suse
+++ b/util/docker/DOCKERFILE.ais_ci_suse
@@ -8,7 +8,12 @@ FROM opensuse/leap:${SUSE_MAJOR_VERSION}.${SUSE_MINOR_VERSION}
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG SUSE_MAJOR_VERSION
 ARG SUSE_MINOR_VERSION
-ARG ROCm_VERSION=7.2
+ARG ROCM_VERSION=7.2.0
+
+# If the target ROCm Version on the package repository is non-standard, you can forcibly
+# set the ROCm version used in the package repo URL.
+# Ex. Package 7.0_alpha installs 7.0.0
+ARG ROCM_PKG_REPO_OVERRIDE
 
 # The initial pull takes some time. Expect ~2.5 minutes to complete.
 RUN zypper refresh
@@ -29,10 +34,13 @@ RUN zypper refresh
 #         -o amdgpu_install.rpm && \
 #     dnf install -y ./amdgpu_install.rpm
 # Method 2: Manually create repo file.
-RUN cat <<EOF > /etc/zypp/repos.d/rocm.repo
-[ROCm-${ROCm_VERSION}]
-name=ROCm${ROCm_VERSION}
-baseurl=https://repo.radeon.com/rocm/zyp/${ROCm_VERSION}/main
+
+# ROCM_PKG_REPO_VERSION removes the version PATCH if it equals 0.
+RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
+    cat <<EOF > /etc/zypp/repos.d/rocm.repo
+[ROCm-${ROCM_VERSION}]
+name=ROCm${ROCM_VERSION}
+baseurl=https://repo.radeon.com/rocm/zyp/${ROCM_PKG_REPO_VERSION}/main
 enabled=1
 priority=50
 gpgcheck=1
@@ -95,6 +103,7 @@ RUN zypper install -y \
 ENV PATH=/usr/local/cuda/bin:/opt/rocm/bin:${PATH}
 
 # Environment Build Arg for ROCm Packaging
+ENV ROCM_VERSION="${ROCM_VERSION}"
 ENV SLES_BUILD_ID_PREFIX="opensuse${SUSE_MAJOR_VERSION}${SUSE_MINOR_VERSION}."
 
 # Configure SUSE to use the GCC-13 by default.

--- a/util/docker/DOCKERFILE.ais_ci_suse
+++ b/util/docker/DOCKERFILE.ais_ci_suse
@@ -35,7 +35,9 @@ RUN zypper refresh
 #     dnf install -y ./amdgpu_install.rpm
 # Method 2: Manually create repo file.
 
-# ROCM_PKG_REPO_VERSION removes the version PATCH if it equals 0.
+# ROCM_PKG_REPO_VERSION normalizes the ROCm version used in the package repo URL.
+# If the PATCH component is 0, the PATCH of the version is dropped. Otherwise no
+# modification is made.
 RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
     cat <<EOF > /etc/zypp/repos.d/rocm.repo
 [ROCm-${ROCM_VERSION}]

--- a/util/docker/DOCKERFILE.ais_ci_suse
+++ b/util/docker/DOCKERFILE.ais_ci_suse
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: MIT
 
 ARG SUSE_MAJOR_VERSION=15
-ARG SUSE_VERSION=${SUSE_MAJOR_VERSION}.6
-FROM opensuse/leap:${SUSE_VERSION}
+ARG SUSE_MINOR_VERSION=6
+FROM opensuse/leap:${SUSE_MAJOR_VERSION}.${SUSE_MINOR_VERSION}
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG SUSE_MAJOR_VERSION
-ARG SUSE_VERSION
+ARG SUSE_MINOR_VERSION
 ARG ROCm_VERSION=7.2
 
 # The initial pull takes some time. Expect ~2.5 minutes to complete.
@@ -93,6 +93,9 @@ RUN zypper install -y \
 
 # Add ROCm and CUDA bin directories to the path
 ENV PATH=/usr/local/cuda/bin:/opt/rocm/bin:${PATH}
+
+# Environment Build Arg for ROCm Packaging
+ENV SLES_BUILD_ID_PREFIX="opensuse${SUSE_MAJOR_VERSION}${SUSE_MINOR_VERSION}."
 
 # Configure SUSE to use the GCC-13 by default.
 # Uncomment to use newer version of GCC.

--- a/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -25,7 +25,9 @@ RUN curl https://repo.radeon.com/rocm/rocm.gpg.key | \
     gpg --dearmor >> /etc/apt/keyrings/rocm.gpg
 
 # Manually setup ROCm Package Repos
-# ROCM_PKG_REPO_VERSION removes the version PATCH if it equals 0.
+# ROCM_PKG_REPO_VERSION normalizes the ROCm version used in the package repo URL.
+# If the PATCH component is 0, the PATCH of the version is dropped. Otherwise no
+# modification is made.
 RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
     cat <<EOF > /etc/apt/sources.list.d/rocm.list
 deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_PKG_REPO_VERSION} ${UBUNTU_CODENAME} main

--- a/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -8,7 +8,12 @@ LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG UBUNTU_CODENAME
 ARG UBUNTU_MAJOR_VERSION=24
 ARG UBUNTU_MINOR_VERSION=04
-ARG ROCm_VERSION=7.2
+ARG ROCM_VERSION=7.2.0
+
+# If the target ROCm Version on the package repository is non-standard, you can forcibly
+# set the ROCm version used in the package repo URL.
+# Ex. Package 7.0_alpha installs 7.0.0
+ARG ROCM_PKG_REPO_OVERRIDE
 
 RUN apt update && \
     apt install -y \
@@ -20,8 +25,10 @@ RUN curl https://repo.radeon.com/rocm/rocm.gpg.key | \
     gpg --dearmor >> /etc/apt/keyrings/rocm.gpg
 
 # Manually setup ROCm Package Repos
-RUN cat <<EOF > /etc/apt/sources.list.d/rocm.list
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCm_VERSION} ${UBUNTU_CODENAME} main
+# ROCM_PKG_REPO_VERSION removes the version PATCH if it equals 0.
+RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
+    cat <<EOF > /etc/apt/sources.list.d/rocm.list
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_PKG_REPO_VERSION} ${UBUNTU_CODENAME} main
 EOF
 
 RUN cat <<EOF > /etc/apt/preferences.d/rocm-pin-600
@@ -69,6 +76,9 @@ RUN apt update && \
 
 # Add ROCm and CUDA bin directories to the path
 ENV PATH=/usr/local/cuda/bin:/opt/rocm/bin:${PATH}
+
+# Environment Build Arg for ROCm
+ENV ROCM_VERSION="${ROCM_VERSION}"
 
 # AIS Code Repository Mount Point
 VOLUME /mnt/ais


### PR DESCRIPTION
## Motivation

The ROCm build process sets certain build variables in the environment from a build orchestrator. These arguments are not strictly necessary for packaging; however, they are used to set a unified filename structure across all ROCm packages for a given release. These are not required though for building. `rocm-cmake` will only accept them through the environment and does not expose a way to provide them directly as a CMake function parameter.

This PR also sets which version of ROCm we are building against rather than just blindly using whatever the `/opt/rocm` symlink refers to. Should neither the ROCm Version or ROCm Path be set at configure time, we fallback to the `/opt/rocm` symlink and try to ascertain what version of ROCm is present.

We can then take this a step further by letting the CI control what version of ROCm we want to target, which gets passed into the DOCKERFILE to construct a CI image for a given platform with the target ROCm version installed. A default ROCm version is still specified in the DOCKERFILE's for convenience if someone is trying to build locally.

## Technical Details

Investigating other project's CMakeLists.txt and setupenv.sh in rocm-build.

## Test Plan

Does CI pass? Does the hipFile build artifacts filename structure now match what ROCm releases?
Does hipFile still build locally without specifying any of the new arguments/environment variables?

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

AIHIPFILE-97