### PR TITLE
cmake: Don't set working directory on system tests.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,7 +69,6 @@ target_link_libraries(hipfile_system_tests PRIVATE Boost::program_options)
 ais_gtest_discover_tests(
     hipfile_system_tests
     EXTRA_ARGS --ais-capable-dir ${AIS_CAPABLE_DIR}
-    WORKING_DIRECTORY ${AIS_CAPABLE_DIR}
     PROPERTIES "LABELS;system;LABELS;hipfile"
     TEST_LIST hipfile_system_tests
 )


### PR DESCRIPTION
This is the cause of an error when CMake lists tests, because it tries to switch to this directory before running the command, which might not exist at build time.