### PR TITLE
Use CMake target options instead of globals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,14 +37,6 @@ project("hipfile"
 # Switch between building static and shared libraries
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
-# Use position-independent code everywhere
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-# Everything uses C++17, which is mandatory, and we disable extensions (so no -std=gnu++17)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 # Set the list of build types for ccmake/CMake GUI
 #
 # This turns the build type box into a multi-select so you don't have to

--- a/cmake/AISAddExecutable.cmake
+++ b/cmake/AISAddExecutable.cmake
@@ -33,6 +33,10 @@ function(ais_add_executable)
     add_executable(${arg_NAME} ${arg_SRCS})
     ais_set_compiler_flags(${arg_NAME})
 
+    # Set C++ standard
+    target_compile_features(${arg_NAME} PRIVATE cxx_std_17)
+    set_target_properties(${arg_NAME} PROPERTIES CXX_EXTENSIONS NO)
+
     # Turn sanitizers off for executables
     target_compile_options(${arg_NAME} PRIVATE -fno-sanitize=all)
 

--- a/cmake/AISAddExecutable.cmake
+++ b/cmake/AISAddExecutable.cmake
@@ -35,7 +35,7 @@ function(ais_add_executable)
 
     # Set C++ standard
     target_compile_features(${arg_NAME} PRIVATE cxx_std_17)
-    set_target_properties(${arg_NAME} PROPERTIES CXX_EXTENSIONS NO)
+    set_target_properties(${arg_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 
     # Turn sanitizers off for executables
     target_compile_options(${arg_NAME} PRIVATE -fno-sanitize=all)

--- a/cmake/AISAddLibraries.cmake
+++ b/cmake/AISAddLibraries.cmake
@@ -29,7 +29,7 @@ function(ais_add_libraries)
 
     # Set C++ standard
     target_compile_features(${arg_NAME} PUBLIC cxx_std_17)
-    set_target_properties(${arg_NAME} PROPERTIES CXX_EXTENSIONS NO)
+    set_target_properties(${arg_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 
     # Set position-independent code
     set_target_properties(${arg_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/cmake/AISAddLibraries.cmake
+++ b/cmake/AISAddLibraries.cmake
@@ -27,6 +27,13 @@ function(ais_add_libraries)
     # Add the library target
     add_library(${arg_NAME} ${arg_SRCS})
 
+    # Set C++ standard
+    target_compile_features(${arg_NAME} PUBLIC cxx_std_17)
+    set_target_properties(${arg_NAME} PROPERTIES CXX_EXTENSIONS NO)
+
+    # Set position-independent code
+    set_target_properties(${arg_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
     # Add version numbers
     set_target_properties(${arg_NAME} PROPERTIES VERSION ${AIS_LIBRARY_VERSION})
     if(BUILD_SHARED_LIBS)

--- a/examples/aiscp/CMakeLists.install.in
+++ b/examples/aiscp/CMakeLists.install.in
@@ -13,6 +13,7 @@ find_package(hip REQUIRED CONFIG)
 find_package(hipfile REQUIRED CONFIG)
 
 add_executable(aiscp aiscp.cpp)
-target_compile_features(aiscp PRIVATE cxx_std_11)
+target_compile_features(aiscp PRIVATE cxx_std_17)
+set_target_properties(aiscp PROPERTIES CXX_EXTENSIONS NO)
 target_compile_options(aiscp PRIVATE -Wall -Wextra)
 target_link_libraries(aiscp PRIVATE hip::host hip::hipfile)

--- a/examples/aiscp/CMakeLists.install.in
+++ b/examples/aiscp/CMakeLists.install.in
@@ -14,6 +14,6 @@ find_package(hipfile REQUIRED CONFIG)
 
 add_executable(aiscp aiscp.cpp)
 target_compile_features(aiscp PRIVATE cxx_std_17)
-set_target_properties(aiscp PROPERTIES CXX_EXTENSIONS NO)
+set_target_properties(aiscp PROPERTIES CXX_EXTENSIONS OFF)
 target_compile_options(aiscp PRIVATE -Wall -Wextra)
 target_link_libraries(aiscp PRIVATE hip::host hip::hipfile)


### PR DESCRIPTION
Previously, in the root CMakeLists.txt, we set global C++ and PIC settings:

```
set(CMAKE_POSITION_INDEPENDENT_CODE ON)

set(CMAKE_CXX_STANDARD 17)
set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
set(CMAKE_CXX_EXTENSIONS OFF)
```

Modern CMake encourages the use of per-target options, so this has been switched to:

```
target_compile_features(${arg_NAME} PUBLIC cxx_std_17)
set_target_properties(${arg_NAME} PROPERTIES CXX_EXTENSIONS OFF)

set_target_properties(${arg_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
```

for libraries and:

```
target_compile_features(${arg_NAME} PRIVATE cxx_std_17)
set_target_properties(${arg_NAME} PROPERTIES CXX_EXTENSIONS OFF)
```

for executables.

The `aiscp` C++ level was also set to C++17 w/ GNU extensions off.
