### PR TITLE
hipfile: Allow buffer offsets when issuing IO to an unregistered buffer

### DIFF
--- a/.github/workflows/build-ais.yml
+++ b/.github/workflows/build-ais.yml
@@ -147,6 +147,7 @@ jobs:
                 -DAIS_BUILD_DOCS=ON \
                 -DAIS_USE_CODE_COVERAGE=${{ env.AIS_USE_CODE_COVERAGE == 'true' && 'ON' || 'OFF' }} \
                 -DROCM_VERSION="${ROCM_VERSION}" \
+                -DAIS_CAPABLE_DIR=/mnt/ais-fs \
                 ..
             '
       - name: Build hipFile for the AMD platform (${{ inputs.cxx_compiler }})

--- a/src/amd_detail/batch/batch.cpp
+++ b/src/amd_detail/batch/batch.cpp
@@ -122,8 +122,8 @@ BatchContext::submit_operations(const hipFileIOParams_t *params, unsigned num_pa
         auto param_copy = std::make_unique<const hipFileIOParams_t>(params[i]);
         // flags currently unused. Ambiguous if flags in hipFileBatchIOSubmit is for buffer or
         // file flags.
-        auto [_file, _buffer] = Context<DriverState>::get()->getFileAndBuffer(
-            param_copy->fh, param_copy->u.batch.devPtr_base, param_copy->u.batch.size, 0);
+        auto [_file, _buffer] =
+            Context<DriverState>::get()->getFileAndBuffer(param_copy->fh, param_copy->u.batch.devPtr_base);
         auto op = std::make_shared<BatchOperation>(std::move(param_copy), _buffer, _file);
 
         pending_ops.push_back(op);

--- a/src/amd_detail/buffer.cpp
+++ b/src/amd_detail/buffer.cpp
@@ -149,6 +149,7 @@ shared_ptr<IBuffer>
 BufferMap::getBuffer(const void *buf, size_t length, int flags)
 {
     (void)flags;
+    (void)length;
 
     auto itr = from_ptr.find(buf);
 
@@ -157,11 +158,6 @@ BufferMap::getBuffer(const void *buf, size_t length, int flags)
         return std::shared_ptr<IBuffer>(new Buffer(buf, PassKey<BufferMap>{}));
     }
     else {
-        // If we found a registered buffer, it's an error if the
-        // length parameter doesn't match what we found
-        if (itr->second->getLength() < length) {
-            throw std::invalid_argument("bad length parameter");
-        }
         return itr->second;
     }
 }

--- a/src/amd_detail/buffer.cpp
+++ b/src/amd_detail/buffer.cpp
@@ -135,7 +135,7 @@ BufferMap::deregisterBuffer(const void *buf)
 }
 
 shared_ptr<IBuffer>
