### PR TITLE
Add Stats Level config value for use with stats counter collection.

### DIFF
--- a/src/amd_detail/configuration.cpp
+++ b/src/amd_detail/configuration.cpp
@@ -17,8 +17,6 @@ Configuration::Configuration() : m_fastpath(true), m_fallback(true), m_statsLeve
     if (maybe_env_force_compat && maybe_env_force_compat.value()) {
         m_fastpath = false;
     }
-    m_fastpath = !!getHipAmdFileReadPtr() && m_fastpath;
-    m_fastpath = !!getHipAmdFileWritePtr() && m_fastpath;
 
     auto maybe_env_allow_compat{Environment::allow_compat_mode()};
     if (maybe_env_allow_compat && !maybe_env_allow_compat.value()) {
@@ -34,7 +32,15 @@ Configuration::Configuration() : m_fastpath(true), m_fallback(true), m_statsLeve
 bool
 Configuration::fastpath() const noexcept
 {
-    return m_fastpath;
+#ifndef AIS_TESTING
+    static
+#endif
+        bool readExists{!!getHipAmdFileReadPtr()};
+#ifndef AIS_TESTING
+    static
+#endif
+        bool writeExists{!!getHipAmdFileWritePtr()};
+    return readExists && writeExists && m_fastpath;
 }
 
 bool

--- a/src/amd_detail/configuration.cpp
+++ b/src/amd_detail/configuration.cpp
@@ -11,7 +11,7 @@
 
 using namespace hipFile;
 
-Configuration::Configuration() : m_fastpath(true), m_fallback(true)
+Configuration::Configuration() : m_fastpath(true), m_fallback(true), m_statsLevel(0)
 {
     auto maybe_env_force_compat{Environment::force_compat_mode()};
     if (maybe_env_force_compat && maybe_env_force_compat.value()) {
@@ -23,6 +23,11 @@ Configuration::Configuration() : m_fastpath(true), m_fallback(true)
     auto maybe_env_allow_compat{Environment::allow_compat_mode()};
     if (maybe_env_allow_compat && !maybe_env_allow_compat.value()) {
         m_fallback = false;
+    }
+
+    auto maybe_stats_level{Environment::stats_level()};
+    if (maybe_stats_level) {
+        m_statsLevel = maybe_stats_level.value();
     }
 }
 
@@ -36,4 +41,10 @@ bool
 Configuration::fallback() const noexcept
 {
     return m_fallback;
+}
+
+unsigned int
+Configuration::statsLevel() const noexcept
+{
+    return m_statsLevel;
 }

--- a/src/amd_detail/configuration.h
+++ b/src/amd_detail/configuration.h
@@ -20,17 +20,23 @@ public:
     /// @brief Checks if the fallback backend is enabled
     /// @return true if the fallback backend is enabled, false otherwise
     virtual bool fallback() const noexcept = 0;
+
+    /// @brief Shows the level of detail for stats collection
+    /// @return 0 if stats collection disabled, higher levels of detail as value increases
+    virtual unsigned int statsLevel() const noexcept = 0;
 };
 
 class Configuration : public IConfiguration {
-    bool m_fastpath;
-    bool m_fallback;
+    bool         m_fastpath;
+    bool         m_fallback;
+    unsigned int m_statsLevel;
 
 public:
     Configuration();
 
-    bool fastpath() const noexcept override;
-    bool fallback() const noexcept override;
+    bool         fastpath() const noexcept override;
+    bool         fallback() const noexcept override;
+    unsigned int statsLevel() const noexcept override;
 };
 
 }

--- a/src/amd_detail/environment.cpp
+++ b/src/amd_detail/environment.cpp
@@ -7,6 +7,9 @@
 #include "environment.h"
 #include "sys.h"
 
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
 #include <strings.h>
 
 using namespace hipFile;
@@ -28,6 +31,27 @@ Environment::get<bool>(const char *key)
     return std::nullopt;
 }
 
