### PR TITLE
Update GTest CMake for use w/ sanitizers

### DIFF
--- a/cmake/AISUseGTest.cmake
+++ b/cmake/AISUseGTest.cmake
@@ -7,24 +7,20 @@ include(FetchContent)
 # This line is used (or not) in FetchContent_Declare to determine
 # if we check for a system GoogleTest install first. When building
 # with the sanitizers, we HAVE to build GoogleTest from source.
-#
-# lint_cmake: -readability/wonkycase
 if(AIS_USE_SANITIZERS OR AIS_USE_INTEGER_SANITIZER OR AIS_USE_THREAD_SANITIZER)
-    FetchContent_Declare(
-      googletest
-      URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
-      DOWNLOAD_EXTRACT_TIMESTAMP true
-      SYSTEM
-    )
+    set(AIS_LOCAL_GTEST_CHECK "")
 else()
-    FetchContent_Declare(
-      googletest
-      URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
-      DOWNLOAD_EXTRACT_TIMESTAMP true
-      FIND_PACKAGE_ARGS NAMES GTest         # <-- Different
-      SYSTEM
-    )
+    set(AIS_LOCAL_GTEST_CHECK FIND_PACKAGE_ARGS NAMES GTest)
 endif()
+
+# lint_cmake: -readability/wonkycase
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
+  DOWNLOAD_EXTRACT_TIMESTAMP true
+  ${AIS_LOCAL_GTEST_CHECK}
+  SYSTEM
+)
 # lint_cmake: +readability/wonkycase
 
 set(INSTALL_GTEST OFF CACHE BOOL "Don't install GoogleTest")

--- a/cmake/AISUseGTest.cmake
+++ b/cmake/AISUseGTest.cmake
@@ -9,7 +9,7 @@ include(FetchContent)
 # with the sanitizers, we HAVE to build GoogleTest from source.
 #
 # lint_cmake: -readability/wonkycase
-if(AIS_USE_SANITIZERS)
+if(AIS_USE_SANITIZERS OR AIS_USE_INTEGER_SANITIZER OR AIS_USE_THREAD_SANITIZER)
     FetchContent_Declare(
       googletest
       URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz

--- a/cmake/AISUseGTest.cmake
+++ b/cmake/AISUseGTest.cmake
@@ -4,25 +4,40 @@
 
 include(FetchContent)
 
+# This line is used (or not) in FetchContent_Declare to determine
+# if we check for a system GoogleTest install first. When building
+# with the sanitizers, we HAVE to build GoogleTest from source.
+#
 # lint_cmake: -readability/wonkycase
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
-  DOWNLOAD_EXTRACT_TIMESTAMP true
-  FIND_PACKAGE_ARGS NAMES GTest
-  SYSTEM
-)
+if(AIS_USE_SANITIZERS)
+    FetchContent_Declare(
+      googletest
+      URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
+      DOWNLOAD_EXTRACT_TIMESTAMP true
+      SYSTEM
+    )
+else()
+    FetchContent_Declare(
+      googletest
+      URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
+      DOWNLOAD_EXTRACT_TIMESTAMP true
+      FIND_PACKAGE_ARGS NAMES GTest         # <-- Different
+      SYSTEM
+    )
+endif()
+# lint_cmake: +readability/wonkycase
 
-set(INSTALL_GTEST OFF CACHE BOOL "Don't install gtest.")
-set(GTEST_HAS_ABSL OFF CACHE BOOL "Don't use abseil for GTest.")
+set(INSTALL_GTEST OFF CACHE BOOL "Don't install GoogleTest")
+set(GTEST_HAS_ABSL OFF CACHE BOOL "Don't use Abseil for GoogleTest")
 
+# lint_cmake: -readability/wonkycase
 FetchContent_MakeAvailable(googletest)
 # lint_cmake: +readability/wonkycase
 
-if(rocm-cmake_SOURCE_DIR)
-    message(STATUS "Using fetched googletest.")
+if(googletest_SOURCE_DIR)
+    message(STATUS "Using fetched GoogleTest")
 else()
-    message(STATUS "Using system googletest.")
+    message(STATUS "Using system GoogleTest")
 endif()
 
 include(GoogleTest)


### PR DESCRIPTION
Ensure that GoogleTest is fetched and built from source with the same flags as the library when building with the sanitizers enabled. Without this, we don't see useful output when there are failures.

Part of AIHIPFILE-62