### PR TITLE
Fix pylint issues

### DIFF
--- a/tools/ais-check/.pylintrc
+++ b/tools/ais-check/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore-patterns=^ais-check$

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -100,7 +100,9 @@ def amdgpu_supports_ais():
 
 def main(args):
     """
-    Run the program
+    Parse command-line arguments, check AIS support in HIP Runtime and
+    amdgpu, optionally print the results, and return an exit code indicating
+    whether all required components support AIS.
     """
 
     parser = argparse.ArgumentParser()

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -81,7 +81,7 @@ def amdgpu_supports_ais():
     Check if kfd_ais_rw_file is in the kernel's symbol table
     """
     try:
-        with open("/proc/kallsyms", "r") as kallsyms:
+        with open("/proc/kallsyms", "r", encoding="utf-8") as kallsyms:
             for line in kallsyms:
                 if "kfd_ais_rw_file" in line:
                     return True
@@ -99,6 +99,10 @@ def amdgpu_supports_ais():
 
 
 def main(args):
+    """
+    Run the program
+    """
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-q", "--quiet", action="store_true", help="Silence regular output"


### PR DESCRIPTION
These are trivial changes, but get us to a perfect pylint score. We are already fine for formatting via black.

* Missing encoding with open()
* Missing a docstring
* Suppress warning that `ais-check` isn't in snake_case via a .pylintrc file