### PR TITLE
ais-check: Add a check for kernel P2PDMA support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ wget https://github.com/ROCm/hipFile/releases/download/nightly/hipfile-dev_0.2.0
 sudo dpkg -i hipfile-dev_0.2.0.70200-nightly.9999.24.04_amd64.deb hipfile_0.2.0.70200-nightly.9999.24.04_amd64.deb
 ```
 
-We can verify that the HIP runtime and the amdgpu kernel module support AIS by running ais-check.
+We can verify that the HIP libraries and kernel support AIS by running ais-check.
 
 ```
 /opt/rocm/bin/ais-check

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,8 +28,9 @@ Successful output from ais-check will show true for both:
 
 ```
 AIS support in:
-   HIP Runtime: true
-        amdgpu: true
+        Kernel P2PDMA support   : True
+        HIP runtime             : True
+        amdgpu                  : True
 ```
 
 hipFile currently works on local NVMe disks. To set up a new NVMe device we can partition it, create a filesystem on the partition, and mount it. Below we use the device `/dev/nvme1n1`. Make sure you use the correct device in your system.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ We can verify that the HIP runtime and the amdgpu kernel module support AIS by r
 /opt/rocm/bin/ais-check
 ```
 
-Successful output from ais-check will show true for both:
+Successful output from ais-check will show True for several checks:
 
 ```
 AIS support in:

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -38,7 +38,7 @@ def kernel_supports_p2pdma():
                         "CONFIG_PCI_P2PDMA=m"
                     ):
                         return True
-        except OSError as e:
+        except OSError:
             continue
 
     if not configs_found:

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -22,20 +22,25 @@ def kernel_supports_p2pdma():
     Check for P2P DMA support in the kernel
     """
 
-    kr = os.uname().release
+    try:
+        kr = os.uname().release
 
-    for path, opener in [
-        (f"/boot/config-{kr}", open),
-        ("/proc/config.gz", gzip.open),
-    ]:
-        if os.path.exists(path):
-            with opener(path, "rt") as f:
-                for line in f:
-                    if line.startswith("CONFIG_PCI_P2PDMA=y") or line.startswith(
-                        "CONFIG_PCI_P2PDMA=m"
-                    ):
-                        return True
-    return False
+        for path, opener in [
+            (f"/boot/config-{kr}", open),
+            ("/proc/config.gz", gzip.open),
+        ]:
+            if os.path.exists(path):
+                with opener(path, "rt") as f:
+                    for line in f:
+                        if line.startswith("CONFIG_PCI_P2PDMA=y") or line.startswith(
+                            "CONFIG_PCI_P2PDMA=m"
+                        ):
+                            return True
+        return False
+
+    except (OSError, PermissionError) as e:
+        print(f"kernel_supports_p2pdma() check failed: {e}", file=sys.stderr)
+        return False
 
 
 def hip_runtime_supports_ais():

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -23,6 +23,7 @@ def kernel_supports_p2pdma():
     """
 
     kr = os.uname().release
+    configs_found = False
 
     for path, opener in [
         (f"/boot/config-{kr}", open),
@@ -30,6 +31,7 @@ def kernel_supports_p2pdma():
         ("/proc/config.gz", gzip.open),
     ]:
         if os.path.exists(path):
+            configs_found = True
             try:
                 with opener(path, "rt") as f:
                     for line in f:
@@ -41,6 +43,8 @@ def kernel_supports_p2pdma():
                 print(f"kernel_supports_p2pdma() check failed: {e}", file=sys.stderr)
                 continue
 
+    if not configs_found:
+        print("No kernel config files found!")
     return False
 
 

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -14,7 +14,6 @@ import ctypes
 import ctypes.util
 import gzip
 import os
-import subprocess
 import sys
 
 
@@ -23,7 +22,7 @@ def kernel_supports_p2pdma():
     Check for P2P DMA support in the kernel
     """
 
-    kr = subprocess.check_output(["uname", "-r"]).decode().strip()
+    kr = os.uname().release
 
     for path, opener in [
         (f"/boot/config-{kr}", open),

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -151,6 +151,11 @@ def main():
     ]
 
     if not args.quiet:
+        u = os.uname()
+        print()
+        print(u.sysname, u.nodename, u.release, u.version, u.machine)
+        print()
+
         print("AIS support in:")
         for name, supported in component_support:
             print(f"\t{name:<24}: {supported}")

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -30,18 +30,17 @@ def kernel_supports_p2pdma():
         (f"/lib/modules/{kr}/build/.config", open),
         ("/proc/config.gz", gzip.open),
     ]:
-        if os.path.exists(path):
-            configs_found = True
-            try:
-                with opener(path, "rt") as f:
-                    for line in f:
-                        if line.startswith("CONFIG_PCI_P2PDMA=y") or line.startswith(
-                            "CONFIG_PCI_P2PDMA=m"
-                        ):
-                            return True
-            except OSError as e:
-                print(f"kernel_supports_p2pdma() check failed: {e}", file=sys.stderr)
-                continue
+        try:
+            with opener(path, "rt") as f:
+                configs_found = True
+                for line in f:
+                    if line.startswith("CONFIG_PCI_P2PDMA=y") or line.startswith(
+                        "CONFIG_PCI_P2PDMA=m"
+                    ):
+                        return True
+        except OSError as e:
+            print(f"kernel_supports_p2pdma() check failed: {e}", file=sys.stderr)
+            continue
 
     if not configs_found:
         print("No kernel config files found!", file=sys.stderr)

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -133,8 +133,8 @@ def amdgpu_supports_ais():
 
 def main():
     """
