### PR TITLE
ci: move fio steps into separate job

### DIFF
--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -194,7 +194,9 @@ jobs:
           docker stop "${AIS_CONTAINER_NAME}"
       - name: Cleanup self-hosted runner workspace
         if: ${{ always() }}
-        run: rm -rf ${GITHUB_WORKSPACE}/* ${GITHUB_WORKSPACE}/.[!.]* ${GITHUB_WORKSPACE}/..?*
+        run: |
+          shopt -s dotglob
+          rm -rf ${GITHUB_WORKSPACE}/*
   build_FIO:
     uses: ROCm/fio/.github/workflows/build-fio.yml@rildixon/ci-hook-for-hipfile
     with:
@@ -395,4 +397,6 @@ jobs:
           docker stop "${AIS_CONTAINER_NAME}"
       - name: Cleanup self-hosted runner workspace
         if: ${{ always() }}
-        run: rm -rf ${GITHUB_WORKSPACE}/* ${GITHUB_WORKSPACE}/.[!.]* ${GITHUB_WORKSPACE}/..?*
+        run: |
+          shopt -s dotglob
+          rm -rf ${GITHUB_WORKSPACE}/*

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -8,6 +8,15 @@ env:
   AIS_INPUT_PLATFORM: ${{ inputs.platform }}
   AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
   AIS_MOUNT_PATH: /mnt/ais/ext4
+  AIS_PKG_INSTALL_CMD: >-
+    ${{
+      case(
+        inputs.platform == 'rocky', 'dnf install -y',
+        inputs.platform == 'suse', 'zypper install -y --allow-unsigned-rpm',
+        inputs.platform == 'ubuntu', 'apt update; apt install -y',
+        ''
+      )
+    }}
   AIS_PKG_MGR: >-
     ${{
       inputs.platform == 'rocky' && 'dnf' ||
@@ -186,8 +195,15 @@ jobs:
       - name: Cleanup self-hosted runner workspace
         if: ${{ always() }}
         run: rm -rf ${GITHUB_WORKSPACE}/* ${GITHUB_WORKSPACE}/.*
+  build_FIO:
+    uses: ROCm/fio/.github/workflows/build-fio.yml@rildixon/ci-hook-for-hipfile
+    with:
+      ais_hipfile_pkg_filename: ${{ inputs.ais_hipfile_pkg_filename }}
+      ais_hipfile_pkg_dev_filename: ${{ inputs.ais_hipfile_pkg_dev_filename }}
+      platform: ${{ inputs.platform }}
   run_FIO_tests:
     runs-on: [linux, AIS]
+    needs: [build_FIO]
     steps:
       - name: Set early AIS CI environment variables
         run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
@@ -213,6 +229,26 @@ jobs:
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
         with:
           name: ${{ inputs.ais_hipfile_pkg_dev_filename }}
+      - name: Download FIO runtime package
+        # Fedora-based distro's need to download multiple packages as the FIO IO engines
+        # are dynamically linked instead of built into the FIO executable.
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        with:
+          artifact-ids: >-
+            ${{
+              case(
+                inputs.platform == 'rocky',
+                format(
+                  '{0},{1}',
+                  needs.build_FIO.outputs.fio_pkg_fedora_artifact_id,
+                  needs.build_FIO.outputs.fio_pkg_fedora_hipfile_engine_artifact_id
+                ),
+                inputs.platform == 'suse', needs.build_FIO.outputs.fio_pkg_suse_artifact_id,
+                inputs.platform == 'ubuntu', needs.build_FIO.outputs.fio_pkg_debian_artifact_id,
+                'unknown-platform-declared'
+              )
+            }}
+          merge-multiple: true
       - name: Authenticating to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
@@ -253,6 +289,8 @@ jobs:
             "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_DEV_FILENAME}" \
             "${AIS_CONTAINER_NAME}:/root"
       - name: Install the hipFile packages
+        # Note: We need to re-run the `ldconfig` post-install step.
+        #       This really should just be done automatically by the ROCm package.
         run: |
           docker exec \
             -t \
@@ -261,7 +299,7 @@ jobs:
             /bin/bash -c '
               ${{
                 format(
-                  env.AIS_PKG_MGR == 'apt' && 'apt install -y "./{0}" "./{1}"' ||
+                  env.AIS_PKG_MGR == 'apt' && 'apt update; apt install -y "./{0}" "./{1}"' ||
                     env.AIS_PKG_MGR == 'dnf' && 'dnf install -y --cacheonly "./{0}" "./{1}"' ||
                     env.AIS_PKG_MGR == 'zypper' && 'zypper --no-refresh install -y --allow-unsigned-rpm "./{0}" "./{1}"' ||
                     'echo "Unknown platform."; exit 1',
@@ -269,30 +307,76 @@ jobs:
                   inputs.ais_hipfile_pkg_dev_filename
                 )
               }}
+              ldconfig
             '
-      - name: Configure fio
+      - name: Copy the FIO packages into the container
+        env:
+          FIO_RUNTIME_PKG_FILENAME: >-
+            ${{
+              case(
+                inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_filename,
+                inputs.platform == 'suse', needs.build_FIO.outputs.fio_pkg_suse_filename,
+                inputs.platform == 'ubuntu', needs.build_FIO.outputs.fio_pkg_debian_filename,
+                ''
+              )
+            }}
+          FIO_HIPFILE_ENGINE_PKG_FILENAME: >-
+            ${{
+              case(
+                inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_hipfile_engine_filename,
+                ''
+              )
+            }}
+        run: |
+          docker cp \
+            "${GITHUB_WORKSPACE}/${FIO_RUNTIME_PKG_FILENAME}" \
+            "${AIS_CONTAINER_NAME}:/root"
+          ${{
+            case(
+              inputs.platform == 'rocky',
+                'docker cp \
+                  "${GITHUB_WORKSPACE}/${FIO_HIPFILE_ENGINE_PKG_FILENAME}" \
+                  "${AIS_CONTAINER_NAME}:/root"
+                ',
+              ''
+            )
+          }}
+      - name: Install the FIO packages
+        env:
+          FIO_RUNTIME_PKG_FILENAME: >-
+            ${{
+              case(
+                inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_filename,
+                inputs.platform == 'suse', needs.build_FIO.outputs.fio_pkg_suse_filename,
+                inputs.platform == 'ubuntu', needs.build_FIO.outputs.fio_pkg_debian_filename,
+                ''
+              )
+            }}
+          FIO_HIPFILE_ENGINE_PKG_FILENAME: >-
+            ${{
+              case(
+                inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_hipfile_engine_filename,
+                ''
+              )
+            }}
         run: |
           docker exec \
             -t \
-            -w /ais/fio/build \
+            -w /root \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              ROCM=/opt/rocm-${ROCM_VERSION} \
-              HIPFILE=/ais/hipFile \
-              HIPFILELIB=${HIPFILE}/build/src/amd_detail/ \
-              HIP_PLATFORM=amd \
-              CFLAGS="-I${ROCM}/include" \
-              LDFLAGS="-L${ROCM}/lib -Wl,-rpath,${ROCM}/lib" \
-              ../configure --enable-libhipfile
-            '
-      - name: Build fio
-        run: |
-          docker exec \
-            -t \
-            -w /ais/fio/build \
-            "${AIS_CONTAINER_NAME}" \
-            /bin/bash -c '
-              make -j
+              ls -al
+              ${{
+                format(
+                  '{0} {1}',
+                  env.AIS_PKG_INSTALL_CMD,
+                  case(
+                    inputs.platform == 'rocky',
+                      format('./{0} ./{1}', env.FIO_RUNTIME_PKG_FILENAME, env.FIO_HIPFILE_ENGINE_PKG_FILENAME),
+                    format('./{0}', env.FIO_RUNTIME_PKG_FILENAME)
+                  )
+                )
+              }}
             '
       - name: hipFile fallback/POSIX IO test using fio
         run: |
@@ -302,7 +386,7 @@ jobs:
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               HIPFILE_FORCE_COMPAT_MODE=true \
-                /ais/fio/build/fio \
+                fio \
                 /ais/hipFile/util/fio/write-read-verify.fio
             '
       - name: hipFile AIS IO test using fio
@@ -313,7 +397,7 @@ jobs:
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               HIPFILE_ALLOW_COMPAT_MODE=false \
-                /ais/fio/build/fio \
+                fio \
                 /ais/hipFile/util/fio/write-read-verify.fio
             '
       - name: Destroy hipfile IO test directory

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -198,7 +198,7 @@ jobs:
           shopt -s dotglob
           rm -rf ${GITHUB_WORKSPACE}/*
   build_FIO:
-    uses: ROCm/fio/.github/workflows/build-fio.yml@rildixon/ci-hook-for-hipfile
+    uses: ROCm/fio/.github/workflows/build-fio.yml@hipFile
     with:
       ais_hipfile_pkg_filename: ${{ inputs.ais_hipfile_pkg_filename }}
       ais_hipfile_pkg_dev_filename: ${{ inputs.ais_hipfile_pkg_dev_filename }}

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -194,7 +194,7 @@ jobs:
           docker stop "${AIS_CONTAINER_NAME}"
       - name: Cleanup self-hosted runner workspace
         if: ${{ always() }}
-        run: rm -rf ${GITHUB_WORKSPACE}/* ${GITHUB_WORKSPACE}/.*
+        run: rm -rf ${GITHUB_WORKSPACE}/* ${GITHUB_WORKSPACE}/.[!.]* ${GITHUB_WORKSPACE}/..?*
   build_FIO:
     uses: ROCm/fio/.github/workflows/build-fio.yml@rildixon/ci-hook-for-hipfile
     with:
@@ -395,4 +395,4 @@ jobs:
           docker stop "${AIS_CONTAINER_NAME}"
       - name: Cleanup self-hosted runner workspace
         if: ${{ always() }}
-        run: rm -rf ${GITHUB_WORKSPACE}/* ${GITHUB_WORKSPACE}/.*
+        run: rm -rf ${GITHUB_WORKSPACE}/* ${GITHUB_WORKSPACE}/.[!.]* ${GITHUB_WORKSPACE}/..?*

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -49,12 +49,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           path: hipFile
-      - name: Fetching fio repository...
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          repository: ROCm/fio
-          ref: hipFile
-          path: fio
       - name: Download hipFile runtime package
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 #v8.0.0
         with:
@@ -101,7 +95,6 @@ jobs:
             /bin/bash -c '
               cp -R /mnt/ais /ais
               mkdir /ais/hipFile/build
-              mkdir /ais/fio/build
             '
       - name: Copy the hipFile packages into the container
         run: |
@@ -181,6 +174,101 @@ jobs:
               HIPFILE_ALLOW_COMPAT_MODE=false
                 /ais/hipFile/util/ci-aiscp-test.sh \
                 /ais/hipFile/build/examples/aiscp/aiscp
+            '
+      - name: Destroy hipfile IO test directory
+        if: ${{ always() }}
+        run: |
+          docker exec -t "${AIS_CONTAINER_NAME}" /bin/bash -c "rm -fr /mnt/ais-fs/${AIS_CONTAINER_NAME}"
+      - name: Cleanup & Stop the Docker container
+        if: ${{ always() }}
+        run: |
+          docker stop "${AIS_CONTAINER_NAME}"
+      - name: Cleanup self-hosted runner workspace
+        if: ${{ always() }}
+        run: rm -rf ${GITHUB_WORKSPACE}/* ${GITHUB_WORKSPACE}/.*
+  run_FIO_tests:
+    runs-on: [linux, AIS]
+    steps:
+      - name: Set early AIS CI environment variables
+        run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+      - name: Set AIS CI container name
+        run: |
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${{ github.job }}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}" >> "${GITHUB_ENV}"
+      # hipFile repo needed for //util directory
+      - name: Fetching hipFile repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          path: hipFile
+      - name: Fetching fio repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          repository: ROCm/fio
+          ref: hipFile
+          path: fio
+      - name: Download hipFile runtime package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        with:
+          name: ${{ inputs.ais_hipfile_pkg_filename }}
+      - name: Download hipFile development package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        with:
+          name: ${{ inputs.ais_hipfile_pkg_dev_filename }}
+      - name: Authenticating to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Starting Docker Container
+        run: |
+          docker run \
+            -dt \
+            --rm \
+            --device=/dev/kfd \
+            --device=/dev/dri \
+            --security-opt seccomp=unconfined \
+            --pull always \
+            -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
+            -v "${AIS_MOUNT_PATH}:/mnt/ais-fs" \
+            --name "${AIS_CONTAINER_NAME}" \
+            "${AIS_INPUT_CI_IMAGE}"
+      - name: Create hipfile IO test directory
+        run: |
+          docker exec -t "${AIS_CONTAINER_NAME}" /bin/bash -c "mkdir -p /mnt/ais-fs/${AIS_CONTAINER_NAME}"
+      - name: Make copy of the code repository and create build directories
+        run: |
+          docker exec \
+            -t \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cp -R /mnt/ais /ais
+              mkdir /ais/fio/build
+            '
+      - name: Copy the hipFile packages into the container
+        run: |
+          docker cp \
+            "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_FILENAME}" \
+            "${AIS_CONTAINER_NAME}:/root"
+          docker cp \
+            "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_DEV_FILENAME}" \
+            "${AIS_CONTAINER_NAME}:/root"
+      - name: Install the hipFile packages
+        run: |
+          docker exec \
+            -t \
+            -w /root \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              ${{
+                format(
+                  env.AIS_PKG_MGR == 'apt' && 'apt install -y "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y --cacheonly "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'zypper' && 'zypper --no-refresh install -y --allow-unsigned-rpm "./{0}" "./{1}"' ||
+                    'echo "Unknown platform."; exit 1',
+                  inputs.ais_hipfile_pkg_filename,
+                  inputs.ais_hipfile_pkg_dev_filename
+                )
+              }}
             '
       - name: Configure fio
         run: |

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -215,12 +215,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           path: hipFile
-      - name: Fetching fio repository...
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          repository: ROCm/fio
-          ref: hipFile
-          path: fio
       - name: Download hipFile runtime package
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
         with:
@@ -245,7 +239,7 @@ jobs:
                 ),
                 inputs.platform == 'suse', needs.build_FIO.outputs.fio_pkg_suse_artifact_id,
                 inputs.platform == 'ubuntu', needs.build_FIO.outputs.fio_pkg_debian_artifact_id,
-                'unknown-platform-declared'
+                format('Platform "{0}" is not supported by build_FIO.', inputs.platform)
               )
             }}
           merge-multiple: true
@@ -271,15 +265,6 @@ jobs:
       - name: Create hipfile IO test directory
         run: |
           docker exec -t "${AIS_CONTAINER_NAME}" /bin/bash -c "mkdir -p /mnt/ais-fs/${AIS_CONTAINER_NAME}"
-      - name: Make copy of the code repository and create build directories
-        run: |
-          docker exec \
-            -t \
-            "${AIS_CONTAINER_NAME}" \
-            /bin/bash -c '
-              cp -R /mnt/ais /ais
-              mkdir /ais/fio/build
-            '
       - name: Copy the hipFile packages into the container
         run: |
           docker cp \
@@ -387,7 +372,7 @@ jobs:
             /bin/bash -c '
               HIPFILE_FORCE_COMPAT_MODE=true \
                 fio \
-                /ais/hipFile/util/fio/write-read-verify.fio
+                /mnt/ais/hipFile/util/fio/write-read-verify.fio
             '
       - name: hipFile AIS IO test using fio
         run: |
@@ -398,7 +383,7 @@ jobs:
             /bin/bash -c '
               HIPFILE_ALLOW_COMPAT_MODE=false \
                 fio \
-                /ais/hipFile/util/fio/write-read-verify.fio
+                /mnt/ais/hipFile/util/fio/write-read-verify.fio
             '
       - name: Destroy hipfile IO test directory
         if: ${{ always() }}

--- a/.github/workflows/test-ais-system.yml
+++ b/.github/workflows/test-ais-system.yml
@@ -206,6 +206,23 @@ jobs:
   run_FIO_tests:
     runs-on: [linux, AIS]
     needs: [build_FIO]
+    env:
+      FIO_RUNTIME_PKG_FILENAME: >-
+        ${{
+          case(
+            inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_filename,
+            inputs.platform == 'suse', needs.build_FIO.outputs.fio_pkg_suse_filename,
+            inputs.platform == 'ubuntu', needs.build_FIO.outputs.fio_pkg_debian_filename,
+            ''
+          )
+        }}
+      FIO_HIPFILE_ENGINE_PKG_FILENAME: >-
+        ${{
+          case(
+            inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_hipfile_engine_filename,
+            ''
+          )
+        }}
     steps:
       - name: Set early AIS CI environment variables
         run: echo "AIS_PR_NUMBER=$(echo ${{ github.ref }} | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
@@ -218,17 +235,17 @@ jobs:
         with:
           path: hipFile
       - name: Download hipFile runtime package
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 #v8.0.0
         with:
           name: ${{ inputs.ais_hipfile_pkg_filename }}
       - name: Download hipFile development package
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 #v8.0.0
         with:
           name: ${{ inputs.ais_hipfile_pkg_dev_filename }}
       - name: Download FIO runtime package
         # Fedora-based distro's need to download multiple packages as the FIO IO engines
         # are dynamically linked instead of built into the FIO executable.
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 #v8.0.0
         with:
           artifact-ids: >-
             ${{
@@ -297,23 +314,6 @@ jobs:
               ldconfig
             '
       - name: Copy the FIO packages into the container
-        env:
-          FIO_RUNTIME_PKG_FILENAME: >-
-            ${{
-              case(
-                inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_filename,
-                inputs.platform == 'suse', needs.build_FIO.outputs.fio_pkg_suse_filename,
-                inputs.platform == 'ubuntu', needs.build_FIO.outputs.fio_pkg_debian_filename,
-                ''
-              )
-            }}
-          FIO_HIPFILE_ENGINE_PKG_FILENAME: >-
-            ${{
-              case(
-                inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_hipfile_engine_filename,
-                ''
-              )
-            }}
         run: |
           docker cp \
             "${GITHUB_WORKSPACE}/${FIO_RUNTIME_PKG_FILENAME}" \
@@ -329,30 +329,12 @@ jobs:
             )
           }}
       - name: Install the FIO packages
-        env:
-          FIO_RUNTIME_PKG_FILENAME: >-
-            ${{
-              case(
-                inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_filename,
-                inputs.platform == 'suse', needs.build_FIO.outputs.fio_pkg_suse_filename,
-                inputs.platform == 'ubuntu', needs.build_FIO.outputs.fio_pkg_debian_filename,
-                ''
-              )
-            }}
-          FIO_HIPFILE_ENGINE_PKG_FILENAME: >-
-            ${{
-              case(
-                inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_hipfile_engine_filename,
-                ''
-              )
-            }}
         run: |
           docker exec \
             -t \
             -w /root \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              ls -al
               ${{
                 format(
                   '{0} {1}',

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -107,6 +107,20 @@ set(CPACK_PACKAGE_RELOCATABLE OFF)
 set(CPACK_RPM_PACKAGE_RELOCATABLE OFF)
 set(CPACK_DEB_PACKAGE_RELOCATABLE OFF)
 
+# Some RPMs set dependencies on a library automatically instead
+# of a manually defined package name via the AutoRequires &
+# AutoProvides RPM features.
+# ROCmCreatePackage however disables AUTOREQPROV by default.
+# The RPM spec does not clearly state how setting AUTOREPROV &
+# AUTOREQ / AUTOPREV to different values behaves. On observation,
+# AUTOREQPROV supersedes the others and continues the build.
+# Ref: https://ftp.rpm.org/max-rpm/s1-rpm-specref-preamble.html#S3-RPM-SPECREF-AUTOREQPROV
+set(CPACK_RPM_PACKAGE_AUTOREQPROV "") # Forcibly 'unset' this variable and don't let ROCmCreatePackage set it.
+set(CPACK_RPM_PACKAGE_AUTOPROV ON)
+set(CPACK_RPM_PACKAGE_AUTOREQ OFF)
+# Alternatively, we could set CPACK_RPM_PACKAGE_PROVIDES,
+# but then we would have to maintain it...
+
 # Set DEB/RPM Release Information
 # rocm_create_package checks if following variables are defined in the environment:
 #   - CPACK_DEBIAN_PACKAGE_RELEASE

--- a/cmake/AISInstall.cmake
+++ b/cmake/AISInstall.cmake
@@ -112,10 +112,10 @@ set(CPACK_DEB_PACKAGE_RELOCATABLE OFF)
 # AutoProvides RPM features.
 # ROCmCreatePackage however disables AUTOREQPROV by default.
 # The RPM spec does not clearly state how setting AUTOREPROV &
-# AUTOREQ / AUTOPREV to different values behaves. On observation,
+# AUTOREQ / AUTOPROV to different values behaves. On observation,
 # AUTOREQPROV supersedes the others and continues the build.
 # Ref: https://ftp.rpm.org/max-rpm/s1-rpm-specref-preamble.html#S3-RPM-SPECREF-AUTOREQPROV
-set(CPACK_RPM_PACKAGE_AUTOREQPROV "") # Forcibly 'unset' this variable and don't let ROCmCreatePackage set it.
+set(CPACK_RPM_PACKAGE_AUTOREQPROV "") # Intentionally set to an empty value so ROCmCreatePackage treats it as defined and does not override it.
 set(CPACK_RPM_PACKAGE_AUTOPROV ON)
 set(CPACK_RPM_PACKAGE_AUTOREQ OFF)
 # Alternatively, we could set CPACK_RPM_PACKAGE_PROVIDES,


### PR DESCRIPTION
Breaks apart our monolithic system test workflow to separate the hipFile system tests from the FIO tests.
The FIO job now consumes the packages built by the ROCm/fio build workflow. This is the same workflow that creates and publishes the fio packages with hipfile support.


AIHIPFILE-121