### PR TITLE
Rildixon/io retry compat system test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * The CMake namespace was changed from `roc::` to `hip::`
 * `AIS_BUILD_EXAMPLES` has been renamed to `AIS_INSTALL_EXAMPLES`
 * `AIS_USE_SANITIZERS` now also enables the following sanitizers: integer, float-divide-by-zero, local-bounds, vptr, nullability (in addition to address, leak, and undefined). Sanitizers should also now emit usable stack trace info.
+* The AIS optimized IO path will automatically fallback to the POSIX IO path if a failure occurs and the compatability mode has not been disabled.
 
 ### Removed
 * The rocFile library has been completely removed and the code is now a part of hipFile.

--- a/src/amd_detail/CMakeLists.txt
+++ b/src/amd_detail/CMakeLists.txt
@@ -7,6 +7,7 @@
 set(HIPFILE_SOURCES
     "${HIPFILE_SRC_COMMON_PATH}/hipfile-common.cpp"
     async.cpp
+    backend.cpp
     backend/asyncop-fallback.cpp
     backend/memcpy-kernel.hip
     backend/fallback.cpp

--- a/src/amd_detail/backend.cpp
+++ b/src/amd_detail/backend.cpp
@@ -26,7 +26,7 @@ RetryableBackend::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<I
     }
     catch (...) {
         std::exception_ptr e_ptr = std::current_exception();
-        if (is_retryable(e_ptr, nbytes)) {
+        if (is_retryable(e_ptr, nbytes, file, buffer, size, file_offset, buffer_offset)) {
             nbytes = retry_backend->io(type, file, buffer, size, file_offset, buffer_offset);
         }
         else {
@@ -49,11 +49,14 @@ RetryableBackend::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<I
 }
 
 bool
-RetryableBackend::is_retryable(std::exception_ptr e_ptr, ssize_t nbytes) const
+RetryableBackend::is_retryable(std::exception_ptr e_ptr, ssize_t nbytes, std::shared_ptr<IFile> file,
+                               std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
+                               hoff_t buffer_offset) const
 {
     (void)e_ptr;
     (void)nbytes;
-    return static_cast<bool>(retry_backend);
+    return static_cast<bool>(retry_backend) &&
+           retry_backend->score(file, buffer, size, file_offset, buffer_offset) >= 0;
 }
 
 void

--- a/src/amd_detail/backend.cpp
+++ b/src/amd_detail/backend.cpp
@@ -74,8 +74,7 @@ BackendWithFallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_pt
 bool
 BackendWithFallback::is_fallback_eligible(std::exception_ptr e_ptr, ssize_t nbytes,
                                           std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
-                                          size_t size, hoff_t file_offset,
-                                          hoff_t buffer_offset) const
+                                          size_t size, hoff_t file_offset, hoff_t buffer_offset) const
 {
     (void)e_ptr;
     (void)nbytes;

--- a/src/amd_detail/backend.cpp
+++ b/src/amd_detail/backend.cpp
@@ -17,8 +17,8 @@
 using namespace hipFile;
 
 ssize_t
-RetryableBackend::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
-                     hoff_t file_offset, hoff_t buffer_offset)
+BackendWithFallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
+                        size_t size, hoff_t file_offset, hoff_t buffer_offset)
 {
     ssize_t nbytes{0};
     try {
@@ -26,8 +26,8 @@ RetryableBackend::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<I
     }
     catch (...) {
         std::exception_ptr e_ptr = std::current_exception();
-        if (is_retryable(e_ptr, nbytes, file, buffer, size, file_offset, buffer_offset)) {
-            nbytes = retry_backend->io(type, file, buffer, size, file_offset, buffer_offset);
+        if (is_fallback_eligible(e_ptr, nbytes, file, buffer, size, file_offset, buffer_offset)) {
+            nbytes = fallback_backend->io(type, file, buffer, size, file_offset, buffer_offset);
         }
         else {
             throw;
@@ -49,18 +49,19 @@ RetryableBackend::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<I
 }
 
 bool
-RetryableBackend::is_retryable(std::exception_ptr e_ptr, ssize_t nbytes, std::shared_ptr<IFile> file,
-                               std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
-                               hoff_t buffer_offset) const
+BackendWithFallback::is_fallback_eligible(std::exception_ptr e_ptr, ssize_t nbytes,
+                                          std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
+                                          size_t size, hoff_t file_offset,
+                                          hoff_t buffer_offset) const
 {
     (void)e_ptr;
     (void)nbytes;
-    return static_cast<bool>(retry_backend) &&
-           retry_backend->score(file, buffer, size, file_offset, buffer_offset) >= 0;
+    return static_cast<bool>(fallback_backend) &&
+           fallback_backend->score(file, buffer, size, file_offset, buffer_offset) >= 0;
 }
 
 void
-RetryableBackend::register_retry_backend(std::shared_ptr<Backend> backend) noexcept
+BackendWithFallback::register_fallback_backend(std::shared_ptr<Backend> backend) noexcept
 {
-    retry_backend = backend;
+    fallback_backend = backend;
 }

--- a/src/amd_detail/backend.cpp
+++ b/src/amd_detail/backend.cpp
@@ -1,0 +1,63 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "backend.h"
+#include "buffer.h"
+#include "file.h"
+#include "io.h"
+
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <sys/types.h>
+#include <unistd.h>
+
+using namespace hipFile;
+
+ssize_t
+RetryableBackend::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+                     hoff_t file_offset, hoff_t buffer_offset)
+{
+    ssize_t nbytes{0};
+    try {
+        nbytes = retryable_io(type, file, buffer, size, file_offset, buffer_offset);
+    }
+    catch (...) {
+        std::exception_ptr e_ptr = std::current_exception();
+        if (is_retryable(e_ptr, nbytes)) {
+            nbytes = retry_backend->io(type, file, buffer, size, file_offset, buffer_offset);
+        }
+        else {
+            throw;
+        }
+        // For now, assume retry_backend will handle its own stats (which is true at this moment).
+        return nbytes;
+    }
+    switch (type) {
+        case (IoType::Read):
+            update_read_stats(nbytes);
+            break;
+        case (IoType::Write):
+            update_write_stats(nbytes);
+            break;
+        default:
+            break;
+    }
+    return nbytes;
+}
+
+bool
+RetryableBackend::is_retryable(std::exception_ptr e_ptr, ssize_t nbytes) const
+{
+    (void)e_ptr;
+    (void)nbytes;
+    return static_cast<bool>(retry_backend);
+}
+
+void
+RetryableBackend::register_retry_backend(std::shared_ptr<Backend> backend) noexcept
+{
+    retry_backend = backend;
+}

--- a/src/amd_detail/backend.cpp
+++ b/src/amd_detail/backend.cpp
@@ -22,7 +22,7 @@ RetryableBackend::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<I
 {
     ssize_t nbytes{0};
     try {
-        nbytes = retryable_io(type, file, buffer, size, file_offset, buffer_offset);
+        nbytes = _io_impl(type, file, buffer, size, file_offset, buffer_offset);
     }
     catch (...) {
         std::exception_ptr e_ptr = std::current_exception();

--- a/src/amd_detail/backend.cpp
+++ b/src/amd_detail/backend.cpp
@@ -17,6 +17,24 @@
 using namespace hipFile;
 
 ssize_t
+Backend::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+            hoff_t file_offset, hoff_t buffer_offset)
+{
+    ssize_t nbytes = _io_impl(type, file, buffer, size, file_offset, buffer_offset);
+    switch (type) {
+        case (IoType::Read):
+            update_read_stats(nbytes);
+            break;
+        case (IoType::Write):
+            update_write_stats(nbytes);
+            break;
+        default:
+            break;
+    }
+    return nbytes;
+}
+
+ssize_t
 BackendWithFallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
                         size_t size, hoff_t file_offset, hoff_t buffer_offset)
 {
@@ -32,7 +50,6 @@ BackendWithFallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_pt
         else {
             throw;
         }
-        // For now, assume retry_backend will handle its own stats (which is true at this moment).
         return nbytes;
     }
     switch (type) {

--- a/src/amd_detail/backend.cpp
+++ b/src/amd_detail/backend.cpp
@@ -12,6 +12,7 @@
 #include <exception>
 #include <memory>
 #include <sys/types.h>
+#include <system_error>
 #include <unistd.h>
 
 using namespace hipFile;
@@ -41,6 +42,11 @@ BackendWithFallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_pt
     ssize_t nbytes{0};
     try {
         nbytes = _io_impl(type, file, buffer, size, file_offset, buffer_offset);
+        if (nbytes < 0) {
+            // Typically we should not reach this point. But in case we do, throw
+            // an exception to use the fallback backend.
+            throw std::system_error(-static_cast<int>(nbytes), std::generic_category());
+        }
     }
     catch (...) {
         std::exception_ptr e_ptr = std::current_exception();

--- a/src/amd_detail/backend.h
+++ b/src/amd_detail/backend.h
@@ -67,14 +67,23 @@ struct RetryableBackend : public Backend {
 
     /// @brief Check if a failed IO operation is retryable.
     ///
-    /// @param e_ptr  Pointer to the thrown Exception by the failed IO
-    /// @param nbytes Number of bytes/error code returned by `retryable_io()`
+    /// @param e_ptr         Pointer to the thrown Exception by the failed IO
+    /// @param nbytes        Return value from `retryable_io`, or 0 if an exception was thrown.
+    /// @param file          File to read from or write to
+    /// @param buffer        Buffer to write to or read from
+    /// @param size          Number of bytes to transfer
+    /// @param file_offset   Offset from the start of the file
+    /// @param buffer_offset Offset from the start of the buffer
     ///
     /// @note By default, RetryableBackend just checks if a Backend has been
-    ///       registered for retrying an IO.
+    ///       registered for retrying an IO, and that backend supports the
+    ///       the request.
+    /// @note The parameters from the original IO request are passed to this function.
     ///
     /// @return True if this RetryableBackend can retry the IO, else False.
-    virtual bool is_retryable(std::exception_ptr e_ptr, ssize_t nbytes) const;
+    virtual bool is_retryable(std::exception_ptr e_ptr, ssize_t nbytes, std::shared_ptr<IFile> file,
+                              std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
+                              hoff_t buffer_offset) const;
 
     /// @brief Register a Backend to call into to retry a failed IO operation.
     ///

--- a/src/amd_detail/backend.h
+++ b/src/amd_detail/backend.h
@@ -12,6 +12,7 @@
 #include "sys.h"
 
 #include <cstddef>
+#include <exception>
 #include <memory>
 #include <sys/types.h>
 #include <unistd.h>
@@ -94,7 +95,7 @@ struct BackendWithFallback : public Backend {
 
     /// @brief Check if a failed IO operation can be re-issued to the fallback Backend.
     ///
-    /// @param e_ptr         Pointer to the thrown Exception by the failed IO
+    /// @param e_ptr         exception_ptr to the thrown exception from the failed IO
     /// @param nbytes        Return value from `_io_impl`, or 0 if an exception was thrown.
     /// @param file          File to read from or write to
     /// @param buffer        Buffer to write to or read from

--- a/src/amd_detail/backend.h
+++ b/src/amd_detail/backend.h
@@ -79,48 +79,47 @@ protected:
                              size_t size, hoff_t file_offset, hoff_t buffer_offset) = 0;
 };
 
-// This kind of Backend allows for an IO to be retried automatically in the
-// event of an error. The RetryableBackend implements the logic to determine
-// which errors are retryable, and which are not, in Backend::io().
-struct RetryableBackend : public Backend {
+// BackendWithFallback allows for an IO to be retried automatically with a
+// different Backend in the event of an error.
+struct BackendWithFallback : public Backend {
     ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                hoff_t file_offset, hoff_t buffer_offset) override final;
 
-    /// @brief Check if a failed IO operation is retryable.
+    /// @brief Check if a failed IO operation can be re-issued to the fallback Backend.
     ///
     /// @param e_ptr         Pointer to the thrown Exception by the failed IO
-    /// @param nbytes        Return value from `retryable_io`, or 0 if an exception was thrown.
+    /// @param nbytes        Return value from `_io_impl`, or 0 if an exception was thrown.
     /// @param file          File to read from or write to
     /// @param buffer        Buffer to write to or read from
     /// @param size          Number of bytes to transfer
     /// @param file_offset   Offset from the start of the file
     /// @param buffer_offset Offset from the start of the buffer
     ///
-    /// @note By default, RetryableBackend just checks if a Backend has been
-    ///       registered for retrying an IO, and that backend supports the
+    /// @note By default, BackendWithFallback checks if a Backend has been
+    ///       registered for retrying an IO, and that fallback backend supports
     ///       the request.
     /// @note The parameters from the original IO request are passed to this function.
     ///
-    /// @return True if this RetryableBackend can retry the IO, else False.
-    virtual bool is_retryable(std::exception_ptr e_ptr, ssize_t nbytes, std::shared_ptr<IFile> file,
-                              std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
-                              hoff_t buffer_offset) const;
+    /// @return True if this BackendWithFallback can retry the IO, else False.
+    virtual bool is_fallback_eligible(std::exception_ptr e_ptr, ssize_t nbytes, std::shared_ptr<IFile> file,
+                                      std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
+                                      hoff_t buffer_offset) const;
 
-    /// @brief Register a Backend to call into to retry a failed IO operation.
+    /// @brief Register a Backend to retry a failed IO operation.
     ///
     /// @param backend Backend to retry a failed IO operation.
-    void register_retry_backend(std::shared_ptr<Backend> backend) noexcept;
+    void register_fallback_backend(std::shared_ptr<Backend> backend) noexcept;
 
     // This maybe should be moved to Backend
-    /// @brief Update the read stats for this RetryableBackend
+    /// @brief Update the read stats for this BackendWithFallback
     virtual void update_read_stats(ssize_t nbytes) = 0;
 
     // This maybe should be moved to Backend
-    /// @brief Update the write stats for this RetryableBackend
+    /// @brief Update the write stats for this BackendWithFallback
     virtual void update_write_stats(ssize_t nbytes) = 0;
 
 protected:
-    std::shared_ptr<Backend> retry_backend;
+    std::shared_ptr<Backend> fallback_backend;
 };
 
 }

--- a/src/amd_detail/backend.h
+++ b/src/amd_detail/backend.h
@@ -58,4 +58,54 @@ struct Backend {
                        hoff_t file_offset, hoff_t buffer_offset) = 0;
 };
 
+// This kind of Backend allows for an IO to be retried automatically in the
+// event of an error. The RetryableBackend implements the logic to determine
+// which errors are retryable, and which are not, in Backend::io().
+struct RetryableBackend : public Backend {
+    ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+               hoff_t file_offset, hoff_t buffer_offset) override final;
+
+    /// @brief Check if a failed IO operation is retryable.
+    ///
+    /// @param e_ptr  Pointer to the thrown Exception by the failed IO
+    /// @param nbytes Number of bytes/error code returned by `retryable_io()`
+    ///
+    /// @note By default, RetryableBackend just checks if a Backend has been
+    ///       registered for retrying an IO.
+    ///
+    /// @return True if this RetryableBackend can retry the IO, else False.
+    virtual bool is_retryable(std::exception_ptr e_ptr, ssize_t nbytes) const;
+
+    /// @brief Register a Backend to call into to retry a failed IO operation.
+    ///
+    /// @param backend Backend to retry a failed IO operation.
+    void register_retry_backend(std::shared_ptr<Backend> backend) noexcept;
+
+    /// @brief Process an IO Request that can be resubmitted to another Backend if the IO fails.
+    ///
+    /// @param type          IO type (read/write)
+    /// @param file          File to read from or write to
+    /// @param buffer        Buffer to write to or read from
+    /// @param size          Number of bytes to transfer
+    /// @param file_offset   Offset from the start of the file
+    /// @param buffer_offset Offset from the start of the buffer
+    ///
+    /// @return Number of bytes transferred, negative on error
+    ///
+    /// @throws Hip::RuntimeError Sys::RuntimeError
+    virtual ssize_t retryable_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
+                                 size_t size, hoff_t file_offset, hoff_t buffer_offset) = 0;
+
+    // This maybe should be moved to Backend
+    /// @brief Update the read stats for this RetryableBackend
+    virtual void update_read_stats(ssize_t nbytes) = 0;
+
+    // This maybe should be moved to Backend
+    /// @brief Update the write stats for this RetryableBackend
+    virtual void update_write_stats(ssize_t nbytes) = 0;
+
+protected:
+    std::shared_ptr<Backend> retry_backend;
+};
+
 }

