### PR TITLE
Install examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED - hipFile 0.2.0
 ### Added
+* The examples can be installed to `share/doc/examples/*` by setting `AIS_INSTALL_EXAMPLES` (formerly `AIS_BUILD_EXAMPLES`) to ON
 
 ### Changed
 * Renamed `hipFileOpStatusError()` to `hipFileGetOpErrorString()`
@@ -9,6 +10,7 @@
 * The `doc` CMake target only exists if the `AIS_BUILD_DOCS` option is enabled
 * `hipFileRead()`/`hipFileWrite()` will transfer at most 0x7ffff000 (2,147,479,552) bytes returning the number of bytes actually transferred
 * The CMake namespace was changed from `roc::` to `hip::`
+* `AIS_BUILD_EXAMPLES` has been renamed to `AIS_INSTALL_EXAMPLES`
 
 ### Removed
 * The rocFile library has been completely removed and the code is now a part of hipFile.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,10 +205,10 @@ include(AISIWYU)
 #-------------------
 include(AISSanitizers)
 
-#-----------------------
-# aiscp example program
-#-----------------------
-option(AIS_BUILD_EXAMPLES "Build example programs" ON)
+#------------------
+# Example programs
+#------------------
+option(AIS_INSTALL_EXAMPLES "Install example programs" ON)
 
 #------
 # docs
@@ -283,8 +283,8 @@ if(BUILD_TESTING AND AIS_BUILD_AMD_DETAIL)
     add_subdirectory(test/amd_detail)
 endif()
 
-# Add the aiscp example directory
-if(AIS_BUILD_EXAMPLES)
+# Add the example directory
+if(AIS_INSTALL_EXAMPLES)
     add_subdirectory(examples/aiscp)
 endif()
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,7 +108,7 @@ Options
 |Option|Default|Purpose|
 |------|-------|-------|
 |AIS\_BUILD\_DOCS|OFF|Build API documentation (requires Doxygen)|
-|AIS\_BUILD\_EXAMPLES|ON|Build example programs|
+|AIS\_INSTALL\_EXAMPLES|ON|Install example programs|
 |AIS\_USE\_CLANG\_TIDY|OFF|Run the `clang-tidy` tool (clang only)|
 |AIS\_USE\_CODE\_COVERAGE|OFF|Generate code coverage information when tests are run (clang only)|
 |AIS\_USE\_IWYU|OFF|Run the `include-what-you-use` tool (clang only)|

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,7 +54,7 @@ wget https://raw.githubusercontent.com/ROCm/hipFile/refs/heads/develop/examples/
 amdclang++ -D__HIP_PLATFORM_AMD__ -L/opt/rocm/lib -I/opt/rocm/include -lamdhip64 -lhipfile aiscp.cpp -o aiscp
 ```
 
-To verify the fast path is working, copy a file with compatibility mode disabled. This should run successfully if the source and destination paths are on filesystems supporting O_DIRECT.
+To verify the fast path is working, copy a file with compatibility mode disabled. This should run successfully if the source and destination paths are on filesystems supporting `O_DIRECT`.
 
 ```
 # Create a random input file
@@ -84,7 +84,7 @@ Supported filesystems: Only ext4 is supported at this time
 
 Targeting NVIDIA requires cuFile to be installed
 
