### PR TITLE
Change the CMake namespace to hip::

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * The `hipfile-doc` CMake target no longer exists (just use `doc`)
 * The `doc` CMake target only exists if the `AIS_BUILD_DOCS` option is enabled
 * `hipFileRead()`/`hipFileWrite()` will transfer at most 0x7ffff000 (2,147,479,552) bytes returning the number of bytes actually transferred
+* The CMake namespace was changed from `roc::` to `hip::`
 
 ### Removed
 * The rocFile library has been completely removed and the code is now a part of hipFile.

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -60,9 +60,12 @@ endif()
 # Export the targets
 set(target_list ${target_list} roc::hipfile)
 
+# Kitware recommends making the namespace match the package name
+# to work with the Common Package Specification, but since the
+# rest of ROCm doesn't do that, we'll stick with hip::
 rocm_export_targets(
     TARGETS ${target_list}
-    NAMESPACE roc::
+    NAMESPACE hip::
 )
 
 # CPack license setup


### PR DESCRIPTION
This was originally roc::, but it looks like libraries are starting to use a hip/roc split depending on the library.

Kitware recommends using hipfile::hipfile to better work with the Common Package Specification, but since no other ROCm libraries do this, we'll stick with the hip:: convention.