--- a/src/amd_detail/backend.h
+++ b/src/amd_detail/backend.h
@@ -55,7 +55,28 @@ struct Backend {
     ///
     /// @throws Hip::RuntimeError Sys::RuntimeError
     virtual ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
-                       hoff_t file_offset, hoff_t buffer_offset) = 0;
+                       hoff_t file_offset, hoff_t buffer_offset)
+    {
+        return _io_impl(type, file, buffer, size, file_offset, buffer_offset);
+    }
+
+protected:
+    /// @brief Perform a read or write operation
+    ///
+    /// @note Provides a common target across all Backends that provides the
+    ///       implementation for running IO.
+    /// @param type          IO type (read/write)
+    /// @param file          File to read from or write to
+    /// @param buffer        Buffer to write to or read from
+    /// @param size          Number of bytes to transfer
+    /// @param file_offset   Offset from the start of the file
+    /// @param buffer_offset Offset from the start of the buffer
+    ///
+    /// @return Number of bytes transferred, negative on error
+    ///
+    /// @throws Hip::RuntimeError Sys::RuntimeError
+    virtual ssize_t _io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
+                             size_t size, hoff_t file_offset, hoff_t buffer_offset) = 0;
 };
 
 // This kind of Backend allows for an IO to be retried automatically in the
@@ -89,21 +110,6 @@ struct RetryableBackend : public Backend {
     ///
     /// @param backend Backend to retry a failed IO operation.
     void register_retry_backend(std::shared_ptr<Backend> backend) noexcept;
-
-    /// @brief Process an IO Request that can be resubmitted to another Backend if the IO fails.
-    ///
-    /// @param type          IO type (read/write)
-    /// @param file          File to read from or write to
-    /// @param buffer        Buffer to write to or read from
-    /// @param size          Number of bytes to transfer
-    /// @param file_offset   Offset from the start of the file
-    /// @param buffer_offset Offset from the start of the buffer
-    ///
-    /// @return Number of bytes transferred, negative on error
-    ///
-    /// @throws Hip::RuntimeError Sys::RuntimeError
-    virtual ssize_t retryable_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
-                                 size_t size, hoff_t file_offset, hoff_t buffer_offset) = 0;
 
     // This maybe should be moved to Backend
     /// @brief Update the read stats for this RetryableBackend

--- a/src/amd_detail/backend.h
+++ b/src/amd_detail/backend.h
@@ -51,7 +51,7 @@ struct Backend {
     /// @param file_offset   Offset from the start of the file
     /// @param buffer_offset Offset from the start of the buffer
     ///
-    /// @return Number of bytes transferred, negative on error
+    /// @return Number of bytes transferred
     ///
     /// @throws Hip::RuntimeError Sys::RuntimeError
     virtual ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
@@ -79,7 +79,7 @@ protected:
     /// @param file_offset   Offset from the start of the file
     /// @param buffer_offset Offset from the start of the buffer
     ///
-    /// @return Number of bytes transferred, negative on error
+    /// @return Number of bytes transferred
     ///
     /// @throws Hip::RuntimeError Sys::RuntimeError
     virtual ssize_t _io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,

--- a/src/amd_detail/backend.h
+++ b/src/amd_detail/backend.h
@@ -55,10 +55,17 @@ struct Backend {
     ///
     /// @throws Hip::RuntimeError Sys::RuntimeError
     virtual ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
-                       hoff_t file_offset, hoff_t buffer_offset)
-    {
-        return _io_impl(type, file, buffer, size, file_offset, buffer_offset);
-    }
+                       hoff_t file_offset, hoff_t buffer_offset);
+
+    /// @brief Update the read stats for this Backend
+    ///
+    /// @param nbytes Number of bytes read
+    virtual void update_read_stats(ssize_t nbytes) = 0;
+
+    /// @brief Update the write stats for this Backend
+    ///
+    /// @param nbytes Number of bytes written
+    virtual void update_write_stats(ssize_t nbytes) = 0;
 
 protected:
     /// @brief Perform a read or write operation