-BufferMap::getBuffer(const void *buf)
+BufferMap::getRegisteredBuffer(const void *buf)
 {
     auto itr = from_ptr.find(buf);
     if (from_ptr.end() == itr) {

--- a/src/amd_detail/buffer.cpp
+++ b/src/amd_detail/buffer.cpp
@@ -60,6 +60,24 @@ Buffer::Buffer(const void *_buffer, size_t _length, int _flags, const PassKey<Bu
     }
 }
 
+Buffer::Buffer(const void *_buffer, const PassKey<BufferMap> &)
+    : buffer{const_cast<void *>(_buffer)}, length{}, flags{}
+{
+    if (!buffer) {
+        throw std::invalid_argument("Buffer pointer cannot be null.");
+    }
+
+    hipPointerAttribute_t _attrs = Context<Hip>::get()->hipPointerGetAttributes(buffer);
+    if (_attrs.type != hipMemoryTypeDevice) {
+        throw InvalidMemoryType();
+    }
+    type   = _attrs.type;
+    gpu_id = _attrs.device;
+
+    HipMemAddressRange range{Context<Hip>::get()->hipMemGetAddressRange(buffer)};
+    length = range.size - (reinterpret_cast<uintptr_t>(buffer) - reinterpret_cast<uintptr_t>(range.base));
+}
+
 void *
 Buffer::getBuffer() const
 {
@@ -130,12 +148,13 @@ BufferMap::getBuffer(const void *buf)
 shared_ptr<IBuffer>
 BufferMap::getBuffer(const void *buf, size_t length, int flags)
 {
+    (void)flags;
+
     auto itr = from_ptr.find(buf);
 
     if (from_ptr.end() == itr) {
-        // If the buffer hasn't been registered, use an unregistered
-        // temporary Buffer object
-        return std::shared_ptr<IBuffer>(new Buffer(buf, length, flags, PassKey<BufferMap>{}));
+        // Create a temporary buffer
+        return std::shared_ptr<IBuffer>(new Buffer(buf, PassKey<BufferMap>{}));
     }
     else {
         // If we found a registered buffer, it's an error if the

--- a/src/amd_detail/buffer.cpp
+++ b/src/amd_detail/buffer.cpp
@@ -146,11 +146,8 @@ BufferMap::getRegisteredBuffer(const void *buf)
 }
 
 shared_ptr<IBuffer>
-BufferMap::getBuffer(const void *buf, size_t length, int flags)
+BufferMap::getBuffer(const void *buf)
 {
-    (void)flags;
-    (void)length;
-
     auto itr = from_ptr.find(buf);
 
     if (from_ptr.end() == itr) {

--- a/src/amd_detail/buffer.h
+++ b/src/amd_detail/buffer.h
@@ -89,6 +89,14 @@ public:
     /// @param k  Key class instance (see passkey.h)
     Buffer(const void *buf, size_t length, int flags, const PassKey<BufferMap> &k);
 
+    /// @brief Creates a buffer.
+    ///
+    /// The length of the buffer is determined by querying the hip runtime
+    ///
+    /// @param buf Buffer pointer
+    /// @param k  Key class instance (see passkey.h)
+    Buffer(const void *buf, const PassKey<BufferMap> &k);
+
 private:
     /// @brief Pointer to a hip allocated buffer
     void *buffer;
@@ -129,7 +137,7 @@ public:
     virtual std::shared_ptr<IBuffer> getBuffer(const void *buf);
 
     /// @brief Look up a registered buffer. Returns a temporary unregistered
-    ///        buffer (of size length, using flags) if no matching buffer is found.
+    ///        buffer if no matching buffer is found.
     /// @attention A shared_lock on HipFileMutex must be held
     /// @param buf Buffer pointer
     /// @param length Buffer length

--- a/src/amd_detail/buffer.h
+++ b/src/amd_detail/buffer.h
@@ -134,7 +134,7 @@ public:
     /// @attention A shared_lock on HipFileMutex must be held
     /// @param buf Buffer pointer
     /// @return A registered buffer
-    virtual std::shared_ptr<IBuffer> getBuffer(const void *buf);
+    virtual std::shared_ptr<IBuffer> getRegisteredBuffer(const void *buf);
 
     /// @brief Look up a registered buffer. Returns a temporary unregistered
     ///        buffer if no matching buffer is found.

--- a/src/amd_detail/buffer.h
+++ b/src/amd_detail/buffer.h
@@ -137,12 +137,11 @@ public:
     virtual std::shared_ptr<IBuffer> getRegisteredBuffer(const void *buf);
 
     /// @brief Look up a registered buffer. Returns a temporary unregistered
-    ///        buffer if no matching buffer is found.
+    ///        buffer if no registered buffer is found.
     /// @attention A shared_lock on HipFileMutex must be held
     /// @param buf Buffer pointer
-    /// @param length Buffer length
     /// @return A registered or temporary unregistered buffer
-    virtual std::shared_ptr<IBuffer> getBuffer(const void *buf, size_t length, int flags);
+    virtual std::shared_ptr<IBuffer> getBuffer(const void *buf);
 
     virtual void clear();
 

--- a/src/amd_detail/hipfile.cpp
+++ b/src/amd_detail/hipfile.cpp
@@ -169,7 +169,7 @@ ssize_t
 hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
           hoff_t buffer_offset, const vector<shared_ptr<Backend>> &backends)
 try {
-    auto [file, buffer] = Context<DriverState>::get()->getFileAndBuffer(fh, buffer_base, size, 0);
+    auto [file, buffer] = Context<DriverState>::get()->getFileAndBuffer(fh, buffer_base);
     int                      score{-1};
     std::shared_ptr<Backend> backend{};
 
@@ -423,7 +423,7 @@ try {
     checkNull({buffer_base, size_p, file_offset_p, buffer_offset_p, bytes_transferred_p});
 
     auto [file, buffer, stream] =
-        Context<DriverState>::get()->getFileBufferAndStream(fh, buffer_base, *size_p, 0, hipStream);
+        Context<DriverState>::get()->getFileBufferAndStream(fh, buffer_base, hipStream);
     Fallback().async_io(io_type, file, buffer, size_p, file_offset_p, buffer_offset_p, bytes_transferred_p,
                         stream);
 

--- a/src/amd_detail/state.cpp
+++ b/src/amd_detail/state.cpp
@@ -92,7 +92,7 @@ DriverState::deregisterBuffer(const void *buf)
 }
 
 shared_ptr<IBuffer>
-DriverState::getBuffer(const void *buf)
+DriverState::getRegisteredBuffer(const void *buf)
 {
     unique_lock<shared_mutex> ulock{state_mutex};
 

--- a/src/amd_detail/state.cpp
+++ b/src/amd_detail/state.cpp
@@ -104,13 +104,13 @@ DriverState::getRegisteredBuffer(const void *buf)
 }
 
 shared_ptr<IBuffer>
-DriverState::getBuffer(const void *buf, size_t length, int flags)
+DriverState::getBuffer(const void *buf)
 {
     // NOTE: This mutex only protects the map, so we'll
     //       also need to protect the data
     shared_lock<shared_mutex> slock{state_mutex};
 
-    return buffer_map->getBuffer(buf, length, flags);
+    return buffer_map->getBuffer(buf);
 }
 
 //
@@ -190,7 +190,7 @@ DriverState::getStream(hipStream_t hip_stream)
 //
 
 file_buffer_pair
-DriverState::getFileAndBuffer(hipFileHandle_t fh, const void *buf, size_t length, int flags)
+DriverState::getFileAndBuffer(hipFileHandle_t fh, const void *buf)
 {
     // NOTE: This mutex only protects the map, so we'll
     //       also need to protect the data
@@ -200,7 +200,7 @@ DriverState::getFileAndBuffer(hipFileHandle_t fh, const void *buf, size_t length
         throw DriverNotInitialized();
     }
 
-    return {file_map->getFile(fh), buffer_map->getBuffer(buf, length, flags)};
+    return {file_map->getFile(fh), buffer_map->getBuffer(buf)};
 }
 
 //
@@ -208,8 +208,7 @@ DriverState::getFileAndBuffer(hipFileHandle_t fh, const void *buf, size_t length
 //
 
 file_buffer_stream_tuple
-DriverState::getFileBufferAndStream(hipFileHandle_t fh, const void *buf, size_t length, int flags,
-                                    hipStream_t hipStream)
+DriverState::getFileBufferAndStream(hipFileHandle_t fh, const void *buf, hipStream_t hipStream)
 {
     shared_lock<shared_mutex> slock{state_mutex};
 
@@ -217,8 +216,7 @@ DriverState::getFileBufferAndStream(hipFileHandle_t fh, const void *buf, size_t 
         throw DriverNotInitialized();
     }
 
-    return {file_map->getFile(fh), buffer_map->getBuffer(buf, length, flags),
-            stream_map->getStream(hipStream)};
+    return {file_map->getFile(fh), buffer_map->getBuffer(buf), stream_map->getStream(hipStream)};
 }
 
 //

--- a/src/amd_detail/state.cpp
+++ b/src/amd_detail/state.cpp
@@ -94,7 +94,7 @@ DriverState::deregisterBuffer(const void *buf)
 shared_ptr<IBuffer>
 DriverState::getRegisteredBuffer(const void *buf)
 {
-    unique_lock<shared_mutex> ulock{state_mutex};
+    shared_lock<shared_mutex> slock{state_mutex};
 
     if (ref_count == 0) {
         throw DriverNotInitialized();

--- a/src/amd_detail/state.cpp
+++ b/src/amd_detail/state.cpp
@@ -100,7 +100,7 @@ DriverState::getRegisteredBuffer(const void *buf)
         throw DriverNotInitialized();
     }
 
-    return buffer_map->getBuffer(buf);
+    return buffer_map->getRegisteredBuffer(buf);
 }
 
 shared_ptr<IBuffer>

--- a/src/amd_detail/state.h
+++ b/src/amd_detail/state.h
@@ -104,10 +104,8 @@ public:
     /// @brief Look up a registered buffer. Returns a temporary unregistered
     ///        buffer if no matching buffer is found.
     /// @param [in] buf Buffer pointer
-    /// @param [in] length Buffer length
-    /// @param [in] flags Buffer flags (unused)
     /// @return A registered or temporary unregistered buffer
-    virtual std::shared_ptr<IBuffer> getBuffer(const void *buf, size_t length, int flags);
+    virtual std::shared_ptr<IBuffer> getBuffer(const void *buf);
 
     //
     // File interface
@@ -158,19 +156,17 @@ public:
     /// This combined file + buffer getter reduces the number of lock calls.
     ///
     /// Like the buffer getter, this function emits a temporary unregistered buffer
-    /// (of size length, using flags) if no matching buffer is found.
+    /// if no matching registered buffer is found.
     ///
     /// @param [in]  fh      File handle
     /// @param [in]  buf     Buffer pointer
-    /// @param [in]  length  Buffer length
-    /// @param [in]  flags   Buffer flags (unused)
-    virtual file_buffer_pair getFileAndBuffer(hipFileHandle_t fh, const void *buf, size_t length, int flags);
+    virtual file_buffer_pair getFileAndBuffer(hipFileHandle_t fh, const void *buf);
 
     //
     // Buffer, file, and stream calls
     //
     virtual file_buffer_stream_tuple getFileBufferAndStream(hipFileHandle_t fh, const void *buf,
-                                                            size_t length, int flags, hipStream_t hipStream);
+                                                            hipStream_t hipStream);
 
     //
     // Reference counts

--- a/src/amd_detail/state.h
+++ b/src/amd_detail/state.h
@@ -102,7 +102,7 @@ public:
     virtual std::shared_ptr<IBuffer> getBuffer(const void *buf);
 
     /// @brief Look up a registered buffer. Returns a temporary unregistered
-    ///        buffer (of size length, using flags) if no matching buffer is found.
+    ///        buffer if no matching buffer is found.
     /// @param [in] buf Buffer pointer
     /// @param [in] length Buffer length
     /// @param [in] flags Buffer flags (unused)

--- a/src/amd_detail/state.h
+++ b/src/amd_detail/state.h
@@ -99,7 +99,7 @@ public:
     /// @brief Look up a registered buffer using the buffer pointer
     /// @param [in] buf Buffer pointer
     /// @return A registered buffer
-    virtual std::shared_ptr<IBuffer> getBuffer(const void *buf);
+    virtual std::shared_ptr<IBuffer> getRegisteredBuffer(const void *buf);
 
     /// @brief Look up a registered buffer. Returns a temporary unregistered
     ///        buffer if no matching buffer is found.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SYSTEM_TEST_SOURCE_FILES
     system/buffer.cpp
     system/config.cpp
     system/driver.cpp
+    system/io.cpp
     system/main.cpp
     system/version.cpp
 )

--- a/test/amd_detail/async.cpp
+++ b/test/amd_detail/async.cpp
@@ -380,20 +380,6 @@ TEST_P(HipFileReadWriteAsync, unregisteredFileReturnsError)
               HipFileOpError(hipFileHandleNotRegistered));
 }
 
-TEST_P(HipFileReadWriteAsync, registeredBufferLengthTooLongReturnsError)
-{
-    size_t bufferLength = 100;
-    expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    Context<DriverState>::get()->registerBuffer(nonnull_void, bufferLength, 0);
-    bufferLength++;
-    EXPECT_CALL(msys, statx);
-    EXPECT_CALL(msys, fcntl);
-    EXPECT_CALL(msys, open);
-    ASSERT_EQ(io_op(Context<DriverState>::get()->registerFile(0), nonnull_void, &bufferLength, nonnull_offset,
-                    nonnull_offset, nonnull_ssize, nonnull_stream),
-              HipFileOpError(hipFileInvalidValue));
-}
-
 TEST_P(HipFileReadWriteAsync, badAllocReturnsHipErrorOutOfMemory)
 {
     MDriverState driver;

--- a/test/amd_detail/buffer.cpp
+++ b/test/amd_detail/buffer.cpp
@@ -210,7 +210,7 @@ TEST_F(HipFileBuffer, deregister_internal_get_prevents_deregister)
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
     {
-        auto buffer = Context<DriverState>::get()->getBuffer(nonnull_ptr);
+        auto buffer = Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr);
         ASSERT_THROW(Context<DriverState>::get()->deregisterBuffer(nonnull_ptr), BufferOperationsOutstanding);
     }
     Context<DriverState>::get()->deregisterBuffer(nonnull_ptr);
@@ -222,7 +222,7 @@ TEST_F(HipFileBuffer, deregister_get_prevents_deregister)
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     ASSERT_EQ(hipFileBufRegister(nonnull_ptr, 0, 0), HIPFILE_SUCCESS);
     {
-        auto buffer = Context<DriverState>::get()->getBuffer(nonnull_ptr);
+        auto buffer = Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr);
         ASSERT_EQ(hipFileBufDeregister(nonnull_ptr), HipFileOpError(hipFileInternalError));
     }
     ASSERT_EQ(hipFileBufDeregister(nonnull_ptr), HIPFILE_SUCCESS);
@@ -230,7 +230,7 @@ TEST_F(HipFileBuffer, deregister_get_prevents_deregister)
 
 TEST_F(HipFileBuffer, get_not_registered)
 {
-    ASSERT_THROW(Context<DriverState>::get()->getBuffer(nonnull_ptr), BufferNotRegistered);
+    ASSERT_THROW(Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr), BufferNotRegistered);
 }
 
 TEST_F(HipFileBuffer, get_internal_after_register)