-Multipath NVMe devices are not supported at this time. If you are using a multipath-supporting device, you may need to disable multipath in the nvme_core kernel driver. On Ubuntu 24.04, this can be done by running the following:
+Multipath NVMe devices are not supported at this time. If you are using a multipath-supporting device, you may need to disable multipath in the nvme\_core kernel driver. On Ubuntu 24.04, this can be done by running the following:
 
 ```
 sudo bash -c 'echo "options nvme_core multipath=N" > /etc/modprobe.d/nvme_core.conf'

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -86,8 +86,8 @@ if(CMAKE_HIP_PLATFORM STREQUAL "nvidia")
     rocm_package_add_rpm_dependencies(DEPENDS libcufile-devel)
 endif()
 
-# Export the targets
-set(target_list ${target_list} hip::hipfile)
+# Export the hipfile target
+set(target_list hip::hipfile)
 
 # Kitware recommends making the namespace match the package name
 # to work with the Common Package Specification, but since the

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -8,7 +8,7 @@
 include(ROCMInstallTargets)
 include(ROCMCreatePackage)
 
-# Install the package
+# Install the library
 rocm_install(TARGETS hipfile)
 
 # Install the headers
@@ -19,6 +19,21 @@ rocm_install(
 
 # Install AIS tools
 install(PROGRAMS tools/ais-check/ais-check DESTINATION bin)
+
+# Install example code
+# Since the input DIRECTORY is `examples` don't include it in
+# the DESTINATION path or you'll get `examples/examples/*` output
+if(AIS_INSTALL_EXAMPLES)
+    install(
+        DIRECTORY ${CMAKE_SOURCE_DIR}/examples
+        DESTINATION share/doc/${CMAKE_PROJECT_NAME}
+        FILES_MATCHING
+            PATTERN "*.cpp"
+            PATTERN "*.h"
+            PATTERN "CMakeLists.txt"
+            PATTERN "README.md"
+    )
+endif()
 
 # When we have RELEASE/DEV builds set up, we can split
 # where these dependencies are added.

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -35,7 +35,7 @@ if(AIS_INSTALL_EXAMPLES)
 
     # Create the installed CMakeLists.txt files from the templates.
     # The CMakeLists.txt files in the examples tree use our build
-    # flags and infrastructure so we can ensure they well-vetted
+    # flags and infrastructure so we can ensure they are well-vetted
     # and these can't be installed.
 
     # aiscp

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -30,8 +30,22 @@ if(AIS_INSTALL_EXAMPLES)
         FILES_MATCHING
             PATTERN "*.cpp"
             PATTERN "*.h"
-            PATTERN "CMakeLists.txt"
             PATTERN "README.md"
+    )
+
+    # Create the installed CMakeLists.txt files from the templates.
+    # The CMakeLists.txt files in the examples tree use our build
+    # flags and infrastructure so we can ensure they well-vetted
+    # and these can't be installed.
+
+    # aiscp
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/examples/aiscp/CMakeLists.install.in"
+        "examples/aiscp/CMakeLists.txt"
+    )
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/examples/aiscp/CMakeLists.txt"
+        DESTINATION "share/doc/${CMAKE_PROJECT_NAME}/examples/aiscp/"
     )
 endif()
 
@@ -61,19 +75,19 @@ if(CMAKE_HIP_PLATFORM STREQUAL "amd")
     rocm_package_add_rpm_dependencies(DEPENDS libmount-devel)
 endif()
 
-# Nvidia Runtime Dependencies
-if(CMAKE_HIP_PLATFORM STREQUAL "nvidida")
+# NVIDIA Runtime Dependencies
+if(CMAKE_HIP_PLATFORM STREQUAL "nvidia")
     rocm_package_add_dependencies(DEPENDS libcufile)
 endif()
 
-# Nvidia Development Dependencies
+# NVIDIA Development Dependencies
 if(CMAKE_HIP_PLATFORM STREQUAL "nvidia")
     rocm_package_add_deb_dependencies(DEPENDS libcufile-dev)
     rocm_package_add_rpm_dependencies(DEPENDS libcufile-devel)
 endif()
 
 # Export the targets
-set(target_list ${target_list} roc::hipfile)
+set(target_list ${target_list} hip::hipfile)
 
 # Kitware recommends making the namespace match the package name
 # to work with the Common Package Specification, but since the

--- a/examples/aiscp/CMakeLists.install.in
+++ b/examples/aiscp/CMakeLists.install.in
@@ -1,0 +1,18 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# You may need to add -DCMAKE_PREFIX_PATH=/path/to/hipfile
+# if hipFile has been installed to a non-standard location
+
+cmake_minimum_required(VERSION 3.21)
+
+project(aiscp LANGUAGES CXX)
+
+find_package(hip REQUIRED CONFIG)
+find_package(hipfile REQUIRED CONFIG)
+
+add_executable(aiscp aiscp.cpp)
+target_compile_features(aiscp PRIVATE cxx_std_11)
+target_compile_options(aiscp PRIVATE -Wall -Wextra)
+target_link_libraries(aiscp PRIVATE hip::host hip::hipfile)

--- a/examples/aiscp/README.md
+++ b/examples/aiscp/README.md
@@ -1,0 +1,16 @@
+# `aiscp`
+
+`aiscp` is a simple test program that uses hipFile to copy a file.
+
+To build it, create a build directory and use cmake to configure and build
+the program. You may need to add the path(s) to ROCm and/or hipFile
+if they are installed in non-standard locations.
+
+```
+cmake -DCMAKE_PREFIX_PATH="/path/to/rocm;/path/to/hipfile" /path/to/aiscp/dir
+cmake --build .
+```
+
+Running it is simple. It works like the Linux `cp` command.
+
+`cp SOURCE DEST`

--- a/examples/aiscp/README.md
+++ b/examples/aiscp/README.md
@@ -13,4 +13,4 @@ cmake --build .
 
 Running it is simple. It works like the Linux `cp` command.
 
-`cp SOURCE DEST`
+`aiscp SOURCE DEST`


### PR DESCRIPTION
The examples can now be installed to `share/doc/examples/*` by setting `AIS_INSTALL_EXAMPLES` (formerly `AIS_BUILD_EXAMPLES`) to ON

Part of AIHIPFILE-120