@@ -109,14 +116,6 @@ struct BackendWithFallback : public Backend {
     ///
     /// @param backend Backend to retry a failed IO operation.
     void register_fallback_backend(std::shared_ptr<Backend> backend) noexcept;
-
-    // This maybe should be moved to Backend
-    /// @brief Update the read stats for this BackendWithFallback
-    virtual void update_read_stats(ssize_t nbytes) = 0;
-
-    // This maybe should be moved to Backend
-    /// @brief Update the write stats for this BackendWithFallback
-    virtual void update_write_stats(ssize_t nbytes) = 0;
 
 protected:
     std::shared_ptr<Backend> fallback_backend;

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -54,14 +54,25 @@ ssize_t
 Fallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
              hoff_t file_offset, hoff_t buffer_offset)
 {
-    return _io_impl(type, file, buffer, size, file_offset, buffer_offset, DefaultChunkSize);
+    return io(type, file, buffer, size, file_offset, buffer_offset, DefaultChunkSize);
 }
 
 ssize_t
 Fallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
              hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size)
 {
-    return _io_impl(type, file, buffer, size, file_offset, buffer_offset, chunk_size);
+    ssize_t nbytes = _io_impl(type, file, buffer, size, file_offset, buffer_offset, chunk_size);
+    switch (type) {
+        case (IoType::Read):
+            update_read_stats(nbytes);
+            break;
+        case (IoType::Write):
+            update_write_stats(nbytes);
+            break;
+        default:
+            break;
+    }
+    return nbytes;
 }
 
 ssize_t

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -54,12 +54,26 @@ ssize_t
 Fallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
              hoff_t file_offset, hoff_t buffer_offset)
 {
-    return io(type, file, buffer, size, file_offset, buffer_offset, DefaultChunkSize);
+    return _io_impl(type, file, buffer, size, file_offset, buffer_offset, DefaultChunkSize);
 }
 
 ssize_t
-Fallback::io(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
+Fallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
              hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size)
+{
+    return _io_impl(type, file, buffer, size, file_offset, buffer_offset, chunk_size);
+}
+
+ssize_t
+Fallback::_io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+                   hoff_t file_offset, hoff_t buffer_offset)
+{
+    return _io_impl(type, file, buffer, size, file_offset, buffer_offset, DefaultChunkSize);
+}
+
+ssize_t
+Fallback::_io_impl(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
+                   hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size)
 {
     size = min(size, hipFile::MAX_RW_COUNT);
 

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -129,17 +129,19 @@ Fallback::_io_impl(IoType io_type, shared_ptr<IFile> file, shared_ptr<IBuffer> b
         }
     } while (static_cast<size_t>(total_io_bytes) < size);
 
-    switch (io_type) {
-        case IoType::Read:
-            statsAddFallbackPathRead(static_cast<size_t>(total_io_bytes));
-            break;
-        case IoType::Write:
-            statsAddFallbackPathWrite(static_cast<size_t>(total_io_bytes));
-            break;
-        default:
-            break;
-    }
     return total_io_bytes;
+}
+
+void
+Fallback::update_read_stats(ssize_t nbytes)
+{
+    statsAddFallbackPathRead(static_cast<size_t>(nbytes));
+}
+
+void
+Fallback::update_write_stats(ssize_t nbytes)
+{
+    statsAddFallbackPathWrite(static_cast<size_t>(nbytes));
 }
 
 void

--- a/src/amd_detail/backend/fallback.h
+++ b/src/amd_detail/backend/fallback.h
@@ -40,10 +40,14 @@ struct Fallback : public Backend {
 
     // Once we can import gtest.h and make test suites or test friends everything
     // below here should be made protected.
-    // protected:
-
     ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size);
+
+protected:
+    ssize_t _io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+                     hoff_t file_offset, hoff_t buffer_offset) override;
+    ssize_t _io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+                     hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size);
 };
 
 }

--- a/src/amd_detail/backend/fallback.h
+++ b/src/amd_detail/backend/fallback.h
@@ -34,6 +34,10 @@ struct Fallback : public Backend {
     ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                hoff_t file_offset, hoff_t buffer_offset) override;
 
+    void update_read_stats(ssize_t nbytes) override;
+
+    void update_write_stats(ssize_t nbytes) override;
+
     void async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t *size_p,
                   hoff_t *file_offset_p, hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p,
                   std::shared_ptr<IStream> stream);

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -154,9 +154,21 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
     return accept_io ? 100 : -1;
 }
 
+void
+Fastpath::update_read_stats(ssize_t nbytes)
+{
+    statsAddFastPathRead(static_cast<uint64_t>(nbytes));
+}
+
+void
+Fastpath::update_write_stats(ssize_t nbytes)
+{
+    statsAddFastPathWrite(static_cast<uint64_t>(nbytes));
+}
+
 ssize_t
-Fastpath::retryable_io(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
-                       hoff_t file_offset, hoff_t buffer_offset)
+Fastpath::_io_impl(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
+                   hoff_t file_offset, hoff_t buffer_offset)
 {
     void *devptr{reinterpret_cast<void *>(reinterpret_cast<intptr_t>(buffer->getBuffer()) + buffer_offset)};
     hipAmdFileHandle_t handle{};
@@ -185,16 +197,4 @@ Fastpath::retryable_io(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> 
             throw std::runtime_error("Invalid IoType");
     }
     return static_cast<ssize_t>(nbytes);
-}
-
-void
-Fastpath::update_read_stats(ssize_t nbytes)
-{
-    statsAddFastPathRead(static_cast<uint64_t>(nbytes));
-}
-
-void
-Fastpath::update_write_stats(ssize_t nbytes)
-{
-    statsAddFastPathWrite(static_cast<uint64_t>(nbytes));
 }

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -155,8 +155,8 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
 }
 
 ssize_t
-Fastpath::io(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
-             hoff_t buffer_offset)
+Fastpath::retryable_io(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
+                       hoff_t file_offset, hoff_t buffer_offset)
 {
     void *devptr{reinterpret_cast<void *>(reinterpret_cast<intptr_t>(buffer->getBuffer()) + buffer_offset)};
     hipAmdFileHandle_t handle{};
@@ -184,15 +184,17 @@ Fastpath::io(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, si
         default:
             throw std::runtime_error("Invalid IoType");
     }
-    switch (type) {
-        case IoType::Read:
-            statsAddFastPathRead(nbytes);
-            break;
-        case IoType::Write:
-            statsAddFastPathWrite(nbytes);
-            break;
-        default:
-            break;
-    }
     return static_cast<ssize_t>(nbytes);
+}
+
+void
+Fastpath::update_read_stats(ssize_t nbytes)
+{
+    statsAddFastPathRead(static_cast<uint64_t>(nbytes));
+}
+
+void
+Fastpath::update_write_stats(ssize_t nbytes)
+{
+    statsAddFastPathWrite(static_cast<uint64_t>(nbytes));
 }

--- a/src/amd_detail/backend/fastpath.h
+++ b/src/amd_detail/backend/fastpath.h
@@ -27,13 +27,14 @@ namespace hipFile {
 struct Fastpath : public RetryableBackend {
     virtual ~Fastpath() override = default;
 
-    int score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
-              hoff_t buffer_offset) const override;
+    int  score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
+               hoff_t buffer_offset) const override;
+    void update_read_stats(ssize_t nbytes) override;
+    void update_write_stats(ssize_t nbytes) override;
 
-    ssize_t retryable_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
-                         size_t size, hoff_t file_offset, hoff_t buffer_offset) override;
-    void    update_read_stats(ssize_t nbytes) override;
-    void    update_write_stats(ssize_t nbytes) override;
+protected:
+    ssize_t _io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+                     hoff_t file_offset, hoff_t buffer_offset) override;
 };
 
 }

--- a/src/amd_detail/backend/fastpath.h
+++ b/src/amd_detail/backend/fastpath.h
@@ -9,6 +9,7 @@
 #include "hipfile.h"
 
 #include <memory>
+#include <stdexcept>
 #include <sys/types.h>
 
 namespace hipFile {
@@ -23,14 +24,16 @@ enum class IoType;
 
 namespace hipFile {
 
-struct Fastpath : public Backend {
+struct Fastpath : public RetryableBackend {
     virtual ~Fastpath() override = default;
 
     int score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
               hoff_t buffer_offset) const override;
 
-    ssize_t io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
-               hoff_t file_offset, hoff_t buffer_offset) override;
+    ssize_t retryable_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer,
+                         size_t size, hoff_t file_offset, hoff_t buffer_offset) override;
+    void    update_read_stats(ssize_t nbytes) override;
+    void    update_write_stats(ssize_t nbytes) override;
 };
 
 }

