### PR TITLE
Turn on the pip cache for Python GH actions

### DIFF
--- a/.github/workflows/cmakelint.yml
+++ b/.github/workflows/cmakelint.yml
@@ -17,7 +17,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
-        cache: 'pip'
+        with:
+          cache: 'pip'
 
       - name: Set up cmakelint
         run: |

--- a/.github/workflows/cmakelint.yml
+++ b/.github/workflows/cmakelint.yml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+        cache: 'pip'
 
       - name: Set up cmakelint
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+        cache: 'pip'
 
       - name: Set up pylint
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
-        cache: 'pip'
+        with:
+          cache: 'pip'
 
       - name: Set up pylint
         run: |


### PR DESCRIPTION
The pylint and cmakelint actions use Python. This PR turns
on the pip cache.