### PR TITLE
Rework sanitizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * `hipFileRead()`/`hipFileWrite()` will transfer at most 0x7ffff000 (2,147,479,552) bytes returning the number of bytes actually transferred
 * The CMake namespace was changed from `roc::` to `hip::`
 * `AIS_BUILD_EXAMPLES` has been renamed to `AIS_INSTALL_EXAMPLES`
-* `AIS_USE_SANITIZERS` now includes the following sanitizers: integer, float-divide-by-zero, local-bounds, vptr, nullability. Sanitizers should also now emit usable stack trace info.
+* `AIS_USE_SANITIZERS` now also enables the following sanitizers: integer, float-divide-by-zero, local-bounds, vptr, nullability (in addition to address, leak, and undefined). Sanitizers should also now emit usable stack trace info.
 
 ### Removed
 * The rocFile library has been completely removed and the code is now a part of hipFile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@
 * `hipFileRead()`/`hipFileWrite()` will transfer at most 0x7ffff000 (2,147,479,552) bytes returning the number of bytes actually transferred
 * The CMake namespace was changed from `roc::` to `hip::`
 * `AIS_BUILD_EXAMPLES` has been renamed to `AIS_INSTALL_EXAMPLES`
+* `AIS_USE_SANITIZERS` now includes the following sanitizers: integer, float-divide-by-zero, local-bounds, vptr, nullability. Sanitizers should also now emit usable stack trace info.
 
 ### Removed
 * The rocFile library has been completely removed and the code is now a part of hipFile.
 * The hipify patch was removed. You can get hipify with hipFile support at https://github.com/derobins/HIPIFY/tree/hipFile.
+* Dropped the `AIS_USE_INTEGER_SANITIZER` CMake option. This has been rolled into the broader `AIS_USE_SANITIZERS` option.
+* Dropped support for GNU sanitizers (probably temporary)
 
 ### Limitations
 * The batch API calls are not supported w/ an AMD backend

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -117,7 +117,7 @@ Options
 Sanitizer options
 |Option|Default|Purpose|
 |------|-------|-------|
-|AIS\_USE\_SANITIZERS|OFF|Build with -fsanitize=address, leak, and undefined|
+|AIS\_USE\_SANITIZERS|OFF|Build with -fsanitize=address,float-divide-by-zero,integer,leak,local-bounds,undefined,vptr|
 |AIS\_USE\_THREAD\_SANITIZER|OFF|Build with -fsanitize=thread (not compatible with AIS\_USE\_SANITIZERS)|
 
 ### Build

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -118,7 +118,6 @@ Sanitizer options
 |Option|Default|Purpose|
 |------|-------|-------|
 |AIS\_USE\_SANITIZERS|OFF|Build with -fsanitize=address, leak, and undefined|
-|AIS\_USE\_INTEGER\_SANITIZER|OFF|Build with -fsanitize=integer (clang only)|
 |AIS\_USE\_THREAD\_SANITIZER|OFF|Build with -fsanitize=thread (not compatible with AIS\_USE\_SANITIZERS)|
 
 ### Build

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -114,10 +114,10 @@ Options
 |AIS\_USE\_IWYU|OFF|Run the `include-what-you-use` tool (clang only)|
 |AIS\_WARN\_UNSAFE\_BUFFER\_OPS|ON|Scan code for unsafe buffer operations (clang only, OFF for others)|
 
-Sanitizer options
+Sanitizer options (clang only)
 |Option|Default|Purpose|
 |------|-------|-------|
-|AIS\_USE\_SANITIZERS|OFF|Build with -fsanitize=address,float-divide-by-zero,integer,leak,local-bounds,undefined,vptr|
+|AIS\_USE\_SANITIZERS|OFF|Build with -fsanitize=address,float-divide-by-zero,integer,leak,local-bounds,nullability,undefined,vptr|
 |AIS\_USE\_THREAD\_SANITIZER|OFF|Build with -fsanitize=thread (not compatible with AIS\_USE\_SANITIZERS)|
 
 ### Build

--- a/cmake/AISCompilerOptions.cmake
+++ b/cmake/AISCompilerOptions.cmake
@@ -6,6 +6,7 @@
 
 include(AISClangCompilerOptions)
 include(AISGNUCompilerOptions)