@@ -238,7 +238,7 @@ TEST_F(HipFileBuffer, get_internal_after_register)
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
-    auto buffer = Context<DriverState>::get()->getBuffer(nonnull_ptr);
+    auto buffer = Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr);
 }
 
 TEST_F(HipFileBuffer, get_after_register)
@@ -246,7 +246,7 @@ TEST_F(HipFileBuffer, get_after_register)
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     ASSERT_EQ(hipFileBufRegister(nonnull_ptr, 0, 0), HIPFILE_SUCCESS);
-    auto buffer = Context<DriverState>::get()->getBuffer(nonnull_ptr);
+    auto buffer = Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr);
 }
 
 TEST_F(HipFileBuffer, get_internal_after_deregister)
@@ -255,7 +255,7 @@ TEST_F(HipFileBuffer, get_internal_after_deregister)
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
     Context<DriverState>::get()->deregisterBuffer(nonnull_ptr);
-    ASSERT_THROW(Context<DriverState>::get()->getBuffer(nonnull_ptr), BufferNotRegistered);
+    ASSERT_THROW(Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr), BufferNotRegistered);
 }
 
 TEST_F(HipFileBuffer, get_after_deregister)
@@ -264,7 +264,7 @@ TEST_F(HipFileBuffer, get_after_deregister)
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     ASSERT_EQ(hipFileBufRegister(nonnull_ptr, 0, 0), HIPFILE_SUCCESS);
     ASSERT_EQ(hipFileBufDeregister(nonnull_ptr), HIPFILE_SUCCESS);