--- a/src/amd_detail/backend/fastpath.h
+++ b/src/amd_detail/backend/fastpath.h
@@ -24,7 +24,7 @@ enum class IoType;
 
 namespace hipFile {
 
-struct Fastpath : public RetryableBackend {
+struct Fastpath : public BackendWithFallback {
     virtual ~Fastpath() override = default;
 
     int  score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,

--- a/src/amd_detail/state.cpp
+++ b/src/amd_detail/state.cpp
@@ -275,11 +275,18 @@ std::vector<std::shared_ptr<Backend>>
 DriverState::getBackends() const
 {
     static bool once = [&]() {
-        if (Context<Configuration>::get()->fastpath()) {
-            backends.emplace_back(new Fastpath{});
-        }
+        std::shared_ptr<Backend> fallback_backend;
         if (Context<Configuration>::get()->fallback()) {
-            backends.emplace_back(new Fallback{});
+            fallback_backend = std::make_shared<Fallback>();
+            backends.push_back(fallback_backend);
+        }
+
+        if (Context<Configuration>::get()->fastpath()) {
+            auto new_backend = std::make_shared<Fastpath>();
+            if (fallback_backend) {
+                new_backend->register_retry_backend(fallback_backend);
+            }
+            backends.push_back(new_backend);
         }
         return true;
     }();

--- a/src/amd_detail/state.cpp
+++ b/src/amd_detail/state.cpp
@@ -284,7 +284,7 @@ DriverState::getBackends() const
         if (Context<Configuration>::get()->fastpath()) {
             auto new_backend = std::make_shared<Fastpath>();
             if (fallback_backend) {
-                new_backend->register_retry_backend(fallback_backend);
+                new_backend->register_fallback_backend(fallback_backend);
             }
             backends.push_back(new_backend);
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SYSTEM_TEST_SOURCE_FILES
     system/buffer.cpp
     system/config.cpp
     system/driver.cpp
+    system/fastpath.cpp
     system/io.cpp
     system/main.cpp
     system/version.cpp
@@ -32,6 +33,7 @@ set(SYSTEM_TEST_SOURCE_FILES
 set(TEST_SYSINCLS
     ${HIPFILE_INCLUDE_PATH}
     ${HIPFILE_TEST_COMMON_PATH}
+    ${HIPFILE_AMD_TEST_PATH} # For mhip
 )
 
 if(AIS_BUILD_NVIDIA_DETAIL)
@@ -66,6 +68,7 @@ ais_add_executable(
     SYSINCLS ${TEST_SYSINCLS}
 )
 target_link_libraries(hipfile_system_tests PRIVATE GTest::gtest)
+target_link_libraries(hipfile_system_tests PRIVATE GTest::gmock)
 target_link_libraries(hipfile_system_tests PRIVATE Boost::program_options)
 
 ais_gtest_discover_tests(

--- a/test/amd_detail/CMakeLists.txt
+++ b/test/amd_detail/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SHARED_SOURCE_FILES
 
 set(TEST_SOURCE_FILES
     async.cpp
+    backend.cpp
     batch/batch.cpp
     configuration.cpp
     context.cpp

--- a/test/amd_detail/async.cpp
+++ b/test/amd_detail/async.cpp
@@ -23,6 +23,7 @@
 #include "mstream.h"
 #include "msys.h"
 #include "state.h"
+#include "test-common.h"
 
 #include <array>
 #include <cerrno>
@@ -386,7 +387,7 @@ TEST_P(HipFileReadWriteAsync, badAllocReturnsHipErrorOutOfMemory)
     EXPECT_CALL(driver, getRefCount).WillOnce(Throw(std::bad_alloc()));
     ASSERT_EQ(io_op(nonnull_void, nonnull_void, nonnull_size, nonnull_offset, nonnull_offset, nullptr,
                     nonnull_stream),
-              HipFileHipError(hipErrorOutOfMemory));
+              HipFileDriverError(hipErrorOutOfMemory));
 }
 
 INSTANTIATE_TEST_SUITE_P(HipFileAsyncSuite, HipFileReadWriteAsync, ::testing::ValuesIn(asyncIOFns),

--- a/test/amd_detail/backend.cpp
+++ b/test/amd_detail/backend.cpp
@@ -1,0 +1,108 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "io.h"
+#include "hipfile-test.h"
+#include "hipfile-warnings.h"
+#include "mbackend.h"
+#include "mbuffer.h"
+#include "mfile.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <memory>
+
+using namespace hipFile;
+
+using ::testing::AnyNumber;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::StrictMock;
+using ::testing::Throw;
+
+// Put tests inside the macros to suppress the global constructor
+// warnings
+HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
+
+struct DummyRetryableBackend : public MRetryableBackend {};
+
+struct DummyFallbackBackend : MBackend {};
+
+struct HipFileRetryableBackend : public HipFileUnopened, ::testing::WithParamInterface<IoType> {
+    std::shared_ptr<StrictMock<MBuffer>> mock_buffer;
+    std::shared_ptr<StrictMock<MFile>>   mock_file;
+
+    std::shared_ptr<StrictMock<DummyRetryableBackend>> default_backend;
+    std::shared_ptr<StrictMock<DummyFallbackBackend>>  fallback_backend;
+
+    IoType  io_type;
+    ssize_t successful_io_size = 0x1234;
+
+    void SetUp() override
+    {
+        mock_buffer = std::make_shared<StrictMock<MBuffer>>();
+        mock_file   = std::make_shared<StrictMock<MFile>>();
+
+        default_backend = std::make_shared<StrictMock<DummyRetryableBackend>>();
+        // By default, use the default is_retryable() implementation unless overriden.
+        EXPECT_CALL(*default_backend, is_retryable)
+            .WillRepeatedly(Invoke([&](std::exception_ptr e_ptr, ssize_t nbytes) {
+                return default_backend->RetryableBackend::is_retryable(e_ptr, nbytes);
+            }));
+        EXPECT_CALL(*default_backend, retryable_io).Times(AnyNumber());
+        EXPECT_CALL(*default_backend, update_read_stats).Times(AnyNumber());
+        EXPECT_CALL(*default_backend, update_write_stats).Times(AnyNumber());
+
+        fallback_backend = std::make_shared<StrictMock<DummyFallbackBackend>>();
+        EXPECT_CALL(*fallback_backend, io).Times(AnyNumber());
+
+        io_type = GetParam();
+    }
+
+    HipFileRetryableBackend()
+    {
+    }
+};
+
+TEST_P(HipFileRetryableBackend, IOSuccess)
+{
+    EXPECT_CALL(*default_backend, retryable_io).WillOnce(Return(successful_io_size));
+
+    ssize_t nbytes = default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0);
+
+    ASSERT_EQ(nbytes, successful_io_size);
+}
+
+TEST_P(HipFileRetryableBackend, IOFailureNoFallback)
+{
+    EXPECT_CALL(*default_backend, retryable_io).WillOnce(Throw(std::runtime_error("IO failure")));
+
+    EXPECT_THROW(default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0), std::runtime_error);
+}
+
+TEST_P(HipFileRetryableBackend, IOFailureWithIneligibleRetry)
+{
+    // The Backend has registered a fallback, but has determined that the
+    // IO error should not be retried.
+    default_backend->register_retry_backend(fallback_backend);
+    EXPECT_CALL(*default_backend, is_retryable).WillOnce(Return(false));
+    EXPECT_CALL(*default_backend, retryable_io).WillOnce(Throw(std::runtime_error("IO failure")));
+
+    EXPECT_THROW(default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0), std::runtime_error);
+}
+
+TEST_P(HipFileRetryableBackend, IOFailureWithGoodFallback)
+{
+    default_backend->register_retry_backend(fallback_backend);
+    EXPECT_CALL(*default_backend, retryable_io).WillOnce(Throw(std::runtime_error("IO failure")));
+    EXPECT_CALL(*fallback_backend, io).WillOnce(Return(successful_io_size));
+
+    ssize_t nbytes = default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0);
+    ASSERT_EQ(nbytes, successful_io_size);
+}
+
+INSTANTIATE_TEST_SUITE_P(, HipFileRetryableBackend, ::testing::Values(IoType::Read, IoType::Write));
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/backend.cpp
+++ b/test/amd_detail/backend.cpp
@@ -46,7 +46,7 @@ struct HipFileRetryableBackend : public HipFileUnopened, ::testing::WithParamInt
         mock_file   = std::make_shared<StrictMock<MFile>>();
 
         default_backend = std::make_shared<StrictMock<DummyRetryableBackend>>();
-        EXPECT_CALL(*default_backend, retryable_io).Times(AnyNumber());
+        EXPECT_CALL(*default_backend, _io_impl).Times(AnyNumber());
         EXPECT_CALL(*default_backend, update_read_stats).Times(AnyNumber());
         EXPECT_CALL(*default_backend, update_write_stats).Times(AnyNumber());
 
@@ -64,7 +64,7 @@ struct HipFileRetryableBackend : public HipFileUnopened, ::testing::WithParamInt
 
 TEST_P(HipFileRetryableBackend, IOSuccess)
 {
-    EXPECT_CALL(*default_backend, retryable_io).WillOnce(Return(successful_io_size));
+    EXPECT_CALL(*default_backend, _io_impl).WillOnce(Return(successful_io_size));
 
     ssize_t nbytes = default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0);
 
@@ -73,7 +73,7 @@ TEST_P(HipFileRetryableBackend, IOSuccess)
 
 TEST_P(HipFileRetryableBackend, IOFailureNoFallback)
 {
-    EXPECT_CALL(*default_backend, retryable_io).WillOnce(Throw(std::runtime_error("IO failure")));
+    EXPECT_CALL(*default_backend, _io_impl).WillOnce(Throw(std::runtime_error("IO failure")));
 
     EXPECT_THROW(default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0), std::runtime_error);
 }
@@ -83,7 +83,7 @@ TEST_P(HipFileRetryableBackend, IOFailureWithIneligibleRetry)
     // The Backend has registered a fallback, but has determined that the
     // IO error should not be retried.
     default_backend->register_retry_backend(fallback_backend);
-    EXPECT_CALL(*default_backend, retryable_io).WillOnce(Throw(std::runtime_error("IO failure")));
+    EXPECT_CALL(*default_backend, _io_impl).WillOnce(Throw(std::runtime_error("IO failure")));
     EXPECT_CALL(*fallback_backend, score).WillOnce(Return(-1));
 
     EXPECT_THROW(default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0), std::runtime_error);
@@ -92,7 +92,7 @@ TEST_P(HipFileRetryableBackend, IOFailureWithIneligibleRetry)
 TEST_P(HipFileRetryableBackend, IOFailureWithGoodFallback)
 {
     default_backend->register_retry_backend(fallback_backend);
-    EXPECT_CALL(*default_backend, retryable_io).WillOnce(Throw(std::runtime_error("IO failure")));
+    EXPECT_CALL(*default_backend, _io_impl).WillOnce(Throw(std::runtime_error("IO failure")));
     EXPECT_CALL(*fallback_backend, io).WillOnce(Return(successful_io_size));
 
     ssize_t nbytes = default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0);

--- a/test/amd_detail/backend.cpp
+++ b/test/amd_detail/backend.cpp
@@ -46,17 +46,13 @@ struct HipFileRetryableBackend : public HipFileUnopened, ::testing::WithParamInt
         mock_file   = std::make_shared<StrictMock<MFile>>();
 
         default_backend = std::make_shared<StrictMock<DummyRetryableBackend>>();
-        // By default, use the default is_retryable() implementation unless overriden.
-        EXPECT_CALL(*default_backend, is_retryable)
-            .WillRepeatedly(Invoke([&](std::exception_ptr e_ptr, ssize_t nbytes) {
-                return default_backend->RetryableBackend::is_retryable(e_ptr, nbytes);
-            }));
         EXPECT_CALL(*default_backend, retryable_io).Times(AnyNumber());
         EXPECT_CALL(*default_backend, update_read_stats).Times(AnyNumber());
         EXPECT_CALL(*default_backend, update_write_stats).Times(AnyNumber());
 
         fallback_backend = std::make_shared<StrictMock<DummyFallbackBackend>>();
         EXPECT_CALL(*fallback_backend, io).Times(AnyNumber());
+        EXPECT_CALL(*fallback_backend, score).WillRepeatedly(Return(0));
 
         io_type = GetParam();
     }