+include(AISSanitizers)
 
 function(ais_set_compiler_flags target)
     get_target_property(sources ${target} SOURCES)
@@ -38,7 +39,9 @@ function(ais_set_compiler_flags target)
         endif()
     endforeach()
 
-    ais_add_sanitizers(${target})
+    if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
+        ais_add_sanitizers(${target})
+    endif()
 
     if(NOT BUILD_TESTING)
         target_compile_options(${target} PRIVATE -fvisibility=hidden)

--- a/cmake/AISSanitizers.cmake
+++ b/cmake/AISSanitizers.cmake
@@ -2,53 +2,50 @@
 #
 # SPDX-License-Identifier: MIT
 
-option(AIS_USE_SANITIZERS "Build with -fsanitize=address, leak, and undefined" OFF)
-option(AIS_USE_THREAD_SANITIZER "Build with -fsanitize=thread (not compatible with AIS_USE_SANITIZERS)" OFF)
-option(AIS_USE_INTEGER_SANITIZER "Build with -fsanitize=integer (clang only)" OFF)
+option(AIS_USE_SANITIZERS "Build with sanitizers (clang only - see docs for a list)" OFF)
+option(AIS_USE_THREAD_SANITIZER "Build with -fsanitize=thread (clang only - not compatible with AIS_USE_SANITIZERS)" OFF)
 
 if(AIS_USE_THREAD_SANITIZER)
     message(WARNING "TSAN has known problems with higher levels of entropy, try using `sudo sysctl vm.mmap_rnd_bits=28` if you encounter errors concerning unexpected memory mappings.")
 endif()
 
 function(ais_add_sanitizers target)
+    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        message(FATAL_ERROR "The sanitizers are only available on clang")
+    endif()
+
     if(AIS_USE_SANITIZERS AND AIS_USE_THREAD_SANITIZER)
         message(FATAL_ERROR "AIS_USE_SANITIZERS is not compatible with AIS_USE_THREAD_SANITIZER")
     endif()
 
     if(AIS_USE_SANITIZERS)
-        # TODO: Consider other sanitizer options
-        target_compile_options(${target} PRIVATE -fsanitize=address)
-        target_link_options(${target} PRIVATE -fsanitize=address)
-        target_compile_options(${target} PRIVATE -fsanitize=leak)
-        target_link_options(${target} PRIVATE -fsanitize=leak)
-        target_compile_options(${target} PRIVATE -fsanitize=undefined)
-        target_link_options(${target} PRIVATE -fsanitize=undefined)
-
-        target_compile_options(${target} PRIVATE -fno-omit-frame-pointer)
+        set(SANITIZER_LIST address,float-divide-by-zero,integer,leak,local-bounds,nullability,undefined,vptr)
+        target_compile_options(${target} PRIVATE
+            $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=${SANITIZER_LIST}>
+            $<$<COMPILE_LANGUAGE:CXX>:-fno-sanitize-recover=integer>
+        )
+        target_link_options(${target} PRIVATE
+            -Xarch_host -fsanitize=${SANITIZER_LIST}
+            -Xarch_host -fno-sanitize-recover=integer
+        )
     endif()
 
     if(AIS_USE_THREAD_SANITIZER)
-        target_compile_options(${target} PRIVATE -fsanitize=thread)
-        target_link_options(${target} PRIVATE -fsanitize=thread)
+        target_compile_options(${target} PRIVATE
+            $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=thread>
+        )
+        target_link_options(${target} PRIVATE
+            -Xarch_host -fsanitize=thread
+        )
     endif()
 
-    # clang-only
-    #
-    # This has a very small runtime penalty (<1%) and will kill
-    # the process if undefined integer behaviour occurs (like
-    # wrapping a signed integer).
-    if(AIS_USE_INTEGER_SANITIZER)
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-            set(integer_sanitize_flags
-                -fsanitize=integer
-                -fsanitize-minimal-runtime
-                -fno-sanitize-recover=integer
-            )
-            target_compile_options(${target} PRIVATE ${integer_sanitize_flags})
-            target_link_options(${target} PRIVATE ${integer_sanitize_flags})
-        else()
-            message(FATAL_ERROR "The integer sanitizer is only available on clang")
-        endif()
-    endif()
-
+    # Options for all sanitizers
+    target_compile_options(${target} PRIVATE
+        -fno-omit-frame-pointer
+    )
+    target_link_options(${target} PRIVATE
+        -fuse-ld=lld
+        --rtlib=compiler-rt
+        --unwindlib=libgcc
+    )
 endfunction()