-    ASSERT_THROW(Context<DriverState>::get()->getBuffer(nonnull_ptr), BufferNotRegistered);
+    ASSERT_THROW(Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr), BufferNotRegistered);
 }
 
 TEST_F(HipFileBuffer, get_buffer_makes_temporary_buffer)
@@ -281,7 +281,7 @@ TEST_F(HipFileBuffer, get_buffer_returns_registered_buffer)
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
     ASSERT_EQ(Context<DriverState>::get()->getBuffer(nonnull_ptr, 0, 0),
-              Context<DriverState>::get()->getBuffer(nonnull_ptr));
+              Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr));
 }
 
 TEST_F(HipFileBuffer, get_buffer_throws_on_getPointerAttributes_error)

--- a/test/amd_detail/buffer.cpp
+++ b/test/amd_detail/buffer.cpp
@@ -284,16 +284,6 @@ TEST_F(HipFileBuffer, get_buffer_returns_registered_buffer)
               Context<DriverState>::get()->getBuffer(nonnull_ptr));
 }
 
-TEST_F(HipFileBuffer, get_buffer_throws_if_length_larger_than_registered_length)
-{
-    StrictMock<MHip> mhip;
-    size_t           buffer_length = 0;
-    expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    Context<DriverState>::get()->registerBuffer(nonnull_ptr, buffer_length, 0);
-    ASSERT_THROW(Context<DriverState>::get()->getBuffer(nonnull_ptr, buffer_length + 1, 0),
-                 std::invalid_argument);
-}
-
 TEST_F(HipFileBuffer, get_buffer_throws_on_getPointerAttributes_error)
 {
     StrictMock<MHip> mhip;

--- a/test/amd_detail/buffer.cpp
+++ b/test/amd_detail/buffer.cpp
@@ -271,7 +271,7 @@ TEST_F(HipFileBuffer, get_buffer_makes_temporary_buffer)
 {
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    auto buffer = Context<DriverState>::get()->getBuffer(nonnull_ptr, 0, 0);
+    auto buffer = Context<DriverState>::get()->getBuffer(nonnull_ptr);
     ASSERT_EQ(buffer.use_count(), 1);
 }
 
@@ -280,7 +280,7 @@ TEST_F(HipFileBuffer, get_buffer_returns_registered_buffer)
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
-    ASSERT_EQ(Context<DriverState>::get()->getBuffer(nonnull_ptr, 0, 0),
+    ASSERT_EQ(Context<DriverState>::get()->getBuffer(nonnull_ptr),
               Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr));
 }
 