-    Parse command-line arguments, check AIS support in HIP Runtime and
-    amdgpu, optionally print the results, and return an exit code indicating
+    Parse command-line arguments, check AIS support in kernel/libraries,
+    optionally print the results, and return an exit code indicating
     whether all required components support AIS.
     """
 

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -143,14 +143,14 @@ def main():
 
     component_support = [
         ("Kernel P2PDMA support", kernel_supports_p2pdma()),
-        ("HIP Runtime", hip_runtime_supports_ais()),
+        ("HIP runtime", hip_runtime_supports_ais()),
         ("amdgpu", amdgpu_supports_ais()),
     ]
 
     if not args.quiet:
         print("AIS support in:")
         for name, supported in component_support:
-            print(f"  {name:>12}: {'true' if supported else 'false'}")
+            print(f"\t{name:<24}: {supported}")
 
     return int(not all(supported for (_, supported) in component_support))
 

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -39,7 +39,7 @@ def kernel_supports_p2pdma():
                             return True
         return False
 
-    except (OSError, PermissionError) as e:
+    except (OSError) as e:
         print(f"kernel_supports_p2pdma() check failed: {e}", file=sys.stderr)
         return False
 

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -22,26 +22,26 @@ def kernel_supports_p2pdma():
     Check for P2P DMA support in the kernel
     """
 
-    try:
-        kr = os.uname().release
+    kr = os.uname().release
 
-        for path, opener in [
-            (f"/boot/config-{kr}", open),
-            (f"/lib/modules/{kr}/build/.config", open),
-            ("/proc/config.gz", gzip.open),
-        ]:
-            if os.path.exists(path):
+    for path, opener in [
+        (f"/boot/config-{kr}", open),
+        (f"/lib/modules/{kr}/build/.config", open),
+        ("/proc/config.gz", gzip.open),
+    ]:
+        if os.path.exists(path):
+            try:
                 with opener(path, "rt") as f:
                     for line in f:
                         if line.startswith("CONFIG_PCI_P2PDMA=y") or line.startswith(
                             "CONFIG_PCI_P2PDMA=m"
                         ):
                             return True
-        return False
+            except OSError as e:
+                print(f"kernel_supports_p2pdma() check failed: {e}", file=sys.stderr)
+                continue
 
-    except (OSError) as e:
-        print(f"kernel_supports_p2pdma() check failed: {e}", file=sys.stderr)
-        return False
+    return False
 
 
 def hip_runtime_supports_ais():

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -27,6 +27,7 @@ def kernel_supports_p2pdma():
 
         for path, opener in [
             (f"/boot/config-{kr}", open),
+            (f"/lib/modules/{kr}/build/.config", open),
             ("/proc/config.gz", gzip.open),
         ]:
             if os.path.exists(path):

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -39,7 +39,6 @@ def kernel_supports_p2pdma():
                     ):
                         return True
         except OSError as e:
-            print(f"kernel_supports_p2pdma() check failed: {e}", file=sys.stderr)
             continue
 
     if not configs_found:

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -12,7 +12,31 @@ If components are missing the program exits with a non-zero exit code.
 import argparse
 import ctypes
 import ctypes.util
+import gzip
+import os
+import subprocess
 import sys
+
+
+def kernel_supports_p2pdma():
+    """
+    Check for P2P DMA support in the kernel
+    """
+
+    kr = subprocess.check_output(["uname", "-r"]).decode().strip()
+
+    for path, opener in [
+        (f"/boot/config-{kr}", open),
+        ("/proc/config.gz", gzip.open),
+    ]:
+        if os.path.exists(path):
+            with opener(path, "rt") as f:
+                for line in f:
+                    if line.startswith("CONFIG_PCI_P2PDMA=y") or line.startswith(
+                        "CONFIG_PCI_P2PDMA=m"
+                    ):
+                        return True
+    return False
 
 
 def hip_runtime_supports_ais():
@@ -114,6 +138,7 @@ def main():
     args = parser.parse_args()
 
     component_support = [
+        ("Kernel P2PDMA support", kernel_supports_p2pdma()),
         ("HIP Runtime", hip_runtime_supports_ais()),
         ("amdgpu", amdgpu_supports_ais()),
     ]

--- a/tools/ais-check/ais-check
+++ b/tools/ais-check/ais-check
@@ -44,7 +44,7 @@ def kernel_supports_p2pdma():
                 continue
 
     if not configs_found:
-        print("No kernel config files found!")
+        print("No kernel config files found!", file=sys.stderr)
     return False
 
 


### PR DESCRIPTION
Looks for CONFIG_PCI_P2PDMA=y, m, or n in the config files

Also adds `uname -a`-like output

Part of AIHIPFILE-139