### PR TITLE
Use make_shared to create a shared pointer

### DIFF
--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -138,8 +138,8 @@ Fallback::async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBu
         return;
     }
 
-    auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback(
-        type, file, buffer, stream, size_p, file_offset_p, buffer_offset_p, bytes_transferred_p));
+    auto op = std::make_shared<AsyncOpFallback>(type, file, buffer, stream, size_p, file_offset_p,
+                                                buffer_offset_p, bytes_transferred_p);
     Context<AsyncMonitor>::get()->addOp(op);
     auto  op_dev_ptr     = op->devPtr();
     void *kernel_args[1] = {&op_dev_ptr};


### PR DESCRIPTION
## Motivation

Small code simplification.

## Technical Details

Constructing a `shared_ptr` instance with `make_shared` is simpler and more efficient than using the raw pointer constructor.

Shared pointers need extra storage for the atomic reference count. `make_shared` has the opportunity to reserve the memory for both ref-count and the object itself in one operation, while the alternative requires two separate allocations, with the ref-count storage requiring an extra indirection to object itself.

## Test Plan

The change has no effect on functionality so all the tests should have the same outcome.

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