@@ -288,7 +288,7 @@ TEST_F(HipFileBuffer, get_buffer_throws_on_getPointerAttributes_error)
 {
     StrictMock<MHip> mhip;
     EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Throw(Hip::RuntimeError(hipErrorUnknown)));
-    ASSERT_THROW(Context<DriverState>::get()->getBuffer(nonnull_ptr, 1, 0), Hip::RuntimeError);
+    ASSERT_THROW(Context<DriverState>::get()->getBuffer(nonnull_ptr), Hip::RuntimeError);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/fallback.cpp
+++ b/test/amd_detail/fallback.cpp
@@ -119,7 +119,7 @@ struct FallbackIo : public HipFileOpened {
 
         expect_buffer_registration(mhip, hipMemoryTypeDevice);
         Context<DriverState>::get()->registerBuffer(buffer_data.data(), buffer_data.size(), 0);
-        buffer = Context<DriverState>::get()->getBuffer(buffer_data.data());
+        buffer = Context<DriverState>::get()->getRegisteredBuffer(buffer_data.data());
 
         expect_file_registration(msys, mlibmounthelper);
         file = Context<DriverState>::get()->getFile(Context<DriverState>::get()->registerFile(0xBADF00D));
@@ -182,7 +182,7 @@ struct FallbackParam : ::testing::TestWithParam<IoType> {
         expect_buffer_registration(mhip, hipMemoryTypeDevice);
         void *buf = reinterpret_cast<void *>(0xFEFEFEFE);
         Context<DriverState>::get()->registerBuffer(buf, 4096, 0);
-        buffer = Context<DriverState>::get()->getBuffer(buf);
+        buffer = Context<DriverState>::get()->getRegisteredBuffer(buf);
 
         expect_file_registration(msys, mlibmounthelper);
         file = Context<DriverState>::get()->getFile(Context<DriverState>::get()->registerFile(0xBADF00D));
@@ -248,7 +248,7 @@ TEST_P(FallbackParam, fallback_io_truncates_size_to_MAX_RW_COUNT)
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     auto buf = reinterpret_cast<void *>(0xABABABAB);
     Context<DriverState>::get()->registerBuffer(buf, MAX_RW_COUNT + 1, 0);
-    auto big_buffer = Context<DriverState>::get()->getBuffer(buf);
+    auto big_buffer = Context<DriverState>::get()->getRegisteredBuffer(buf);
 
     EXPECT_CALL(msys, mmap).WillOnce(testing::Return(reinterpret_cast<void *>(0xFEFEFEFE)));
     switch (io_type) {

--- a/test/amd_detail/hipfile-api.cpp
+++ b/test/amd_detail/hipfile-api.cpp
@@ -235,8 +235,7 @@ TEST_P(HipFileIoBackendSelectionParam, HipFileIoThrowsIfThereAreNoBackends)
 {
     auto backends{std::vector<std::shared_ptr<Backend>>()};
 
-    EXPECT_CALL(mds, getFileAndBuffer(handle, buffer, io_size, flags))
-        .WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
+    EXPECT_CALL(mds, getFileAndBuffer(handle, buffer)).WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
     EXPECT_CALL(mds, getBackends).WillOnce(Return(backends));
 
     switch (io_type) {
@@ -257,8 +256,7 @@ TEST_P(HipFileIoBackendSelectionParam, HipFileIoThrowsIfAllBackendsRejectTheIO)
 {
     std::vector<std::shared_ptr<Backend>> backends{mbe1, mbe2, mbe3};
 
-    EXPECT_CALL(mds, getFileAndBuffer(handle, buffer, io_size, flags))
-        .WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
+    EXPECT_CALL(mds, getFileAndBuffer(handle, buffer)).WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
     EXPECT_CALL(mds, getBackends).WillOnce(Return(backends));
     EXPECT_CALL(*mbe1, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
         .WillOnce(Return(-1));
@@ -285,8 +283,7 @@ TEST_P(HipFileIoBackendSelectionParam, HipFileIoIssuesIoToHighestScoringBackend)
 {
     std::vector<std::shared_ptr<Backend>> backends{mbe1, mbe2, mbe3};
 
-    EXPECT_CALL(mds, getFileAndBuffer(handle, buffer, io_size, flags))
-        .WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
+    EXPECT_CALL(mds, getFileAndBuffer(handle, buffer)).WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
     EXPECT_CALL(mds, getBackends).WillOnce(Return(backends));
     EXPECT_CALL(*mbe1, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
         .WillOnce(Return(0));

--- a/test/amd_detail/hipfile-api.cpp
+++ b/test/amd_detail/hipfile-api.cpp
@@ -174,13 +174,6 @@ TEST_P(HipFileIoParam, HipFileIoHandlesUnsupportedHipMemoryType)
     }
 }
 
-TEST_P(HipFileIoParam, HipFileIoHandlesInvalidRegisteredBufferLength)
-{
-    StrictMock<MHip> mhip;
-    ASSERT_EQ(hipFileIo(GetParam(), file_handle, bufptr, buflen + 1, 0, 0, mbackends),
-              -static_cast<ssize_t>(hipFileInvalidValue));
-}
-
 TEST_P(HipFileIoParam, HipFileIoHandlesInvalidFileHandle)
 {
     auto invalid_handle{reinterpret_cast<hipFileHandle_t>(0xdeadbeef)};

--- a/test/amd_detail/mbuffer.h
+++ b/test/amd_detail/mbuffer.h
@@ -32,8 +32,7 @@ public:
     MOCK_METHOD(void, registerBuffer, (const void *bufptr, size_t length, int flags), (override));
     MOCK_METHOD(void, deregisterBuffer, (const void *bufptr), (override));
     MOCK_METHOD(std::shared_ptr<IBuffer>, getRegisteredBuffer, (const void *bufptr), (override));
-    MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *bufptr, size_t length, int flags),
-                (override));
+    MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *bufptr), (override));
     MOCK_METHOD(void, clear, (), (override));
 };
 

--- a/test/amd_detail/mbuffer.h
+++ b/test/amd_detail/mbuffer.h
@@ -31,7 +31,7 @@ public:
     }
     MOCK_METHOD(void, registerBuffer, (const void *bufptr, size_t length, int flags), (override));
     MOCK_METHOD(void, deregisterBuffer, (const void *bufptr), (override));
-    MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *bufptr), (override));
+    MOCK_METHOD(std::shared_ptr<IBuffer>, getRegisteredBuffer, (const void *bufptr), (override));
     MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *bufptr, size_t length, int flags),
                 (override));
     MOCK_METHOD(void, clear, (), (override));