+template <>
+std::optional<unsigned int>
+Environment::get<unsigned int>(const char *key)
+{
+    const char *value{Context<Sys>::get()->getenv(key)};
+    if (value == nullptr)
+        return std::nullopt;
+    errno = 0;
+    char         *end;
+    unsigned long x{std::strtoul(value, &end, 10)};
+    if (errno != 0)
+        return std::nullopt;
+    if (end == value)
+        return std::nullopt;
+    if (*end != '\0')
+        return std::nullopt;
+    if (x > static_cast<unsigned long>(std::numeric_limits<unsigned int>::max()))
+        return std::numeric_limits<unsigned int>::max();
+    return static_cast<unsigned int>(x);
+}
+
 optional<bool>
 Environment::allow_compat_mode()
 {
@@ -38,4 +62,10 @@ optional<bool>
 Environment::force_compat_mode()
 {
     return Environment::get<bool>(Environment::FORCE_COMPAT_MODE);
+}
+
+optional<unsigned int>
+Environment::stats_level()
+{
+    return Environment::get<unsigned int>(Environment::STATS_LEVEL);
 }

--- a/src/amd_detail/environment.h
+++ b/src/amd_detail/environment.h
@@ -39,6 +39,14 @@ public:
     static constexpr const char *const FORCE_COMPAT_MODE{"HIPFILE_FORCE_COMPAT_MODE"};
 
     static std::optional<bool> force_compat_mode();
+
+    /// @brief Control how much information is collected to be reported to ais-stats
+    ///
+    /// 0 indicates no stats should be recorded.
+    /// >= 1 indicates basic stats will be collected.
+    static constexpr const char *const STATS_LEVEL{"HIPFILE_STATS_LEVEL"};
+
+    static std::optional<unsigned int> stats_level();
 };
 
 }