@@ -87,8 +83,8 @@ TEST_P(HipFileRetryableBackend, IOFailureWithIneligibleRetry)
     // The Backend has registered a fallback, but has determined that the
     // IO error should not be retried.
     default_backend->register_retry_backend(fallback_backend);
-    EXPECT_CALL(*default_backend, is_retryable).WillOnce(Return(false));
     EXPECT_CALL(*default_backend, retryable_io).WillOnce(Throw(std::runtime_error("IO failure")));
+    EXPECT_CALL(*fallback_backend, score).WillOnce(Return(-1));
 
     EXPECT_THROW(default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0), std::runtime_error);
 }

--- a/test/amd_detail/backend.cpp
+++ b/test/amd_detail/backend.cpp
@@ -17,7 +17,6 @@
 using namespace hipFile;
 
 using ::testing::AnyNumber;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StrictMock;
 using ::testing::Throw;

--- a/test/amd_detail/backend.cpp
+++ b/test/amd_detail/backend.cpp
@@ -26,16 +26,16 @@ using ::testing::Throw;
 // warnings
 HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
 
-struct DummyRetryableBackend : public MRetryableBackend {};
+struct DummyBackendWithFallback : public MBackendWithFallback {};
 
 struct DummyFallbackBackend : MBackend {};
 
-struct HipFileRetryableBackend : public HipFileUnopened, ::testing::WithParamInterface<IoType> {
+struct HipFileBackendWithFallback : public HipFileUnopened, ::testing::WithParamInterface<IoType> {
     std::shared_ptr<StrictMock<MBuffer>> mock_buffer;
     std::shared_ptr<StrictMock<MFile>>   mock_file;
 
-    std::shared_ptr<StrictMock<DummyRetryableBackend>> default_backend;
-    std::shared_ptr<StrictMock<DummyFallbackBackend>>  fallback_backend;
+    std::shared_ptr<StrictMock<DummyBackendWithFallback>> default_backend;
+    std::shared_ptr<StrictMock<DummyFallbackBackend>>     fallback_backend;
 
     IoType  io_type;
     ssize_t successful_io_size = 0x1234;
@@ -45,7 +45,7 @@ struct HipFileRetryableBackend : public HipFileUnopened, ::testing::WithParamInt
         mock_buffer = std::make_shared<StrictMock<MBuffer>>();
         mock_file   = std::make_shared<StrictMock<MFile>>();
 
-        default_backend = std::make_shared<StrictMock<DummyRetryableBackend>>();
+        default_backend = std::make_shared<StrictMock<DummyBackendWithFallback>>();
         EXPECT_CALL(*default_backend, _io_impl).Times(AnyNumber());
         EXPECT_CALL(*default_backend, update_read_stats).Times(AnyNumber());
         EXPECT_CALL(*default_backend, update_write_stats).Times(AnyNumber());
@@ -57,12 +57,12 @@ struct HipFileRetryableBackend : public HipFileUnopened, ::testing::WithParamInt
         io_type = GetParam();
     }
 
-    HipFileRetryableBackend()
+    HipFileBackendWithFallback()
     {
     }
 };
 
-TEST_P(HipFileRetryableBackend, IOSuccess)
+TEST_P(HipFileBackendWithFallback, IOSuccess)
 {
     EXPECT_CALL(*default_backend, _io_impl).WillOnce(Return(successful_io_size));
 
@@ -71,27 +71,27 @@ TEST_P(HipFileRetryableBackend, IOSuccess)
     ASSERT_EQ(nbytes, successful_io_size);
 }
 
-TEST_P(HipFileRetryableBackend, IOFailureNoFallback)
+TEST_P(HipFileBackendWithFallback, IOFailureNoFallback)
 {
     EXPECT_CALL(*default_backend, _io_impl).WillOnce(Throw(std::runtime_error("IO failure")));
 
     EXPECT_THROW(default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0), std::runtime_error);
 }
 
-TEST_P(HipFileRetryableBackend, IOFailureWithIneligibleRetry)
+TEST_P(HipFileBackendWithFallback, IOFailureWithIneligibleRetry)
 {
     // The Backend has registered a fallback, but has determined that the
     // IO error should not be retried.
-    default_backend->register_retry_backend(fallback_backend);
+    default_backend->register_fallback_backend(fallback_backend);
     EXPECT_CALL(*default_backend, _io_impl).WillOnce(Throw(std::runtime_error("IO failure")));
     EXPECT_CALL(*fallback_backend, score).WillOnce(Return(-1));
 
     EXPECT_THROW(default_backend->io(io_type, mock_file, mock_buffer, 0, 0, 0), std::runtime_error);
 }
 
-TEST_P(HipFileRetryableBackend, IOFailureWithGoodFallback)
+TEST_P(HipFileBackendWithFallback, IOFailureWithGoodFallback)
 {
-    default_backend->register_retry_backend(fallback_backend);
+    default_backend->register_fallback_backend(fallback_backend);
     EXPECT_CALL(*default_backend, _io_impl).WillOnce(Throw(std::runtime_error("IO failure")));
     EXPECT_CALL(*fallback_backend, io).WillOnce(Return(successful_io_size));
 
@@ -99,6 +99,6 @@ TEST_P(HipFileRetryableBackend, IOFailureWithGoodFallback)
     ASSERT_EQ(nbytes, successful_io_size);
 }
 
-INSTANTIATE_TEST_SUITE_P(, HipFileRetryableBackend, ::testing::Values(IoType::Read, IoType::Write));
+INSTANTIATE_TEST_SUITE_P(, HipFileBackendWithFallback, ::testing::Values(IoType::Read, IoType::Write));
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/buffer.cpp
+++ b/test/amd_detail/buffer.cpp
@@ -11,6 +11,7 @@
 #include "hipfile-warnings.h"
 #include "mhip.h"
 #include "state.h"
+#include "test-common.h"
 
 #include <array>
 #include <cstddef>
@@ -97,7 +98,7 @@ TEST_F(HipFileBuffer, register_hip_pointer_get_attributes_error)
 {
     StrictMock<MHip> mhip;
     EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Throw(Hip::RuntimeError(hipErrorUnknown)));
-    ASSERT_EQ(hipFileBufRegister(nonnull_ptr, 0, 0), HipFileHipError(hipErrorUnknown));
+    ASSERT_EQ(hipFileBufRegister(nonnull_ptr, 0, 0), HipFileDriverError(hipErrorUnknown));
 
     // hipErrorInvalidValue is handled differently to match the behaviour of cufile
     EXPECT_CALL(mhip, hipPointerGetAttributes)

--- a/test/amd_detail/driver.cpp
+++ b/test/amd_detail/driver.cpp
@@ -9,6 +9,7 @@
 #include "mhip.h"
 #include "mmountinfo.h"
 #include "msys.h"
+#include "test-common.h"
 
 #include <cerrno>
 #include <cstdint>

--- a/test/amd_detail/fallback.cpp
+++ b/test/amd_detail/fallback.cpp
@@ -19,6 +19,7 @@
 #include "mmountinfo.h"
 #include "msys.h"
 #include "state.h"
+#include "test-common.h"
 
 #include <array>
 #include <cassert>

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -649,6 +649,8 @@ TEST_P(FastpathIoParamWithFallback, IntegrationFallbackRejectsIO)
     }
 
     // Have to rethrow the exception_ptr to be able to access the exception
+    // This looks ugly, but is better than the alternative of trying to preserve the
+    // exception type when setting Throw(*std::shared_ptr<std::exception>>).
     try {
         std::rethrow_exception(_get_param_exc_ptr());
     }
@@ -656,9 +658,14 @@ TEST_P(FastpathIoParamWithFallback, IntegrationFallbackRejectsIO)
         // Can't use EXPECT_THROW due to the thrown exception type only being known at runtime
         try {
             fastpath_backend->io(_get_param_io_type(), mfile, mbuffer, DEFAULT_IO_SIZE, 0, 0);
+            FAIL() << "io() was expected to throw, but it returned normally";
         }
         catch (const std::exception &actual_exc) {
-            ASSERT_EQ(&expected_exc, &actual_exc);
+            // Verify that the propagated exception has the same dynamic type and message
+            // as the one stored in the original std::exception_ptr, without relying on
+            // pointer identity of the underlying exception object.
+            ASSERT_EQ(typeid(expected_exc), typeid(actual_exc));
+            ASSERT_STREQ(expected_exc.what(), actual_exc.what());
         }
         catch (...) {
             FAIL() << "io() threw something other than a std::exception";

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "backend/fallback.h"
 #include "backend/fastpath.h"
 #include "hip.h"
 #include "hipfile.h"
@@ -12,10 +13,12 @@
 #include "mbuffer.h"
 #include "mfile.h"
 #include "mhip.h"
+#include "msys.h"
 
 #include <array>
 #include <cerrno>
 #include <cstdint>
+#include <exception>
 #include <fcntl.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -25,6 +28,7 @@
 #include <stdexcept>
 #include <sys/types.h>
 #include <system_error>
+#include <tuple>
 
 using namespace hipFile;
 using namespace testing;
@@ -554,5 +558,74 @@ TEST_P(FastpathIoParam, IoSizeIsTruncatedToMaxRWCount)
 }
 
 INSTANTIATE_TEST_SUITE_P(FastpathTest, FastpathIoParam, Values(IoType::Read, IoType::Write));