--- a/cmake/AISUseGTest.cmake
+++ b/cmake/AISUseGTest.cmake
@@ -7,7 +7,7 @@ include(FetchContent)
 # This line is used (or not) in FetchContent_Declare to determine
 # if we check for a system GoogleTest install first. When building
 # with the sanitizers, we HAVE to build GoogleTest from source.
-if(AIS_USE_SANITIZERS OR AIS_USE_INTEGER_SANITIZER OR AIS_USE_THREAD_SANITIZER)
+if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
     set(AIS_LOCAL_GTEST_CHECK "")
 else()
     set(AIS_LOCAL_GTEST_CHECK FIND_PACKAGE_ARGS NAMES GTest)

--- a/cmake/AISUseGTest.cmake
+++ b/cmake/AISUseGTest.cmake
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+include(AISSanitizers)
 include(FetchContent)
 
 # This line is used (or not) in FetchContent_Declare to determine

--- a/docs/sanitizers.rst
+++ b/docs/sanitizers.rst
@@ -4,9 +4,9 @@ sanitizers
 hipFile has CMake support for running various sanitizers. There are
 two CMake options that control this:
 
-`AIS_USE_SANITIZERS`
+``AIS_USE_SANITIZERS``
 
-This adds `-fsanitize=<sanitizers>` where <sanitizers> includes:
+This adds ``-fsanitize=<sanitizers>`` where <sanitizers> includes:
 
 * address
 * float-divide-by-zero
@@ -17,10 +17,10 @@ This adds `-fsanitize=<sanitizers>` where <sanitizers> includes:
 * undefined
 * vptr
 
-`AIS_USE_THREAD_SANITIZER`
+``AIS_USE_THREAD_SANITIZER``
 
-This adds `-fsanitize=thread`, which is not compatible with
-`AIS_USE_SANITIZERS`.
+This adds ``-fsanitize=thread``, which is not compatible with
+``AIS_USE_SANITIZERS``.
 
 NOTE: We currently only support clang's sanitizers. We'll add GNU in
       the future.

--- a/docs/sanitizers.rst
+++ b/docs/sanitizers.rst
@@ -1,0 +1,39 @@
+sanitizers
+==========
+
+hipFile has CMake support for running various sanitizers. There are
+two CMake options that control this:
+
+`AIS_USE_SANITIZERS`
+
+This adds `-fsanitize=<sanitizers>` where <sanitizers> includes:
+
+* address
+* float-divide-by-zero
+* integer
+* leak
+* local-bounds
+* nullability
+* undefined
+* vptr
+
+`AIS_USE_THREAD_SANITIZER`
+
+This adds `-fsanitize=thread`, which is not compatible with
+`AIS_USE_SANITIZERS`.
+
+NOTE: We currently only support clang's sanitizers. We'll add GNU in
+      the future.
+
+We also add the following options to the test environment when running
+CTest:
+
+`ASAN_OPTIONS=print_stacktrace=1:symbolize=1:fast_unwind_on_malloc=0:malloc_context_size=30`
+
+`USBSAN_OPTIONS=print_stacktrace=1:symbolize=1`
+
+This should give you stack traces on failures, though you will need
+sanitizer-built ROCm libraries to track anything that was allocated
+in the HIP layer. We fetch and build GoogleTest with the sanitizer
+options set instead of using the system GoogleTest when the sanitizers
+are enabled.

--- a/docs/sanitizers.rst
+++ b/docs/sanitizers.rst
@@ -25,14 +25,8 @@ This adds `-fsanitize=thread`, which is not compatible with
 NOTE: We currently only support clang's sanitizers. We'll add GNU in
       the future.
 
