### PR TITLE
ci: Write 1MB instead of 1GB in fio test

### DIFF
--- a/util/fio/write-read-verify.fio
+++ b/util/fio/write-read-verify.fio
@@ -4,8 +4,8 @@ ioengine=libhipfile
 rocm_io=hipfile
 gpu_dev_ids=0
 filename=fio.dat
-size=1G
-bs=1M
+size=1M
+bs=4K
 verify=md5
 numjobs=1
 


### PR DESCRIPTION
Two goals here.

1. Reduce the wear on the real NVMe drives in our CI fleet.

2. Reduce the runtime of this job on CI runners with emulated NVMe drives. Writing 1G on emulated NVMe drives can take upward of eight minutes