+
+struct FastpathIoParamWithFallback : public FastpathTestBase,
+                                     public TestWithParam<std::tuple<IoType, std::exception_ptr>> {
+    inline IoType _get_param_io_type() const
+    {
+        return std::get<0>(GetParam());
+    }
+
+    inline const std::exception_ptr _get_param_exc_ptr() const
+    {
+        return std::get<1>(GetParam());
+    }
+};
+
+// The Fastpath can throw a few different kinds of derived std::runtime_errors.
+TEST_P(FastpathIoParamWithFallback, IntegrationRunWithFallback)
+{
+    StrictMock<MHip> mhip;
+    StrictMock<MSys> msys;
+
+    auto fallback_backend = std::make_shared<StrictMock<Fallback>>();
+    auto fastpath_backend = std::make_shared<StrictMock<Fastpath>>();
+    fastpath_backend->register_fallback_backend(fallback_backend);
+
+    const int DEFAULT_BUFFERED_FD = DEFAULT_UNBUFFERED_FD.value() + 1;
+
+    // Called by both Fastpath and Fallback
+    EXPECT_CALL(*mbuffer, getBuffer).WillRepeatedly(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mbuffer, getLength).Times(2).WillRepeatedly(Return(DEFAULT_BUFFER_LENGTH));
+    // Called only by Fastpath
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    // Called only by Fallback
+    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(hipMemoryTypeDevice));
+    EXPECT_CALL(*mfile, getBufferedFd).WillRepeatedly(Return(DEFAULT_BUFFERED_FD));
+    EXPECT_CALL(mhip, hipMemcpy).WillRepeatedly(Return());
+    EXPECT_CALL(msys, mmap).WillOnce(Return(reinterpret_cast<void *>(0x12345678)));
+    EXPECT_CALL(msys, munmap).WillOnce(Return());
+    switch (_get_param_io_type()) {
+        case IoType::Read:
+            // Called by Fastpath
+            EXPECT_CALL(mhip, hipAmdFileRead).WillOnce(Rethrow(_get_param_exc_ptr()));
+            // Called by Fallback
+            EXPECT_CALL(msys, pread).WillRepeatedly(ReturnArg<2>());
+            break;
+        case IoType::Write:
+            // Called by Fastpath
+            EXPECT_CALL(mhip, hipAmdFileWrite).WillOnce(Rethrow(_get_param_exc_ptr()));
+            // Called by Fallback
+            EXPECT_CALL(mhip, hipStreamSynchronize).WillRepeatedly(Return());
+            EXPECT_CALL(msys, fdatasync).WillRepeatedly(Return());
+            EXPECT_CALL(msys, pwrite).WillRepeatedly(ReturnArg<2>());
+            break;
+        default:
+            FAIL() << "Invalid IoType";
+    }
+
+    ssize_t num_bytes = fastpath_backend->io(_get_param_io_type(), mfile, mbuffer, DEFAULT_IO_SIZE, 0, 0);
+    ASSERT_EQ(num_bytes, DEFAULT_IO_SIZE);
+}
+
+// Using std::exception_ptr is more straightforward here than storing a pointer
+// to a derived std::exception type, which would require careful handling when
+// setting expectations. Note that Throw() does not accept std::exception_ptr,
+// but the public (though undocumented) Rethrow() action does support it.
+INSTANTIATE_TEST_SUITE_P(
+    FastpathTest, FastpathIoParamWithFallback,
+    Combine(Values(IoType::Read, IoType::Write),
+            Values(std::make_exception_ptr(Hip::RuntimeError(hipErrorNoDevice)),
+                   std::make_exception_ptr(std::system_error(make_error_code(errc::no_such_device))))));
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -618,6 +618,54 @@ TEST_P(FastpathIoParamWithFallback, IntegrationRunWithFallback)
     ASSERT_EQ(num_bytes, DEFAULT_IO_SIZE);
 }
 
+// If the fallback backend rejects the IO, the original exception from
+// Fastpath should be raised.
+TEST_P(FastpathIoParamWithFallback, IntegrationFallbackRejectsIO)
+{
+    StrictMock<MHip> mhip;
+    StrictMock<MSys> msys;
+
+    auto fallback_backend = std::make_shared<StrictMock<Fallback>>();
+    auto fastpath_backend = std::make_shared<StrictMock<Fastpath>>();
+    fastpath_backend->register_fallback_backend(fallback_backend);
+
+    // Called only by Fastpath
+    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
+    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    // Called only by Fallback - should fail the score() check.
+    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(hipMemoryTypeHost));
+    switch (_get_param_io_type()) {
+        case IoType::Read:
+            // Called by Fastpath
+            EXPECT_CALL(mhip, hipAmdFileRead).WillOnce(Rethrow(_get_param_exc_ptr()));
+            break;
+        case IoType::Write:
+            // Called by Fastpath
+            EXPECT_CALL(mhip, hipAmdFileWrite).WillOnce(Rethrow(_get_param_exc_ptr()));
+            break;
+        default:
+            FAIL() << "Invalid IoType";
+    }
+
+    // Have to rethrow the exception_ptr to be able to access the exception
+    try {
+        std::rethrow_exception(_get_param_exc_ptr());
+    }
+    catch (const std::exception &expected_exc) {
+        // Can't use EXPECT_THROW due to the thrown exception type only being known at runtime
+        try {
+            fastpath_backend->io(_get_param_io_type(), mfile, mbuffer, DEFAULT_IO_SIZE, 0, 0);
+        }
+        catch (const std::exception &actual_exc) {
+            ASSERT_EQ(&expected_exc, &actual_exc);
+        }
+        catch (...) {
+            FAIL() << "io() threw something other than a std::exception";
+        }
+    }
+}
+
 // Using std::exception_ptr is more straightforward here than storing a pointer
 // to a derived std::exception type, which would require careful handling when
 // setting expectations. Note that Throw() does not accept std::exception_ptr,

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -12,6 +12,7 @@
 #include "mmountinfo.h"
 #include "mountinfo.h"
 #include "state.h"
+#include "test-common.h"
 
 #include <cerrno>
 #include <cstring>

--- a/test/amd_detail/hipfile-api.cpp
+++ b/test/amd_detail/hipfile-api.cpp
@@ -29,6 +29,7 @@
 #include "mstate.h"
 #include "msys.h"
 #include "state.h"
+#include "test-common.h"
 
 #include <array>
 #include <cerrno>

--- a/test/amd_detail/hipfile-test.h
+++ b/test/amd_detail/hipfile-test.h
@@ -12,62 +12,13 @@
 #include "mhip.h"
 #include "mmountinfo.h"
 #include "msys.h"
+#include "test-common.h"
 
 #include <array>
 #include <cassert>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
 #include <optional>
-
-// ***********************************************************************
-//  ERRORS AND ERROR HANDLING
-// ***********************************************************************
-
-// Set a particular hipFile error
-constexpr hipFileError_t
-HipFileHipError(hipError_t err)
-{
-    return {hipFileHipDriverError, err};
-}
-
-// Set a particular HIP error
-constexpr hipFileError_t
-HipFileOpError(hipFileOpError_t err)
-{
-    return {err, hipSuccess};
-}
-
-// == overload for hipFileError_t values
-inline bool
-operator==(const hipFileError_t &lhs, const hipFileError_t &rhs)
-{
-    return lhs.err == rhs.err && lhs.hip_drv_err == rhs.hip_drv_err;
-}
-
-// != overload for hipFileError_t values
-inline bool
-operator!=(const hipFileError_t &lhs, const hipFileError_t &rhs)
-{
-    return lhs.err != rhs.err || lhs.hip_drv_err != rhs.hip_drv_err;
-}
-
-// << overload for hipFileError_t values
-//
-// Unused in the test code, but kept here for iostream debugging
-#ifndef NDEBUG
-#include <iostream>
-inline std::ostream &
-operator<<(std::ostream &os, const hipFileError_t &rfe)
-{
-    return os << "hipFileError_t{ err: " << rfe.err << ", hip_drv_err: " << rfe.hip_drv_err << " }";
-}
-#endif
-
-// Convenience "success" value
-inline constexpr hipFileError_t HIPFILE_SUCCESS{hipFileSuccess, hipSuccess};
-
-// Convenience "invalid argument" value
-inline constexpr hipFileError_t HIPFILE_INVALID_VALUE{hipFileInvalidValue, hipSuccess};
 
 // ***********************************************************************
 //  BASE ERROR CLASSES

