### PR TITLE
Avoid `CMAKE_SOURCE_DIR`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 #-----------------------------------------------------------------------------
 # Include our custom CMake code in the module path
 #-----------------------------------------------------------------------------
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 #-----------------------------------------------------------------------------
 # Set ROCm Version and Install Path

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,16 @@ project("hipfile"
 # Switch between building static and shared libraries
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
+# Set the path to the include directories for later use
+# Do this early so we can use these later, in functions, etc.
+set(HIPFILE_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+set(HIPFILE_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include")
+set(HIPFILE_AMD_SOURCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/amd_detail")
+set(HIPFILE_NVIDIA_SOURCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/nvidia_detail")
+set(HIPFILE_SRC_COMMON_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/common")
+set(HIPFILE_TEST_COMMON_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/common")
+set(HIPFILE_AMD_TEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/amd_detail")
+
 # Set the list of build types for ccmake/CMake GUI
 #
 # This turns the build type box into a multi-select so you don't have to
@@ -251,15 +261,6 @@ endif()
 #-----------------------------------------------------------------------------
 # Configure hipFile
 #-----------------------------------------------------------------------------
-
-# Set the path to the include directories for later use
-set(HIPFILE_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
-set(HIPFILE_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include")
-set(HIPFILE_AMD_SOURCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/amd_detail")
-set(HIPFILE_NVIDIA_SOURCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/nvidia_detail")
-set(HIPFILE_SRC_COMMON_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/common")
-set(HIPFILE_TEST_COMMON_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/common")
-set(HIPFILE_AMD_TEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/amd_detail")
 
 # Add the src directory depending on the HIP platform
 if(AIS_BUILD_NVIDIA_DETAIL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 #-----------------------------------------------------------------------------
 # Include our custom CMake code in the module path
 #-----------------------------------------------------------------------------
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 #-----------------------------------------------------------------------------
 # Set ROCm Version and Install Path

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ endif()
 #-----------------------------------------------------------------------------
 
 # Set the path to the include directories for later use
+set(HIPFILE_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 set(HIPFILE_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include")
 set(HIPFILE_AMD_SOURCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/amd_detail")
 set(HIPFILE_NVIDIA_SOURCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/nvidia_detail")

--- a/cmake/AISAddExecutable.cmake
+++ b/cmake/AISAddExecutable.cmake
@@ -72,5 +72,5 @@ function(ais_add_executable)
         target_include_directories(${arg_NAME} SYSTEM PRIVATE ${incl})
     endforeach()
 
-    target_include_directories(${arg_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/shared")
+    target_include_directories(${arg_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/shared")
 endfunction()

--- a/cmake/AISAddExecutable.cmake
+++ b/cmake/AISAddExecutable.cmake
@@ -72,5 +72,5 @@ function(ais_add_executable)
         target_include_directories(${arg_NAME} SYSTEM PRIVATE ${incl})
     endforeach()
 
-    target_include_directories(${arg_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/shared")
+    target_include_directories(${arg_NAME} PRIVATE "${HIPFILE_ROOT_PATH}/shared")
 endfunction()

--- a/cmake/AISAddLibraries.cmake
+++ b/cmake/AISAddLibraries.cmake
@@ -93,7 +93,7 @@ function(ais_add_libraries)
     endif()
 
     # Add the common include path
-    target_include_directories(${arg_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/shared")
+    target_include_directories(${arg_NAME} PRIVATE "${HIPFILE_ROOT_PATH}/shared")
 
     # Set compiler flags
     ais_set_compiler_flags(${arg_NAME})

--- a/cmake/AISAddLibraries.cmake
+++ b/cmake/AISAddLibraries.cmake
@@ -93,7 +93,7 @@ function(ais_add_libraries)
     endif()
 
     # Add the common include path
-    target_include_directories(${arg_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/shared")
+    target_include_directories(${arg_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/shared")
 
     # Set compiler flags
     ais_set_compiler_flags(${arg_NAME})

--- a/cmake/AISDocumentation.cmake
+++ b/cmake/AISDocumentation.cmake
@@ -15,7 +15,7 @@ if(AIS_BUILD_DOCS)
     find_package(Doxygen REQUIRED)
 
     # Set Doxygen input (pasted into Doxyfile.in)
-    set(AIS_DOXYFILE_INPUT "${CMAKE_SOURCE_DIR}/include")
+    set(AIS_DOXYFILE_INPUT "${PROJECT_SOURCE_DIR}/include")
 
     # Set the path to the documentation
     set(AIS_DOC_PATH "${CMAKE_CURRENT_BINARY_DIR}/docs")

--- a/cmake/AISDocumentation.cmake
+++ b/cmake/AISDocumentation.cmake
@@ -15,7 +15,7 @@ if(AIS_BUILD_DOCS)
     find_package(Doxygen REQUIRED)
 
     # Set Doxygen input (pasted into Doxyfile.in)
-    set(AIS_DOXYFILE_INPUT "${PROJECT_SOURCE_DIR}/include")
+    set(AIS_DOXYFILE_INPUT "${HIPFILE_ROOT_PATH}/include")
 
     # Set the path to the documentation
     set(AIS_DOC_PATH "${CMAKE_CURRENT_BINARY_DIR}/docs")

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -13,7 +13,7 @@ rocm_install(TARGETS hipfile)
 
 # Install the headers
 rocm_install(
-    DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+    DIRECTORY ${HIPFILE_ROOT_PATH}/include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
@@ -25,7 +25,7 @@ install(PROGRAMS tools/ais-check/ais-check DESTINATION bin)
 # the DESTINATION path or you'll get `examples/examples/*` output
 if(AIS_INSTALL_EXAMPLES)
     install(
-        DIRECTORY ${PROJECT_SOURCE_DIR}/examples
+        DIRECTORY ${HIPFILE_ROOT_PATH}/examples
         DESTINATION share/doc/${CMAKE_PROJECT_NAME}
         FILES_MATCHING
             PATTERN "*.cpp"
@@ -98,7 +98,7 @@ rocm_export_targets(
 )
 
 # CPack license setup
-set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${HIPFILE_ROOT_PATH}/LICENSE.md")
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 
 # rocm-cmake sets CPACK_SET_DESTDIR on Linux, which conflicts with

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -13,7 +13,7 @@ rocm_install(TARGETS hipfile)
 
 # Install the headers
 rocm_install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+    DIRECTORY ${PROJECT_SOURCE_DIR}/include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
@@ -25,7 +25,7 @@ install(PROGRAMS tools/ais-check/ais-check DESTINATION bin)
 # the DESTINATION path or you'll get `examples/examples/*` output
 if(AIS_INSTALL_EXAMPLES)
     install(
-        DIRECTORY ${CMAKE_SOURCE_DIR}/examples
+        DIRECTORY ${PROJECT_SOURCE_DIR}/examples
         DESTINATION share/doc/${CMAKE_PROJECT_NAME}
         FILES_MATCHING
             PATTERN "*.cpp"
@@ -98,7 +98,7 @@ rocm_export_targets(
 )
 
 # CPack license setup
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE.md")
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 
 # rocm-cmake sets CPACK_SET_DESTDIR on Linux, which conflicts with

--- a/cmake/AISUseGTest.cmake
+++ b/cmake/AISUseGTest.cmake
@@ -46,7 +46,7 @@ function(ais_gtest_discover_tests target)
         set_property(
             DIRECTORY APPEND PROPERTY
             TEST_INCLUDE_FILES
-            "${PROJECT_SOURCE_DIR}/cmake/AISSetCoverageFile.cmake"
+            "${HIPFILE_ROOT_PATH}/cmake/AISSetCoverageFile.cmake"
             "${coverage_include_file}"
         )
 

--- a/cmake/AISUseGTest.cmake
+++ b/cmake/AISUseGTest.cmake
@@ -46,7 +46,7 @@ function(ais_gtest_discover_tests target)
         set_property(
             DIRECTORY APPEND PROPERTY
             TEST_INCLUDE_FILES
-            "${CMAKE_SOURCE_DIR}/cmake/AISSetCoverageFile.cmake"
+            "${PROJECT_SOURCE_DIR}/cmake/AISSetCoverageFile.cmake"
             "${coverage_include_file}"
         )
 


### PR DESCRIPTION
If hipFile is used as a subproject in another project, `CMAKE_SOURCE_DIR` will point to the root of *that* project instead of ours, which could break the build. These changes use alternative paths to address this.

Part of AIHIPFILE-129