### PR TITLE
Add -UNDEBUG for all tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,7 +48,7 @@ ais_add_executable(
     SYSINCLS ${TEST_SYSINCLS}
 )
 target_compile_options(hipfile_tests
-    PRIVATE "-UNDEBUG" -Wno-unused-function
+    PRIVATE -UNDEBUG -Wno-unused-function
 )
 target_link_libraries(hipfile_tests PRIVATE GTest::gtest)
 target_link_libraries(hipfile_tests PRIVATE GTest::gtest_main)
@@ -65,7 +65,7 @@ ais_add_executable(
     SRCS ${SYSTEM_TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
     SYSINCLS ${TEST_SYSINCLS}
 )
-target_compile_options(hipfile_system_tests PRIVATE "-UNDEBUG")
+target_compile_options(hipfile_system_tests PRIVATE -UNDEBUG)
 target_link_libraries(hipfile_system_tests PRIVATE GTest::gtest)
 target_link_libraries(hipfile_system_tests PRIVATE Boost::program_options)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,7 +48,7 @@ ais_add_executable(
     SYSINCLS ${TEST_SYSINCLS}
 )
 target_compile_options(hipfile_tests
-    PRIVATE -Wno-unused-function
+    PRIVATE "-UNDEBUG" -Wno-unused-function
 )
 target_link_libraries(hipfile_tests PRIVATE GTest::gtest)
 target_link_libraries(hipfile_tests PRIVATE GTest::gtest_main)
@@ -65,6 +65,7 @@ ais_add_executable(
     SRCS ${SYSTEM_TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
     SYSINCLS ${TEST_SYSINCLS}
 )
+target_compile_options(hipfile_system_tests PRIVATE "-UNDEBUG")
 target_link_libraries(hipfile_system_tests PRIVATE GTest::gtest)
 target_link_libraries(hipfile_system_tests PRIVATE Boost::program_options)
 

--- a/test/amd_detail/CMakeLists.txt
+++ b/test/amd_detail/CMakeLists.txt
@@ -72,6 +72,7 @@ add_test(
     NAME state_mt_test
     COMMAND gdb --batch --quiet -ex run -ex "thread apply all bt full" --return-child-result --args $<TARGET_FILE:state_mt>
 )
+target_compile_options(state_mt PRIVATE "-UNDEBUG")
 set_tests_properties(state_mt_test PROPERTIES LABELS "stress;internal")
 
 ais_add_executable(
@@ -84,4 +85,5 @@ add_test(
     NAME batch_mt_test
     COMMAND gdb --batch --quiet -ex run -ex "thread apply all bt full" --return-child-result --args $<TARGET_FILE:batch_mt>
 )
+target_compile_options(batch_mt PRIVATE "-UNDEBUG")
 set_tests_properties(batch_mt_test PROPERTIES LABELS "stress;internal")

--- a/test/amd_detail/CMakeLists.txt
+++ b/test/amd_detail/CMakeLists.txt
@@ -43,7 +43,7 @@ ais_add_executable(
     SRCS ${TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
     SYSINCLS ${TEST_SYSINCLS}
 )
-target_compile_options(internal_tests PRIVATE "-UNDEBUG")
+target_compile_options(internal_tests PRIVATE -UNDEBUG)
 
 # Add gtest
 target_link_libraries(internal_tests PRIVATE GTest::gmock)
@@ -72,7 +72,7 @@ add_test(
     NAME state_mt_test
     COMMAND gdb --batch --quiet -ex run -ex "thread apply all bt full" --return-child-result --args $<TARGET_FILE:state_mt>
 )
-target_compile_options(state_mt PRIVATE "-UNDEBUG")
+target_compile_options(state_mt PRIVATE -UNDEBUG)
 set_tests_properties(state_mt_test PROPERTIES LABELS "stress;internal")
 
 ais_add_executable(
@@ -85,5 +85,5 @@ add_test(
     NAME batch_mt_test
     COMMAND gdb --batch --quiet -ex run -ex "thread apply all bt full" --return-child-result --args $<TARGET_FILE:batch_mt>
 )
-target_compile_options(batch_mt PRIVATE "-UNDEBUG")
+target_compile_options(batch_mt PRIVATE -UNDEBUG)
 set_tests_properties(batch_mt_test PROPERTIES LABELS "stress;internal")

--- a/test/amd_detail/hipfile-test.h
+++ b/test/amd_detail/hipfile-test.h
@@ -54,14 +54,12 @@ operator!=(const hipFileError_t &lhs, const hipFileError_t &rhs)
 // << overload for hipFileError_t values
 //
 // Unused in the test code, but kept here for iostream debugging
-#ifndef NDEBUG
 #include <iostream>
 inline std::ostream &
 operator<<(std::ostream &os, const hipFileError_t &rfe)
 {
     return os << "hipFileError_t{ err: " << rfe.err << ", hip_drv_err: " << rfe.hip_drv_err << " }";
 }
-#endif
 
 // Convenience "success" value
 inline constexpr hipFileError_t HIPFILE_SUCCESS{hipFileSuccess, hipSuccess};


### PR DESCRIPTION
Allows assert() everywhere and avoids unused parameter/variable warnings.