--- a/test/amd_detail/mstate.h
+++ b/test/amd_detail/mstate.h
@@ -33,12 +33,11 @@ public:
     MOCK_METHOD(void, registerBuffer, (const void *buf, size_t length, int flags), (override));
     MOCK_METHOD(void, deregisterBuffer, (const void *buf), (override));
     MOCK_METHOD(std::shared_ptr<IBuffer>, getRegisteredBuffer, (const void *buf), (override));
-    MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *buf, size_t length, int flags), (override));
+    MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *buf), (override));
     MOCK_METHOD(hipFileHandle_t, registerFile, (UnregisteredFile && uf), (override));
     MOCK_METHOD(void, deregisterFile, (hipFileHandle_t fh), (override));
     MOCK_METHOD(std::shared_ptr<IFile>, getFile, (hipFileHandle_t fh), (override));
-    MOCK_METHOD(file_buffer_pair, getFileAndBuffer,
-                (hipFileHandle_t fh, const void *buf, size_t length, int flags), (override));
+    MOCK_METHOD(file_buffer_pair, getFileAndBuffer, (hipFileHandle_t fh, const void *buf), (override));
     MOCK_METHOD(void, incrRefCount, (), (override));
     MOCK_METHOD(void, decrRefCount, (), (override));
     MOCK_METHOD(int64_t, getRefCount, (), (override, const));