--- a/test/amd_detail/mbackend.h
+++ b/test/amd_detail/mbackend.h
@@ -23,7 +23,6 @@ struct MBackend : Backend {
 struct MRetryableBackend : RetryableBackend {
     MOCK_METHOD(int, score, (std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t, hoff_t),
                 (const, override));
-    MOCK_METHOD(bool, is_retryable, (std::exception_ptr e_ptr, ssize_t nbytes), (const, override));
     MOCK_METHOD(ssize_t, retryable_io,
                 (IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                  hoff_t file_offset, hoff_t buffer_offset),

--- a/test/amd_detail/mbackend.h
+++ b/test/amd_detail/mbackend.h
@@ -18,16 +18,20 @@ struct MBackend : Backend {
                 (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
                  hoff_t),
                 (override));
+    MOCK_METHOD(ssize_t, _io_impl,
+                (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
+                 hoff_t),
+                (override));
 };
 
 struct MRetryableBackend : RetryableBackend {
     MOCK_METHOD(int, score, (std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t, hoff_t),
                 (const, override));
-    MOCK_METHOD(ssize_t, retryable_io,
+    MOCK_METHOD(void, update_read_stats, (ssize_t nbytes), (override));
+    MOCK_METHOD(void, update_write_stats, (ssize_t nbytes), (override));
+    MOCK_METHOD(ssize_t, _io_impl,
                 (IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                  hoff_t file_offset, hoff_t buffer_offset),
                 (override));
-    MOCK_METHOD(void, update_read_stats, (ssize_t nbytes), (override));
-    MOCK_METHOD(void, update_write_stats, (ssize_t nbytes), (override));
 };
 }

--- a/test/amd_detail/mbackend.h
+++ b/test/amd_detail/mbackend.h
@@ -18,6 +18,8 @@ struct MBackend : Backend {
                 (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
                  hoff_t),
                 (override));
+    MOCK_METHOD(void, update_read_stats, (ssize_t nbytes), (override));
+    MOCK_METHOD(void, update_write_stats, (ssize_t nbytes), (override));
     MOCK_METHOD(ssize_t, _io_impl,
                 (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
                  hoff_t),

--- a/test/amd_detail/mbackend.h
+++ b/test/amd_detail/mbackend.h
@@ -24,7 +24,7 @@ struct MBackend : Backend {
                 (override));
 };
 
-struct MRetryableBackend : RetryableBackend {
+struct MBackendWithFallback : BackendWithFallback {
     MOCK_METHOD(int, score, (std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t, hoff_t),
                 (const, override));
     MOCK_METHOD(void, update_read_stats, (ssize_t nbytes), (override));

--- a/test/amd_detail/mbackend.h
+++ b/test/amd_detail/mbackend.h
@@ -20,4 +20,15 @@ struct MBackend : Backend {
                 (override));
 };
 
+struct MRetryableBackend : RetryableBackend {
+    MOCK_METHOD(int, score, (std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t, hoff_t),
+                (const, override));
+    MOCK_METHOD(bool, is_retryable, (std::exception_ptr e_ptr, ssize_t nbytes), (const, override));
+    MOCK_METHOD(ssize_t, retryable_io,
+                (IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+                 hoff_t file_offset, hoff_t buffer_offset),
+                (override));
+    MOCK_METHOD(void, update_read_stats, (ssize_t nbytes), (override));
+    MOCK_METHOD(void, update_write_stats, (ssize_t nbytes), (override));
+};
 }

--- a/test/amd_detail/mhip.h
+++ b/test/amd_detail/mhip.h
@@ -7,18 +7,11 @@
 
 #include "context.h"
 #include "hip.h"
+#include "test-common.h"
 
 #include <gmock/gmock.h>
 
-using ::testing::Invoke;
-
-// ON_CALL is not compatible with StrictMock's
-#define MOCK_PASSTHROUGH(base_class, func) \
-    ON_CALL(*this, func).WillByDefault( \
-        [this](auto&&... args) { \
-            return this->base_class::func(std::forward<decltype(args)>(args)...); \
-        } \
-    )
+#define MHIP_PASSTHROUGH(func) MOCK_PASSTHROUGH(hipFile::Hip, func)
 
 /* mhipxx (mock hip++)
  *
@@ -61,21 +54,21 @@ struct MHip : Hip {
 
     void enable_passthrough()
     {
-        MOCK_PASSTHROUGH(Hip, hipPointerGetAttributes);
-        MOCK_PASSTHROUGH(Hip, hipMemcpy);
-        MOCK_PASSTHROUGH(Hip, hipStreamSynchronize);
-        MOCK_PASSTHROUGH(Hip, hipHostMalloc);
-        MOCK_PASSTHROUGH(Hip, hipHostFree);
-        MOCK_PASSTHROUGH(Hip, hipHostGetDevicePointer);
-        MOCK_PASSTHROUGH(Hip, hipRuntimeGetVersion);
-        MOCK_PASSTHROUGH(Hip, hipGetProcAddress);
-        MOCK_PASSTHROUGH(Hip, hipAmdFileRead);
-        MOCK_PASSTHROUGH(Hip, hipAmdFileWrite);
-        MOCK_PASSTHROUGH(Hip, hipMemGetAddressRange);
-        MOCK_PASSTHROUGH(Hip, hipLaunchHostFunc);
-        MOCK_PASSTHROUGH(Hip, hipLaunchKernel);
-        MOCK_PASSTHROUGH(Hip, hipDeviceGetAttribute);
-        MOCK_PASSTHROUGH(Hip, hipStreamGetDevice);
+        MHIP_PASSTHROUGH(hipPointerGetAttributes);
+        MHIP_PASSTHROUGH(hipMemcpy);
+        MHIP_PASSTHROUGH(hipStreamSynchronize);
+        MHIP_PASSTHROUGH(hipHostMalloc);
+        MHIP_PASSTHROUGH(hipHostFree);
+        MHIP_PASSTHROUGH(hipHostGetDevicePointer);
+        MHIP_PASSTHROUGH(hipRuntimeGetVersion);
+        MHIP_PASSTHROUGH(hipGetProcAddress);
+        MHIP_PASSTHROUGH(hipAmdFileRead);
+        MHIP_PASSTHROUGH(hipAmdFileWrite);
+        MHIP_PASSTHROUGH(hipMemGetAddressRange);
+        MHIP_PASSTHROUGH(hipLaunchHostFunc);
+        MHIP_PASSTHROUGH(hipLaunchKernel);
+        MHIP_PASSTHROUGH(hipDeviceGetAttribute);
+        MHIP_PASSTHROUGH(hipStreamGetDevice);
     }
 };
 

--- a/test/amd_detail/mhip.h
+++ b/test/amd_detail/mhip.h
@@ -10,6 +10,8 @@
 
 #include <gmock/gmock.h>
 
+using ::testing::Invoke;
+
 /* mhipxx (mock hip++)
  *
  * Mock implementations for Hip. Enables unit tests to mock HIP APIs.
@@ -48,6 +50,26 @@ struct MHip : Hip {
                 (const, override));
     MOCK_METHOD(int, hipDeviceGetAttribute, (hipDeviceAttribute_t attr, int device_id), (const, override));
     MOCK_METHOD(hipDevice_t, hipStreamGetDevice, (hipStream_t stream), (const, override));
+
+    // This function is not compatible with StrictMocks.
+    void enable_passthrough()
+    {
+        ON_CALL(*this, hipPointerGetAttributes).WillByDefault(Invoke(this, &Hip::hipPointerGetAttributes));
+        ON_CALL(*this, hipMemcpy).WillByDefault(Invoke(this, &Hip::hipMemcpy));
+        ON_CALL(*this, hipStreamSynchronize).WillByDefault(Invoke(this, &Hip::hipStreamSynchronize));
+        ON_CALL(*this, hipHostMalloc).WillByDefault(Invoke(this, &Hip::hipHostMalloc));
+        ON_CALL(*this, hipHostFree).WillByDefault(Invoke(this, &Hip::hipHostFree));
+        ON_CALL(*this, hipHostGetDevicePointer).WillByDefault(Invoke(this, &Hip::hipHostGetDevicePointer));
+        ON_CALL(*this, hipRuntimeGetVersion).WillByDefault(Invoke(this, &Hip::hipRuntimeGetVersion));
+        ON_CALL(*this, hipGetProcAddress).WillByDefault(Invoke(this, &Hip::hipGetProcAddress));
+        ON_CALL(*this, hipAmdFileRead).WillByDefault(Invoke(this, &Hip::hipAmdFileRead));
+        ON_CALL(*this, hipAmdFileWrite).WillByDefault(Invoke(this, &Hip::hipAmdFileWrite));
+        ON_CALL(*this, hipMemGetAddressRange).WillByDefault(Invoke(this, &Hip::hipMemGetAddressRange));
+        ON_CALL(*this, hipLaunchHostFunc).WillByDefault(Invoke(this, &Hip::hipLaunchHostFunc));
+        ON_CALL(*this, hipLaunchKernel).WillByDefault(Invoke(this, &Hip::hipLaunchKernel));
+        ON_CALL(*this, hipDeviceGetAttribute).WillByDefault(Invoke(this, &Hip::hipDeviceGetAttribute));
+        ON_CALL(*this, hipStreamGetDevice).WillByDefault(Invoke(this, &Hip::hipStreamGetDevice));
+    }
 };
 
 }

--- a/test/amd_detail/mhip.h
+++ b/test/amd_detail/mhip.h
@@ -12,6 +12,14 @@
 
 using ::testing::Invoke;
 
+// ON_CALL is not compatible with StrictMock's
+#define MOCK_PASSTHROUGH(base_class, func) \
+    ON_CALL(*this, func).WillByDefault( \
+        [this](auto&&... args) { \
+            return this->base_class::func(std::forward<decltype(args)>(args)...); \
+        } \
+    )
+
 /* mhipxx (mock hip++)
  *
  * Mock implementations for Hip. Enables unit tests to mock HIP APIs.
@@ -51,24 +59,23 @@ struct MHip : Hip {
     MOCK_METHOD(int, hipDeviceGetAttribute, (hipDeviceAttribute_t attr, int device_id), (const, override));
     MOCK_METHOD(hipDevice_t, hipStreamGetDevice, (hipStream_t stream), (const, override));
 
-    // This function is not compatible with StrictMocks.
     void enable_passthrough()
     {
-        ON_CALL(*this, hipPointerGetAttributes).WillByDefault(Invoke(this, &Hip::hipPointerGetAttributes));
-        ON_CALL(*this, hipMemcpy).WillByDefault(Invoke(this, &Hip::hipMemcpy));
-        ON_CALL(*this, hipStreamSynchronize).WillByDefault(Invoke(this, &Hip::hipStreamSynchronize));
-        ON_CALL(*this, hipHostMalloc).WillByDefault(Invoke(this, &Hip::hipHostMalloc));
-        ON_CALL(*this, hipHostFree).WillByDefault(Invoke(this, &Hip::hipHostFree));
-        ON_CALL(*this, hipHostGetDevicePointer).WillByDefault(Invoke(this, &Hip::hipHostGetDevicePointer));
-        ON_CALL(*this, hipRuntimeGetVersion).WillByDefault(Invoke(this, &Hip::hipRuntimeGetVersion));
-        ON_CALL(*this, hipGetProcAddress).WillByDefault(Invoke(this, &Hip::hipGetProcAddress));
-        ON_CALL(*this, hipAmdFileRead).WillByDefault(Invoke(this, &Hip::hipAmdFileRead));
-        ON_CALL(*this, hipAmdFileWrite).WillByDefault(Invoke(this, &Hip::hipAmdFileWrite));
-        ON_CALL(*this, hipMemGetAddressRange).WillByDefault(Invoke(this, &Hip::hipMemGetAddressRange));
-        ON_CALL(*this, hipLaunchHostFunc).WillByDefault(Invoke(this, &Hip::hipLaunchHostFunc));
-        ON_CALL(*this, hipLaunchKernel).WillByDefault(Invoke(this, &Hip::hipLaunchKernel));
-        ON_CALL(*this, hipDeviceGetAttribute).WillByDefault(Invoke(this, &Hip::hipDeviceGetAttribute));
-        ON_CALL(*this, hipStreamGetDevice).WillByDefault(Invoke(this, &Hip::hipStreamGetDevice));
+        MOCK_PASSTHROUGH(Hip, hipPointerGetAttributes);
+        MOCK_PASSTHROUGH(Hip, hipMemcpy);
+        MOCK_PASSTHROUGH(Hip, hipStreamSynchronize);
+        MOCK_PASSTHROUGH(Hip, hipHostMalloc);
+        MOCK_PASSTHROUGH(Hip, hipHostFree);
+        MOCK_PASSTHROUGH(Hip, hipHostGetDevicePointer);
+        MOCK_PASSTHROUGH(Hip, hipRuntimeGetVersion);
+        MOCK_PASSTHROUGH(Hip, hipGetProcAddress);
+        MOCK_PASSTHROUGH(Hip, hipAmdFileRead);
+        MOCK_PASSTHROUGH(Hip, hipAmdFileWrite);
+        MOCK_PASSTHROUGH(Hip, hipMemGetAddressRange);
+        MOCK_PASSTHROUGH(Hip, hipLaunchHostFunc);
+        MOCK_PASSTHROUGH(Hip, hipLaunchKernel);
+        MOCK_PASSTHROUGH(Hip, hipDeviceGetAttribute);
+        MOCK_PASSTHROUGH(Hip, hipStreamGetDevice);
     }
 };
 

--- a/test/amd_detail/stream.cpp
+++ b/test/amd_detail/stream.cpp
@@ -9,6 +9,7 @@
 #include "mhip.h"
 #include "msys.h"
 #include "stream.h"
+#include "test-common.h"
 
 #include <cstdint>
 #include <gmock/gmock.h>

--- a/test/common/test-common.h
+++ b/test/common/test-common.h
@@ -14,6 +14,14 @@
 #include <stdexcept>
 #include <unistd.h>
 
+// ON_CALL is not compatible with StrictMock's
+#define MOCK_PASSTHROUGH(base_class, func) \
+    ON_CALL(*this, func).WillByDefault( \
+        [this](auto&&... args) { \
+            return this->base_class::func(std::forward<decltype(args)>(args)...); \
+        } \
+    )
+
 // Set a particular hipfile error
 constexpr hipFileError_t
 HipFileOpError(hipFileOpError_t err)

--- a/test/common/test-common.h
+++ b/test/common/test-common.h
@@ -14,32 +14,49 @@
 #include <stdexcept>
 #include <unistd.h>
 
+// Set a particular hipfile error
 constexpr hipFileError_t
 HipFileOpError(hipFileOpError_t err)
 {
     return {err, hipSuccess};
 }
 
+// Set a particular HIP error
 constexpr hipFileError_t
 HipFileDriverError(hipError_t err)
 {
     return {hipFileHipDriverError, err};
 }
 
+// == overload for hipFileError_t values
 inline bool
 operator==(const hipFileError_t &lhs, const hipFileError_t &rhs)
 {
     return lhs.err == rhs.err && lhs.hip_drv_err == rhs.hip_drv_err;
 }
 
-static std::ostream &
+// != overload for hipFileError_t values
+inline bool
+operator!=(const hipFileError_t &lhs, const hipFileError_t &rhs)
+{
+    return lhs.err != rhs.err || lhs.hip_drv_err != rhs.hip_drv_err;
+}
+
+// Unused in the test code, but kept here for iostream debugging
+#ifndef NDEBUG
+#include <iostream>
+inline std::ostream &
 operator<<(std::ostream &os, const hipFileError_t &hfe)
 {
     return os << "hipFileError_t{ err: " << hfe.err << ", hip_drv_err: " << hfe.hip_drv_err << " }";
 }
+#endif
 
 // Convenience "success" value
 inline constexpr hipFileError_t HIPFILE_SUCCESS{hipFileSuccess, hipSuccess};
+
+// Convenience "invalid argument" value
+inline constexpr hipFileError_t HIPFILE_INVALID_VALUE{hipFileInvalidValue, hipSuccess};
 
 inline void
 rfill(void *buffer, uint64_t len, uint32_t seed = 97)

--- a/test/system/fastpath.cpp
+++ b/test/system/fastpath.cpp
@@ -1,0 +1,105 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "hip.h"
+#include "hipfile.h"
+#include "mhip.h"
+
+#include "test-common.h"
+#include "test-options.h"
+
+#include <cstdlib>
+#include <unistd.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime_api.h>
+
+//using namespace hipFile;
+using namespace testing;
+using namespace std;
+
+extern SystemTestOptions test_env;
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
+
+enum IoType {
+    Read = 0,
+    Write = 1
+}
+
+struct FastpathWithFallbackIO : public TestWithParam<std::tuple<IoType, std::exception_ptr>> {
+    
+    Tmpfile         tmpfile;
+    size_t          tmpfile_size;
+    hipFileHandle_t tmpfile_handle;
+    void           *device_buffer;
+    size_t          device_buffer_size;
+
+    NiceMock<hipFile::MHip> mhip;
+
+    FastpathWithFallbackIO()
+        : tmpfile{test_env.ais_capable_dir}, tmpfile_size{1024 * 1024}, tmpfile_handle{nullptr},
+          device_buffer{nullptr}, device_buffer_size{1024 * 1024}
+    {
+    }
+
+    void SetUp() override
+    {
+        if (unsetenv("HIPFILE_FORCE_COMPAT_MODE")) {
+            FAIL() << "Could not clear HIPFILE_FORCE_COMPAT_MODE";
+        }
+        if (setenv("HIPFILE_ALLOW_COMPAT_MODE", "true", 1)) {
+            FAIL() << "Could not set HIPFILE_ALLOW_COMPAT_MODE=true";
+        }
+        // Must be called prior to any expectations on Hip set.
+        mhip.enable_passthrough();
+
+        switch (_get_param_io_type()) {
+            case IoType::Read:
+                EXPECT_CALL(mhip, hipAmdFileRead);
+                break;
+            case IoType::Write:
+                EXPECT_CALL(mhip, hipAmdFileWrite);
+                break;
+            default:
+                FAIL() << "Unsupported IoTestBackend";
+        }
+
+        ASSERT_EQ(0, ftruncate(tmpfile.fd, static_cast<off_t>(tmpfile_size)));
+
+        hipFileDescr_t descr{};
+        descr.type      = hipFileHandleTypeOpaqueFD;
+        descr.handle.fd = tmpfile.fd;
+
+        ASSERT_EQ(HIPFILE_SUCCESS, hipFileHandleRegister(&tmpfile_handle, &descr));
+        ASSERT_EQ(hipSuccess, hipMalloc(&device_buffer, device_buffer_size));
+        ASSERT_EQ(HIPFILE_SUCCESS, hipFileBufRegister(device_buffer, device_buffer_size, 0));
+    }
+
+    void TearDown() override
+    {
+        ASSERT_EQ(HIP_SUCCESS, hipFileBufDeregister(device_buffer););
+        ASSERT_EQ(hipSuccess, hipFree(device_buffer));
+        hipFileHandleDeregister(tmpfile_handle);
+    }
+
+    inline IoType _get_param_io_type() const
+    {
+        return std::get<0>(GetParam());
+    }
+
+    inline const std::exception_ptr _get_param_exc_ptr() const
+    {
+        return std::get<1>(GetParam());
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    , FastpathWithFallbackIO,
+    Combine(Values(IoType::Read, IoType::Write),
+            Values(std::make_exception_ptr(hipFile::Hip::RuntimeError(hipErrorNoDevice)),
+                   std::make_exception_ptr(std::system_error(make_error_code(errc::no_such_device))))));
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/system/fastpath.cpp
+++ b/test/system/fastpath.cpp
@@ -5,6 +5,7 @@
 
 #include "hip.h"
 #include "hipfile.h"
+#include "io.h"
 #include "mhip.h"
 
 #include "test-common.h"
@@ -24,12 +25,7 @@ extern SystemTestOptions test_env;
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
 
-enum IoType {
-    Read = 0,
-    Write = 1
-}
-
-struct FastpathWithFallbackIO : public TestWithParam<std::tuple<IoType, std::exception_ptr>> {
+struct FastpathWithFallbackIO : public TestWithParam<std::tuple<hipFile::IoType, std::exception_ptr>> {
     
     Tmpfile         tmpfile;
     size_t          tmpfile_size;
@@ -53,15 +49,16 @@ struct FastpathWithFallbackIO : public TestWithParam<std::tuple<IoType, std::exc
         if (setenv("HIPFILE_ALLOW_COMPAT_MODE", "true", 1)) {
             FAIL() << "Could not set HIPFILE_ALLOW_COMPAT_MODE=true";
         }
+        std::cout << "HIPFILE_ALLOW_COMPAT_MODE=" << getenv("HIPFILE_ALLOW_COMPAT_MODE") << std::endl;
         // Must be called prior to any expectations on Hip set.
         mhip.enable_passthrough();
 
         switch (_get_param_io_type()) {
-            case IoType::Read:
-                EXPECT_CALL(mhip, hipAmdFileRead);
+            case hipFile::IoType::Read:
+                EXPECT_CALL(mhip, hipAmdFileRead).WillOnce(Rethrow(_get_param_exc_ptr()));
                 break;
-            case IoType::Write:
-                EXPECT_CALL(mhip, hipAmdFileWrite);
+            case hipFile::IoType::Write:
+                EXPECT_CALL(mhip, hipAmdFileWrite).WillOnce(Rethrow(_get_param_exc_ptr()));
                 break;
             default:
                 FAIL() << "Unsupported IoTestBackend";
@@ -80,12 +77,12 @@ struct FastpathWithFallbackIO : public TestWithParam<std::tuple<IoType, std::exc
 
     void TearDown() override
     {
-        ASSERT_EQ(HIP_SUCCESS, hipFileBufDeregister(device_buffer););
+        ASSERT_EQ(HIPFILE_SUCCESS, hipFileBufDeregister(device_buffer));
         ASSERT_EQ(hipSuccess, hipFree(device_buffer));
         hipFileHandleDeregister(tmpfile_handle);
     }
 
-    inline IoType _get_param_io_type() const
+    inline hipFile::IoType _get_param_io_type() const
     {
         return std::get<0>(GetParam());
     }
@@ -96,9 +93,24 @@ struct FastpathWithFallbackIO : public TestWithParam<std::tuple<IoType, std::exc
     }
 };
 
+TEST_P(FastpathWithFallbackIO, DummyTest)
+{
+    // Simply checks to see if the set & teardown portions have been configured correctly.
+    switch (_get_param_io_type()) {
+        case hipFile::IoType::Read:
+            ASSERT_EQ(tmpfile_size, hipFileRead(tmpfile_handle, device_buffer, tmpfile_size, 0, 0));
+            break;
+        case hipFile::IoType::Write:
+            ASSERT_EQ(tmpfile_size, hipFileWrite(tmpfile_handle, device_buffer, tmpfile_size, 0, 0));
+            break;
+        default:
+            FAIL() << "Unsupported IoTestBackend";
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(
     , FastpathWithFallbackIO,
-    Combine(Values(IoType::Read, IoType::Write),
+    Combine(Values(hipFile::IoType::Read, hipFile::IoType::Write),
             Values(std::make_exception_ptr(hipFile::Hip::RuntimeError(hipErrorNoDevice)),
                    std::make_exception_ptr(std::system_error(make_error_code(errc::no_such_device))))));
 


### PR DESCRIPTION
GTest's framework allows for a mock to call the real implementation of a method. We can utilize this in our system tests to very selectively choose what gets mocked. In this case, we want to mock the call from KFD/HSA to induce a failure to test the fallback mechanism.

Relies on #215 

AIHIPFILE-155