--- a/src/amd_detail/hip.cpp
+++ b/src/amd_detail/hip.cpp
@@ -24,16 +24,22 @@ catch (...) {
 hipAmdFileRead_t
 getHipAmdFileReadPtr()
 {
-    static hipAmdFileRead_t hipAmdFileReadPtr{
-        reinterpret_cast<hipAmdFileRead_t>(hipGetProcAddressHelper("hipAmdFileRead"))};
+#ifndef AIS_TESTING
+    static
+#endif
+        hipAmdFileRead_t hipAmdFileReadPtr{
+            reinterpret_cast<hipAmdFileRead_t>(hipGetProcAddressHelper("hipAmdFileRead"))};
     return hipAmdFileReadPtr;
 }
 
 hipAmdFileWrite_t
 getHipAmdFileWritePtr()
 {
-    static hipAmdFileWrite_t hipAmdFileWritePtr{
-        reinterpret_cast<hipAmdFileRead_t>(hipGetProcAddressHelper("hipAmdFileWrite"))};
+#ifndef AIS_TESTING
+    static
+#endif
+        hipAmdFileWrite_t hipAmdFileWritePtr{
+            reinterpret_cast<hipAmdFileWrite_t>(hipGetProcAddressHelper("hipAmdFileWrite"))};
     return hipAmdFileWritePtr;
 }
 

--- a/src/amd_detail/stats.cpp
+++ b/src/amd_detail/stats.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "configuration.h"
 #include "context.h"
 #include "stats.h"
 #include "sys.h"
@@ -98,7 +99,9 @@ StatsServer::StatsServer()
     Context<Sys>::get()->ftruncate(fd, sizeof(Stats));
     void *shm = Context<Sys>::get()->mmap(nullptr, sizeof(Stats), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     Context<Sys>::get()->fcntl(fd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_FUTURE_WRITE);
-    m_stats  = UniqueStats{new (shm) Stats{}, &statsDeleter};
+    m_stats = UniqueStats{new (shm) Stats{}, &statsDeleter};
+    m_stats->level =
+        std::min(static_cast<StatsLevel>(Context<Configuration>::get()->statsLevel()), StatsLevel::Max);
     m_thread = std::thread(&StatsServer::threadFn, this);
 }
 
@@ -209,6 +212,8 @@ StatsClient::generateReport(std::ostream &stream)
     if (stats == nullptr) {
         return false;
     }
+    stream << "AIS-STATS Version: " << stats->version
+           << "\nHipFile Stats Level: " << static_cast<uint64_t>(stats->level) << '\n';
     switch (stats->version) {
         case 1:
             generateReportV1(stream, stats);
@@ -239,7 +244,7 @@ void
 statsAddFastPathRead(uint64_t bytes)
 {
     Stats *stats{Context<StatsServer>::get()->getStats()};
-    if (stats) {
+    if (stats && stats->level >= StatsLevel::Basic) {
         stats->getCounter(StatsCounters::TotalFastPathReadBytes) += bytes;
     }
 }
@@ -248,7 +253,7 @@ void
 statsAddFastPathWrite(uint64_t bytes)
 {
     Stats *stats{Context<StatsServer>::get()->getStats()};
-    if (stats) {
+    if (stats && stats->level >= StatsLevel::Basic) {
         stats->getCounter(StatsCounters::TotalFastPathWriteBytes) += bytes;
     }
 }
@@ -257,7 +262,7 @@ void
 statsAddFallbackPathRead(uint64_t bytes)
 {
     Stats *stats{Context<StatsServer>::get()->getStats()};
-    if (stats) {
+    if (stats && stats->level >= StatsLevel::Basic) {
         stats->getCounter(StatsCounters::TotalFallbackPathReadBytes) += bytes;
     }
 }
@@ -266,7 +271,7 @@ void
 statsAddFallbackPathWrite(uint64_t bytes)
 {
     Stats *stats{Context<StatsServer>::get()->getStats()};
-    if (stats) {
+    if (stats && stats->level >= StatsLevel::Basic) {
         stats->getCounter(StatsCounters::TotalFallbackPathWriteBytes) += bytes;
     }
 }

--- a/src/amd_detail/stats.h
+++ b/src/amd_detail/stats.h
@@ -14,6 +14,13 @@
 
 namespace hipFile {
 
+enum class StatsLevel : uint64_t {
+    Disabled,
+    Basic,
+    Detailed,
+    Max,
+};
+
 /// When adding new fields, remember to increment Stats::version
 enum class StatsCounters {
     TotalFastPathReadBytes,
@@ -29,6 +36,7 @@ static_assert(StatsCounters::Max <= StatsCounters::Capacity, "Increase StatsCoun
 
 struct Stats {
     using Array = std::array<std::atomic_uint64_t, static_cast<std::size_t>(StatsCounters::Capacity)>;
+    StatsLevel     level{};
     const uint64_t version{1};
     Array          counters;
 

--- a/test/amd_detail/configuration.cpp
+++ b/test/amd_detail/configuration.cpp
@@ -30,6 +30,7 @@ struct ConfigurationExpectationBuilder {
     std::optional<const char *> m_env_stats_level;
     void                       *m_hip_amd_file_read{reinterpret_cast<void *>(0xDEADBEEF)};
     void                       *m_hip_amd_file_write{reinterpret_cast<void *>(0x0BADF00D)};
+    bool                        m_fastpath{false};
 
     ConfigurationExpectationBuilder(StrictMock<MSys> &msys, StrictMock<MHip> &mhip)
         : m_msys(msys), m_mhip(mhip)
@@ -66,6 +67,12 @@ struct ConfigurationExpectationBuilder {
         return *this;
     }
 
+    ConfigurationExpectationBuilder &fastpath()
+    {
+        m_fastpath = true;
+        return *this;
+    }
+
     ConfigurationExpectation build();
 };
 
@@ -95,12 +102,13 @@ struct ConfigurationExpectation {
         else {
             EXPECT_CALL(builder.m_msys, getenv(StrEq(hipFile::Environment::STATS_LEVEL)));
         }
-
-        EXPECT_CALL(builder.m_mhip, hipRuntimeGetVersion).Times(2);
-        EXPECT_CALL(builder.m_mhip, hipGetProcAddress(StrEq("hipAmdFileRead"), _, _, _))
-            .WillOnce(Return(builder.m_hip_amd_file_read));
-        EXPECT_CALL(builder.m_mhip, hipGetProcAddress(StrEq("hipAmdFileWrite"), _, _, _))
-            .WillOnce(Return(builder.m_hip_amd_file_write));
+        if (builder.m_fastpath) {
+            EXPECT_CALL(builder.m_mhip, hipRuntimeGetVersion).Times(2);
+            EXPECT_CALL(builder.m_mhip, hipGetProcAddress(StrEq("hipAmdFileRead"), _, _, _))
+                .WillOnce(Return(builder.m_hip_amd_file_read));
+            EXPECT_CALL(builder.m_mhip, hipGetProcAddress(StrEq("hipAmdFileWrite"), _, _, _))
+                .WillOnce(Return(builder.m_hip_amd_file_write));
+        }
     }
 };
 
@@ -117,31 +125,31 @@ struct HipFileConfiguration : public Test {
 
 TEST_F(HipFileConfiguration, FastpathEnabledIfForceCompatModeEnvironmentVariableIsNotSetOrInvalid)
 {
-    ConfigurationExpectationBuilder{msys, mhip}.build();
+    ConfigurationExpectationBuilder{msys, mhip}.fastpath().build();
     ASSERT_TRUE(Configuration().fastpath());
 }
 
 TEST_F(HipFileConfiguration, FastpathEnabledIfForceCompatModeEnvironmentVariableIsFalse)
 {
-    ConfigurationExpectationBuilder{msys, mhip}.env_force_compat_mode("false").build();
+    ConfigurationExpectationBuilder{msys, mhip}.fastpath().env_force_compat_mode("false").build();
     ASSERT_TRUE(Configuration().fastpath());
 }
 
 TEST_F(HipFileConfiguration, FastpathDisabledIfForceCompatModeEnvironmentVariableIsTrue)
 {
-    ConfigurationExpectationBuilder{msys, mhip}.env_force_compat_mode("true").build();
+    ConfigurationExpectationBuilder{msys, mhip}.fastpath().env_force_compat_mode("true").build();
     ASSERT_FALSE(Configuration().fastpath());
 }
 
 TEST_F(HipFileConfiguration, FastpathDisabledIfHipAmdFileReadIsNotFound)
 {
-    ConfigurationExpectationBuilder{msys, mhip}.hip_amd_file_read(nullptr).build();
+    ConfigurationExpectationBuilder{msys, mhip}.fastpath().hip_amd_file_read(nullptr).build();
     ASSERT_FALSE(Configuration().fastpath());
 }
 
 TEST_F(HipFileConfiguration, FastpathDisabledIfHipAmdFileWriteIsNotFound)
 {
-    ConfigurationExpectationBuilder{msys, mhip}.hip_amd_file_write(nullptr).build();
+    ConfigurationExpectationBuilder{msys, mhip}.fastpath().hip_amd_file_write(nullptr).build();
     ASSERT_FALSE(Configuration().fastpath());
 }
 

--- a/test/amd_detail/configuration.cpp
+++ b/test/amd_detail/configuration.cpp
@@ -27,6 +27,7 @@ struct ConfigurationExpectationBuilder {
     StrictMock<MHip>           &m_mhip;
     std::optional<const char *> m_env_force_compat_mode;
     std::optional<const char *> m_env_allow_compat_mode;
+    std::optional<const char *> m_env_stats_level;
     void                       *m_hip_amd_file_read{reinterpret_cast<void *>(0xDEADBEEF)};
     void                       *m_hip_amd_file_write{reinterpret_cast<void *>(0x0BADF00D)};
 
@@ -44,6 +45,12 @@ struct ConfigurationExpectationBuilder {
     ConfigurationExpectationBuilder &env_allow_compat_mode(const char *value)
     {
         m_env_allow_compat_mode = value;
+        return *this;
+    }
+
+    ConfigurationExpectationBuilder &env_stats_level(const char *value)
+    {
+        m_env_stats_level = value;
         return *this;
     }
 
@@ -79,6 +86,14 @@ struct ConfigurationExpectation {
         }
         else {
             EXPECT_CALL(builder.m_msys, getenv(StrEq(hipFile::Environment::ALLOW_COMPAT_MODE)));
+        }
+
+        if (builder.m_env_stats_level) {
+            EXPECT_CALL(builder.m_msys, getenv(StrEq(hipFile::Environment::STATS_LEVEL)))
+                .WillOnce(Return(const_cast<char *>(builder.m_env_stats_level.value())));
+        }
+        else {
+            EXPECT_CALL(builder.m_msys, getenv(StrEq(hipFile::Environment::STATS_LEVEL)));
         }
 
         EXPECT_CALL(builder.m_mhip, hipRuntimeGetVersion).Times(2);
@@ -146,6 +161,18 @@ TEST_F(HipFileConfiguration, FallbackDisabledIfAllowCompatModeEnvironmentVariabl
 {
     ConfigurationExpectationBuilder{msys, mhip}.env_allow_compat_mode("false").build();
     ASSERT_FALSE(Configuration().fallback());
+}
+
+TEST_F(HipFileConfiguration, StatsLevelEnvironmentVariableIsNotSetOrInvalid)
+{
+    ConfigurationExpectationBuilder{msys, mhip}.build();
+    ASSERT_EQ(0, Configuration().statsLevel());
+}
+
+TEST_F(HipFileConfiguration, StatsLevelEnvironmentVariableIsSet)
+{
+    ConfigurationExpectationBuilder{msys, mhip}.env_stats_level("1").build();
+    ASSERT_EQ(1, Configuration().statsLevel());
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/environment.cpp
+++ b/test/amd_detail/environment.cpp
@@ -63,4 +63,32 @@ TEST(HipFileEnvironment, GetBoolReturnsOptionalFalseIfFalse)
     ASSERT_EQ(hipFile::Environment::get<bool>(""), make_optional<>(false));
 }
 
+TEST(HipFileEnvironment, GetUnsignedIntReturnsNulloptIfNotSet)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(nullptr));
+    ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), nullopt);
+}
+
+TEST(HipFileEnvironment, GetUnsignedIntReturnsNulloptIfValueIsInvalid)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("blah")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), nullopt);
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), nullopt);
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("1abc")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), nullopt);
+}
+
+TEST(HipFileEnvironment, GetUnsignedIntReturnsIntIfValueIsInt)
+{
+    StrictMock<MSys> msys;
+
+    EXPECT_CALL(msys, getenv).WillOnce(Return(const_cast<char *>("0")));
+    ASSERT_EQ(hipFile::Environment::get<unsigned int>(""), make_optional<>(0));
+}
+
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/mconfiguration.h
+++ b/test/amd_detail/mconfiguration.h
@@ -14,6 +14,7 @@ namespace rocFile {
 struct MConfiguration : IConfiguration {
     MOCK_METHOD(bool, fastpath, (), (const, noexcept, override));
     MOCK_METHOD(bool, fallback, (), (const, noexcept, override));
+    MOCK_METHOD(unsigned int, statsLevel, (), (const, noexcept, override));
 };
 
 }

--- a/test/amd_detail/stats.cpp
+++ b/test/amd_detail/stats.cpp
@@ -28,8 +28,12 @@ struct HipFileStats : public HipFileUnopened {};
         Stats                    stats{};                                                                    \
         StrictMock<MStatsServer> mstats{};                                                                   \
         EXPECT_CALL(mstats, getStats).WillRepeatedly(testing::Return(&stats));                               \
+        stats.level = StatsLevel::Basic;                                                                     \
         statsAdd##name(0x10);                                                                                \
         ASSERT_EQ(0x10, stats.getCounter(StatsCounters::Total##name##Bytes).load());                         \
+        statsAdd##name(0x10);                                                                                \
+        ASSERT_EQ(0x20, stats.getCounter(StatsCounters::Total##name##Bytes).load());                         \
+        stats.level = StatsLevel::Disabled;                                                                  \
         statsAdd##name(0x10);                                                                                \
         ASSERT_EQ(0x20, stats.getCounter(StatsCounters::Total##name##Bytes).load());                         \
     }


### PR DESCRIPTION
## Motivation

AIHIPFILE-53 It's possible as we add more counters to ais-stats that we may start to see a performance overhead to the data collection. This setting will be used to let us control exactly how much data we collect from a given process in the event very detailed stats gathering has a large performance impact.

## Technical Details

Adds an environment variable(HIPFILE_STATS_LEVEL) and Configuration method(::statsLevel()) in the same vein as HIPFILE_FORCE_COMPAT_MODE.

## Test Plan

Added Environment and Configuration unit tests for the new functions.

## Test Result

All unit tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