--- a/test/amd_detail/mstate.h
+++ b/test/amd_detail/mstate.h
@@ -32,7 +32,7 @@ public:
     MOCK_METHOD(std::shared_ptr<IBatchContext>, getBatchContext, (hipFileBatchHandle_t handle), (override));
     MOCK_METHOD(void, registerBuffer, (const void *buf, size_t length, int flags), (override));
     MOCK_METHOD(void, deregisterBuffer, (const void *buf), (override));
-    MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *buf), (override));
+    MOCK_METHOD(std::shared_ptr<IBuffer>, getRegisteredBuffer, (const void *buf), (override));
     MOCK_METHOD(std::shared_ptr<IBuffer>, getBuffer, (const void *buf, size_t length, int flags), (override));
     MOCK_METHOD(hipFileHandle_t, registerFile, (UnregisteredFile && uf), (override));
     MOCK_METHOD(void, deregisterFile, (hipFileHandle_t fh), (override));

--- a/test/amd_detail/state_mt.cpp
+++ b/test/amd_detail/state_mt.cpp
@@ -257,7 +257,7 @@ thread_function(int id)
                     uniform_int_distribution<size_t> vec_dist{0, buffers.size() - 1};
                     size_t                           idx = vec_dist(gen);
 
-                    auto data = ds->getBuffer(buffers[idx], ALLOC_SIZE, 0);
+                    auto data = ds->getBuffer(buffers[idx]);
 
                     // TODO: Maintain a data collection to ensure there are no races
                     //       on the data
@@ -291,7 +291,7 @@ thread_function(int id)
                     idx      = buf_dist(gen);
                     auto buf = buffers[idx];
 
-                    auto [file, buffer] = ds->getFileAndBuffer(fh, buf, ALLOC_SIZE, 0);
+                    auto [file, buffer] = ds->getFileAndBuffer(fh, buf);
 
                     // TODO: Maintain a data collection to ensure there are no races
                     //       on the data
@@ -318,8 +318,7 @@ thread_function(int id)
                     idx             = stream_dist(gen);
                     auto hip_stream = hip_streams[idx];
 
-                    auto [file, buffer, stream] =
-                        ds->getFileBufferAndStream(fh, buf, ALLOC_SIZE, 0, hip_stream);
+                    auto [file, buffer, stream] = ds->getFileBufferAndStream(fh, buf, hip_stream);
                 } break;
 
                 default:

--- a/test/amd_detail/state_mt.cpp
+++ b/test/amd_detail/state_mt.cpp
@@ -243,7 +243,7 @@ thread_function(int id)
                     uniform_int_distribution<size_t> vec_dist{0, buffers.size() - 1};
                     size_t                           idx = vec_dist(gen);
 
-                    auto data = ds->getBuffer(buffers[idx]);
+                    auto data = ds->getRegisteredBuffer(buffers[idx]);
 
                     // TODO: Maintain a data collection to ensure there are no races
                     //       on the data

--- a/test/system/async.cpp
+++ b/test/system/async.cpp
@@ -210,7 +210,7 @@ public:
         ASSERT_EQ(hipStreamCreateWithFlags(&hip_stream, hipStreamNonBlocking), hipSuccess);
         ASSERT_EQ(hipFileStreamRegister(hip_stream, 0xf), HIPFILE_SUCCESS);
         auto [_file, _buffer, _stream] =
-            Context<DriverState>::get()->getFileBufferAndStream(fh, dev_ptr, buffer_size, 0, hip_stream);
+            Context<DriverState>::get()->getFileBufferAndStream(fh, dev_ptr, hip_stream);
         file              = _file;
         buffer            = _buffer;
         stream            = _stream;