-We also add the following options to the test environment when running
-CTest:
-
-`ASAN_OPTIONS=print_stacktrace=1:symbolize=1:fast_unwind_on_malloc=0:malloc_context_size=30`
-
-`UBSAN_OPTIONS=print_stacktrace=1:symbolize=1`
-
-This should give you stack traces on failures, though you will need
+We don't set any sanitizer environment variables, but this should
+still give you stack traces on failures, though you will need
 sanitizer-built ROCm libraries to track anything that was allocated
 in the HIP layer. We fetch and build GoogleTest with the sanitizer
 options set instead of using the system GoogleTest when the sanitizers

--- a/docs/sanitizers.rst
+++ b/docs/sanitizers.rst
@@ -30,7 +30,7 @@ CTest:
 
 `ASAN_OPTIONS=print_stacktrace=1:symbolize=1:fast_unwind_on_malloc=0:malloc_context_size=30`
 
-`USBSAN_OPTIONS=print_stacktrace=1:symbolize=1`
+`UBSAN_OPTIONS=print_stacktrace=1:symbolize=1`
 
 This should give you stack traces on failures, though you will need
 sanitizer-built ROCm libraries to track anything that was allocated

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 include(AISAddExecutable)
 include(AISUseGTest)
+include(AISSanitizers)
+
 find_package(Boost COMPONENTS program_options REQUIRED)
 
 set(SHARED_SOURCE_FILES
@@ -73,6 +75,15 @@ ais_gtest_discover_tests(
     PROPERTIES "LABELS;system;LABELS;hipfile"
     TEST_LIST hipfile_system_tests
 )
+
+if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
+    set(SANITIZER_ENV
+        "ASAN_OPTIONS=print_stacktrace=1:symbolize=1:fast_unwind_on_malloc=0:malloc_context_size=30"
+        "USBSAN_OPTIONS=print_stacktrace=1:symbolize=1"
+    )
+    set_tests_properties(${hipfile_tests} PROPERTIES ENVIRONMENT "${SANITIZER_ENV}")
+    set_tests_properties(${hipfile_system_tests} PROPERTIES ENVIRONMENT "${SANITIZER_ENV}")
+endif()
 
 # Temporary Test Files
 # Can be deleted once proper testing added

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,7 +79,7 @@ ais_gtest_discover_tests(
 if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
     set(SANITIZER_ENV
         "ASAN_OPTIONS=print_stacktrace=1:symbolize=1:fast_unwind_on_malloc=0:malloc_context_size=30"
-        "USBSAN_OPTIONS=print_stacktrace=1:symbolize=1"
+        "UBSAN_OPTIONS=print_stacktrace=1:symbolize=1"
     )
     set_tests_properties(${hipfile_tests} PROPERTIES ENVIRONMENT "${SANITIZER_ENV}")
     set_tests_properties(${hipfile_system_tests} PROPERTIES ENVIRONMENT "${SANITIZER_ENV}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,15 +76,6 @@ ais_gtest_discover_tests(
     TEST_LIST hipfile_system_tests
 )
 
-if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
-    set(SANITIZER_ENV
-        "ASAN_OPTIONS=print_stacktrace=1:symbolize=1:fast_unwind_on_malloc=0:malloc_context_size=30"
-        "UBSAN_OPTIONS=print_stacktrace=1:symbolize=1"
-    )
-    set_tests_properties(${hipfile_tests} PROPERTIES ENVIRONMENT "${SANITIZER_ENV}")
-    set_tests_properties(${hipfile_system_tests} PROPERTIES ENVIRONMENT "${SANITIZER_ENV}")
-endif()
-
 # Temporary Test Files
 # Can be deleted once proper testing added
 # ----------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,6 @@
 
 include(AISAddExecutable)
 include(AISUseGTest)
-include(AISSanitizers)
 
 find_package(Boost COMPONENTS program_options REQUIRED)
 


### PR DESCRIPTION
* Drop AIS_USE_INTEGER_SANITIZER and roll that into AIS_USE_SANITIZERS
* Add additional sanitizers:
    * float-divide-by-zero
    * vptr
    * local-bounds
    * nullability
* All sanitizers are clang-only (for now)
* Protect C++ compiler options with generator expressions
* Protect linker options with -Xarch_host
* Add the following linker options under sanitizers. These select the LLVM linker and runtime, but GNU unwind library.
    * -fuse-ld=lld
    * --rtlib=compiler-rt
    * --unwindlib=libgcc

Part of AIHIPFILE-62