--- a/test/system/io.cpp
+++ b/test/system/io.cpp
@@ -1,0 +1,114 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "hipfile-warnings.h"
+#include "hipfile.h"
+
+#include "test-common.h"
+#include "test-options.h"
+
+#include <cstdlib>
+#include <unistd.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime_api.h>
+
+extern SystemTestOptions test_env;
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
+
+enum class IoTestBackend {
+    Fastpath,
+    Fallback,
+};
+
+struct HipFileIo : public testing::TestWithParam<IoTestBackend> {
+
+    Tmpfile         tmpfile;
+    size_t          tmpfile_size;
+    hipFileHandle_t tmpfile_handle;
+    void           *unregistered_device_buffer;
+    size_t          unregistered_device_buffer_size;
+
+    HipFileIo()
+        : tmpfile{test_env.ais_capable_dir}, tmpfile_size{1024 * 1024}, tmpfile_handle{nullptr},
+          unregistered_device_buffer{nullptr}, unregistered_device_buffer_size{1024 * 1024}
+    {
+    }
+
+    // Must be called before hipfile is initialized. Relies on each test being
+    // run in a separate process
+    void enable_fastpath_only()
+    {
+        if (unsetenv("HIPFILE_FORCE_COMPAT_MODE")) {
+            FAIL() << "Could not clear HIPFILE_FORCE_COMPAT_MODE";
+        }
+        if (setenv("HIPFILE_ALLOW_COMPAT_MODE", "false", 1)) {
+            FAIL() << "Could not set HIPFILE_ALLOW_COMPAT_MODE=false";
+        }
+    }
+
+    // Must be called before hipfile is initialized. Relies on each test being
+    // run in a separate process
+    void enable_fallback_only()
+    {
+        if (unsetenv("HIPFILE_ALLOW_COMPAT_MODE")) {
+            FAIL() << "Could not clear HIPFILE_ALLOW_COMPAT_MODE";
+        }
+        if (setenv("HIPFILE_FORCE_COMPAT_MODE", "true", 1)) {
+            FAIL() << "Could not set HIPFILE_FORCE_COMPAT_MODE=true";
+        }
+    }
+
+    void SetUp() override
+    {
+        switch (GetParam()) {
+            case IoTestBackend::Fastpath:
+                enable_fastpath_only();
+                break;
+
+            case IoTestBackend::Fallback:
+                enable_fallback_only();
+                break;
+
+            default:
+                FAIL() << "Unsupported IoTestBackend";
+        }
+
+        ASSERT_EQ(0, ftruncate(tmpfile.fd, static_cast<off_t>(tmpfile_size)));
+
+        hipFileDescr_t descr{};
+        descr.type      = hipFileHandleTypeOpaqueFD;
+        descr.handle.fd = tmpfile.fd;
+
+        ASSERT_EQ(HIPFILE_SUCCESS, hipFileHandleRegister(&tmpfile_handle, &descr));
+
+        ASSERT_EQ(hipSuccess, hipMalloc(&unregistered_device_buffer, unregistered_device_buffer_size));
+    }
+
+    void TearDown() override
+    {
+        ASSERT_EQ(hipSuccess, hipFree(unregistered_device_buffer));
+
+        hipFileHandleDeregister(tmpfile_handle);
+    }
+};
+
+TEST_P(HipFileIo, ReadToUnregisteredBufferAtOffset)
+{
+    hoff_t io_buffer_offset{4096};
+    size_t io_size{unregistered_device_buffer_size - static_cast<size_t>(io_buffer_offset)};
+
+    // When we create a temporary buffer to handle the hipFileRead(), we pass in
+    // the io size to Buffer's constructor as the buffer's size. Before issuing
+    // the IO, the backends (fastpath/fallback) check if the IO would overflow
+    // the buffer. This check fails with temporary buffers because,
+    // size < size + offset when 0 < offset.
+    ASSERT_EQ(-hipFileInvalidValue,
+              hipFileRead(tmpfile_handle, unregistered_device_buffer, io_size, 0, io_buffer_offset));
+}
+
+INSTANTIATE_TEST_SUITE_P(, HipFileIo, testing::Values(IoTestBackend::Fastpath, IoTestBackend::Fallback));
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/system/io.cpp
+++ b/test/system/io.cpp
@@ -100,11 +100,14 @@ TEST_P(HipFileIo, ReadToUnregisteredBufferAtOffset)
     hoff_t io_buffer_offset{4096};
     size_t io_size{unregistered_device_buffer_size - static_cast<size_t>(io_buffer_offset)};
 
-    // When we create a temporary buffer to handle the hipFileRead(), we pass in
-    // the io size to Buffer's constructor as the buffer's size. Before issuing
-    // the IO, the backends (fastpath/fallback) check if the IO would overflow
-    // the buffer. This check fails with temporary buffers because,
-    // size < size + offset when 0 < offset.
+    ASSERT_EQ(io_size, hipFileRead(tmpfile_handle, unregistered_device_buffer, io_size, 0, io_buffer_offset));
+}
+
+TEST_P(HipFileIo, ReadToUnregisteredBufferAtOffsetReturnsErrorIfOverflow)
+{
+    hoff_t io_buffer_offset{4096};
+    size_t io_size{unregistered_device_buffer_size};
+
     ASSERT_EQ(-hipFileInvalidValue,
               hipFileRead(tmpfile_handle, unregistered_device_buffer, io_size, 0, io_buffer_offset));
 }


### PR DESCRIPTION
When hipfile creates a temporary buffer to handle an IO the IO size is passed into Buffer's constructor as the buffer's size. Before issuing the IO, the backends (fastpath/fallback) check if the IO would overflow the buffer. This check fails with temporary buffers because buffer_size < io_size + offset when 0 < offset.