### PR TITLE
fastpath: Only allow IO to approved file types and file systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * The AIS optimized IO path will automatically fallback to the POSIX IO path if a failure occurs and the compatibility mode has not been disabled.
 * Added check in the Fastpath/AIS backend to ensure the HIP Runtime is initialized. This avoids causing a segfault in the HIP Runtime.
 * The default CMake build type was changed from `Debug` to `RelWithDebInfo`
+* Added file type and file system validation in Fastpath. Fastpath will only accept IO targeting block devices or regular files backed by xfs or ext4 with ordered journaling mode. Other file systems can be explicitly allowed via the `HIPFILE_UNSUPPORTED_FILE_SYSTEMS` environment variable.
 
 ### Removed
 * The rocFile library has been completely removed and the code is now a part of hipFile.

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -97,7 +97,7 @@ Fallback::_io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBu
             switch (type) {
                 case IoType::Read:
                     io_bytes =
-                        Context<Sys>::get()->pread(file->getBufferedFd(), bounce_buffer.get(), count, offset);
+                        Context<Sys>::get()->pread(file->bufferedFd(), bounce_buffer.get(), count, offset);
                     if (io_bytes > 0) {
                         Context<Hip>::get()->hipMemcpy(device_buffer_position, bounce_buffer.get(),
                                                        static_cast<size_t>(io_bytes), hipMemcpyHostToDevice);
@@ -107,9 +107,9 @@ Fallback::_io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBu
                     Context<Hip>::get()->hipMemcpy(bounce_buffer.get(), device_buffer_position, count,
                                                    hipMemcpyDeviceToHost);
                     Context<Hip>::get()->hipStreamSynchronize(nullptr);
-                    io_bytes = Context<Sys>::get()->pwrite(file->getBufferedFd(), bounce_buffer.get(), count,
-                                                           offset);
-                    Context<Sys>::get()->fdatasync(file->getBufferedFd());
+                    io_bytes =
+                        Context<Sys>::get()->pwrite(file->bufferedFd(), bounce_buffer.get(), count, offset);
+                    Context<Sys>::get()->fdatasync(file->bufferedFd());
                     break;
                 default:
                     throw std::runtime_error("Invalid IO type");
@@ -274,11 +274,11 @@ async_io_cpu_copy(void *userargs)
         try {
             switch (op->io_type) {
                 case IoType::Read:
-                    ret = Context<Sys>::get()->pread(op->file->getBufferedFd(), cur_buf_position,
+                    ret = Context<Sys>::get()->pread(op->file->bufferedFd(), cur_buf_position,
                                                      remaining_bytes, cur_file_offset);
                     break;
                 case IoType::Write:
-                    ret = Context<Sys>::get()->pwrite(op->file->getBufferedFd(), cur_buf_position,
+                    ret = Context<Sys>::get()->pwrite(op->file->bufferedFd(), cur_buf_position,
                                                       remaining_bytes, cur_file_offset);
                     break;
                 default:

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -143,21 +143,19 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
     accept_io &= 0 <= file_offset;
     accept_io &= 0 <= buffer_offset;
 
-    uint64_t mem_align_mask{4096 - 1};
     uint64_t offset_align_mask{4096 - 1};
-
 #if defined(STATX_DIOALIGN)
     const struct statx &stx{file->getStatx()};
     accept_io &= !!(stx.stx_mask & STATX_DIOALIGN);
     accept_io &= stx.stx_dio_offset_align && stx.stx_dio_mem_align;
-    mem_align_mask    = stx.stx_dio_mem_align - 1;
     offset_align_mask = stx.stx_dio_offset_align - 1;
 #endif
-
     accept_io &= !(size & offset_align_mask);
     accept_io &= !(file_offset & static_cast<int64_t>(offset_align_mask));
-    auto buffer_address{reinterpret_cast<intptr_t>(buffer->getBuffer())};
-    accept_io &= !((buffer_address + buffer_offset) & static_cast<int64_t>(mem_align_mask));
+
+    const uint32_t dio_mem_align{file->dioMemAlign()};
+    const auto     mem_addr{reinterpret_cast<intptr_t>(buffer->getBuffer()) + buffer_offset};
+    accept_io &= dio_mem_align && !(mem_addr & (dio_mem_align - 1));
 
     return accept_io ? 100 : -1;
 }

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -146,7 +146,8 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
     bool is_regular_file{file->isRegularFile()};
     bool is_block_device{file->isBlockDevice()};
     bool on_ext4_ordered{file->onExt4Ordered()};
-    accept_io &= is_block_device || (is_regular_file && on_ext4_ordered);
+    bool on_xfs{file->onXfs()};
+    accept_io &= is_block_device || (is_regular_file && (on_ext4_ordered || on_xfs));
 
     const uint32_t dio_offset_align{file->dioOffsetAlign()};
     accept_io &= dio_offset_align && !(file_offset & (dio_offset_align - 1));

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -143,6 +143,8 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
     accept_io &= 0 <= file_offset;
     accept_io &= 0 <= buffer_offset;
 
+    accept_io &= file->isRegularFile();
+
     const uint32_t dio_offset_align{file->dioOffsetAlign()};
     accept_io &= dio_offset_align && !(file_offset & (dio_offset_align - 1));
     accept_io &= dio_offset_align && !(size & (dio_offset_align - 1));

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -143,15 +143,9 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
     accept_io &= 0 <= file_offset;
     accept_io &= 0 <= buffer_offset;
 
-    uint64_t offset_align_mask{4096 - 1};
-#if defined(STATX_DIOALIGN)
-    const struct statx &stx{file->getStatx()};
-    accept_io &= !!(stx.stx_mask & STATX_DIOALIGN);
-    accept_io &= stx.stx_dio_offset_align && stx.stx_dio_mem_align;
-    offset_align_mask = stx.stx_dio_offset_align - 1;
-#endif
-    accept_io &= !(size & offset_align_mask);
-    accept_io &= !(file_offset & static_cast<int64_t>(offset_align_mask));
+    const uint32_t dio_offset_align{file->dioOffsetAlign()};
+    accept_io &= dio_offset_align && !(file_offset & (dio_offset_align - 1));
+    accept_io &= dio_offset_align && !(size & (dio_offset_align - 1));
 
     const uint32_t dio_mem_align{file->dioMemAlign()};
     const auto     mem_addr{reinterpret_cast<intptr_t>(buffer->getBuffer()) + buffer_offset};

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -147,7 +147,9 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
     bool is_block_device{file->isBlockDevice()};
     bool on_ext4_ordered{file->onExt4Ordered()};
     bool on_xfs{file->onXfs()};
-    accept_io &= is_block_device || (is_regular_file && (on_ext4_ordered || on_xfs));
+    bool unsupported_file_systems{Context<Configuration>::get()->unsupportedFileSystems()};
+    accept_io &=
+        is_block_device || (is_regular_file && (unsupported_file_systems || on_ext4_ordered || on_xfs));
 
     const uint32_t dio_offset_align{file->dioOffsetAlign()};
     accept_io &= dio_offset_align && !(file_offset & (dio_offset_align - 1));

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -145,7 +145,8 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
 
     bool is_regular_file{file->isRegularFile()};
     bool is_block_device{file->isBlockDevice()};
-    accept_io &= is_block_device || is_regular_file;
+    bool on_ext4_ordered{file->onExt4Ordered()};
+    accept_io &= is_block_device || (is_regular_file && on_ext4_ordered);
 
     const uint32_t dio_offset_align{file->dioOffsetAlign()};
     accept_io &= dio_offset_align && !(file_offset & (dio_offset_align - 1));

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -143,7 +143,9 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
     accept_io &= 0 <= file_offset;
     accept_io &= 0 <= buffer_offset;
 
-    accept_io &= file->isRegularFile();
+    bool is_regular_file{file->isRegularFile()};
+    bool is_block_device{file->isBlockDevice()};
+    accept_io &= is_block_device || is_regular_file;
 
     const uint32_t dio_offset_align{file->dioOffsetAlign()};
     accept_io &= dio_offset_align && !(file_offset & (dio_offset_align - 1));

--- a/src/amd_detail/backend/fastpath.cpp
+++ b/src/amd_detail/backend/fastpath.cpp
@@ -136,7 +136,7 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
 
     accept_io &= Context<Configuration>::get()->fastpath();
 
-    accept_io &= file->getUnbufferedFd().has_value();
+    accept_io &= file->unbufferedFd().has_value();
 
     accept_io &= buffer->getType() == hipMemoryTypeDevice;
 
@@ -166,7 +166,7 @@ Fastpath::_io_impl(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buff
     hipAmdFileHandle_t handle{};
     size_t             nbytes{};
 
-    handle.fd = file->getUnbufferedFd().value();
+    handle.fd = file->unbufferedFd().value();
 
     if (!paramsValid(buffer, size, file_offset, buffer_offset)) {
         throw std::invalid_argument("The selected file or buffer region is invalid");

--- a/src/amd_detail/batch/batch.cpp
+++ b/src/amd_detail/batch/batch.cpp
@@ -56,7 +56,7 @@ BatchOperation::BatchOperation(std::unique_ptr<const hipFileIOParams_t> params,
     }
 
     // Check File parameters
-    if (io_params->fh != file->getHandle()) {
+    if (io_params->fh != file->handle()) {
         throw std::invalid_argument("File does not match handle specified in io_params.");
     }
     if (io_params->u.batch.file_offset < 0) {

--- a/src/amd_detail/configuration.cpp
+++ b/src/amd_detail/configuration.cpp
@@ -46,3 +46,10 @@ Configuration::statsLevel() const noexcept
     HIPFILE_STATIC unsigned int stats_level_env{Environment::stats_level().value_or(0)};
     return stats_level_env;
 }
+
+bool
+Configuration::unsupportedFileSystems() const noexcept
+{
+    HIPFILE_STATIC bool unsupported_file_systems_env{Environment::unsupported_file_systems().value_or(false)};
+    return unsupported_file_systems_env;
+}

--- a/src/amd_detail/configuration.h
+++ b/src/amd_detail/configuration.h
@@ -37,6 +37,11 @@ public:
     /// @brief Shows the level of detail for stats collection
     /// @return 0 if stats collection disabled, higher levels of detail as value increases
     virtual unsigned int statsLevel() const noexcept;
+
+    /// @brief Checks if unsupported file systems are allowed in the fastpath backend
+    /// @return true if unsupported file systems are allowed, false if only supported file systems are
+    /// permitted (default)
+    virtual bool unsupportedFileSystems() const noexcept;
 };
 
 }

--- a/src/amd_detail/environment.cpp
+++ b/src/amd_detail/environment.cpp
@@ -64,6 +64,12 @@ Environment::force_compat_mode()
     return Environment::get<bool>(Environment::FORCE_COMPAT_MODE);
 }
 
+optional<bool>
+Environment::unsupported_file_systems()
+{
+    return Environment::get<bool>(Environment::UNSUPPORTED_FILE_SYSTEMS);
+}
+
 optional<unsigned int>
 Environment::stats_level()
 {

--- a/src/amd_detail/environment.h
+++ b/src/amd_detail/environment.h
@@ -47,6 +47,19 @@ public:
     static constexpr const char *const STATS_LEVEL{"HIPFILE_STATS_LEVEL"};
 
     static std::optional<unsigned int> stats_level();
+
+    /// @brief Allow unsupported file systems in the fastpath backend
+    ///
+    /// If enabled, the fastpath backend will allow I/O on file systems other than
+    /// ext4 (with ordered journaling) and xfs. If disabled (default), only supported
+    /// file systems are permitted.
+    static constexpr const char *const UNSUPPORTED_FILE_SYSTEMS{"HIPFILE_UNSUPPORTED_FILE_SYSTEMS"};
+
+    /// @brief Get the value of HIPFILE_UNSUPPORTED_FILE_SYSTEMS from the environment
+    /// @return An optional boolean value if HIPFILE_UNSUPPORTED_FILE_SYSTEMS was set,
+    /// nullopt if HIPFILE_UNSUPPORTED_FILE_SYSTEMS was unset or had a value other than
+    /// true or false.
+    static std::optional<bool> unsupported_file_systems();
 };
 
 }

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -71,7 +71,7 @@ IFile::getHandle() const
 }
 
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
-    : client_fd{std::move(uf.client_fd)}, m_buffered_fd{std::move(uf.buffered_fd)},
+    : m_client_fd{std::move(uf.client_fd)}, m_buffered_fd{std::move(uf.buffered_fd)},
       m_unbuffered_fd{std::move(uf.unbuffered_fd)}, m_dio_mem_align{uf.m_dio_mem_align},
       m_dio_offset_align{uf.m_dio_offset_align},
       m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)},
@@ -85,7 +85,7 @@ File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
 int
 File::getClientFd() const
 {
-    return client_fd.get();
+    return m_client_fd.get();
 }
 
 int

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -34,9 +34,10 @@ UnregisteredFile::UnregisteredFile(int fd)
       flags{Context<Sys>::get()->fcntl(fd, F_GETFL, 0)},
       mountinfo{Context<LibMountHelper>::get()->getMountInfo(makedev(stx.stx_dev_major, stx.stx_dev_minor))},
 #if defined(STATX_DIOALIGN)
-      m_dio_mem_align{stx.stx_mask & STATX_DIOALIGN ? stx.stx_dio_mem_align : 4096}
+      m_dio_mem_align{stx.stx_mask & STATX_DIOALIGN ? stx.stx_dio_mem_align : 4096},
+      m_dio_offset_align{stx.stx_mask & STATX_DIOALIGN ? stx.stx_dio_offset_align : 4096}
 #else
-      m_dio_mem_align{4096}
+      m_dio_mem_align{4096}, m_dio_offset_align{4096}
 #endif
 {
     std::string path = "/proc/self/fd/" + std::to_string(fd);
@@ -56,8 +57,9 @@ UnregisteredFile::UnregisteredFile(int fd)
             if (e.code().value() != EINVAL) {
                 throw;
             }
-            unbuffered_fd   = nullopt;
-            m_dio_mem_align = 0;
+            unbuffered_fd      = nullopt;
+            m_dio_mem_align    = 0;
+            m_dio_offset_align = 0;
         }
     }
 }
@@ -71,7 +73,7 @@ IFile::getHandle() const
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
     : client_fd{std::move(uf.client_fd)}, buffered_fd{std::move(uf.buffered_fd)},
       unbuffered_fd{std::move(uf.unbuffered_fd)}, stx{uf.stx}, status_flags{uf.flags},
-      mountinfo{uf.mountinfo}, m_dio_mem_align{uf.m_dio_mem_align}
+      mountinfo{uf.mountinfo}, m_dio_mem_align{uf.m_dio_mem_align}, m_dio_offset_align{uf.m_dio_offset_align}
 {
 }
 
@@ -118,6 +120,12 @@ uint32_t
 File::dioMemAlign() const noexcept
 {
     return m_dio_mem_align;
+}
+
+uint32_t
+File::dioOffsetAlign() const noexcept
+{
+    return m_dio_offset_align;
 }
 
 shared_ptr<IFile>

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -83,7 +83,7 @@ File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
 }
 
 int
-File::getClientFd() const
+File::getClientFd() const noexcept
 {
     return m_client_fd.get();
 }

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -83,7 +83,7 @@ File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
 }
 
 int
-File::getClientFd() const noexcept
+File::clientFd() const noexcept
 {
     return m_client_fd.get();
 }
@@ -157,9 +157,9 @@ FileMap::registerFile(UnregisteredFile &&uf)
         throw FileAlreadyRegistered();
     }
 
-    auto file                    = std::shared_ptr<IFile>(new File(std::move(uf), PassKey<FileMap>{}));
-    from_fd[file->getClientFd()] = file;
-    from_fh[file->getHandle()]   = file;
+    auto file                  = std::shared_ptr<IFile>(new File(std::move(uf), PassKey<FileMap>{}));
+    from_fd[file->clientFd()]  = file;
+    from_fh[file->getHandle()] = file;
 
     return file->getHandle();
 }
@@ -177,7 +177,7 @@ FileMap::deregisterFile(hipFileHandle_t fh)
         throw FileOperationsOutstanding();
     }
 
-    from_fd.erase(itr->second->getClientFd());
+    from_fd.erase(itr->second->clientFd());
     from_fh.erase(fh);
 }
 

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -73,7 +73,8 @@ IFile::getHandle() const
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
     : client_fd{std::move(uf.client_fd)}, buffered_fd{std::move(uf.buffered_fd)},
       unbuffered_fd{std::move(uf.unbuffered_fd)}, stx{uf.stx}, status_flags{uf.flags},
-      mountinfo{uf.mountinfo}, m_dio_mem_align{uf.m_dio_mem_align}, m_dio_offset_align{uf.m_dio_offset_align}
+      mountinfo{uf.mountinfo}, m_dio_mem_align{uf.m_dio_mem_align}, m_dio_offset_align{uf.m_dio_offset_align},
+      m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)}
 {
 }
 
@@ -126,6 +127,12 @@ uint32_t
 File::dioOffsetAlign() const noexcept
 {
     return m_dio_offset_align;
+}
+
+bool
+File::isBlockDevice() const noexcept
+{
+    return m_is_block_device;
 }
 
 shared_ptr<IFile>

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -72,8 +72,8 @@ IFile::getHandle() const
 
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
     : client_fd{std::move(uf.client_fd)}, buffered_fd{std::move(uf.buffered_fd)},
-      unbuffered_fd{std::move(uf.unbuffered_fd)}, stx{uf.stx}, status_flags{uf.flags},
-      mountinfo{uf.mountinfo}, m_dio_mem_align{uf.m_dio_mem_align}, m_dio_offset_align{uf.m_dio_offset_align},
+      unbuffered_fd{std::move(uf.unbuffered_fd)}, status_flags{uf.flags}, mountinfo{uf.mountinfo},
+      m_dio_mem_align{uf.m_dio_mem_align}, m_dio_offset_align{uf.m_dio_offset_align},
       m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)},
       m_is_regular_file{(uf.stx.stx_mask & STATX_TYPE) && S_ISREG(uf.stx.stx_mode)}
 {
@@ -98,12 +98,6 @@ File::getUnbufferedFd() const
         return unbuffered_fd.value().get();
     }
     return nullopt;
-}
-
-const struct statx &
-File::getStatx() const noexcept
-{
-    return stx;
 }
 
 int

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -89,7 +89,7 @@ File::getClientFd() const
 }
 
 int
-File::getBufferedFd() const noexcept
+File::bufferedFd() const noexcept
 {
     return m_buffered_fd.get();
 }

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -95,7 +95,7 @@ File::getBufferedFd() const
 }
 
 optional<int>
-File::getUnbufferedFd() const noexcept
+File::unbufferedFd() const noexcept
 {
     if (m_unbuffered_fd) {
         return m_unbuffered_fd.value().get();

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -75,7 +75,9 @@ File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
       unbuffered_fd{std::move(uf.unbuffered_fd)}, status_flags{uf.flags}, mountinfo{uf.mountinfo},
       m_dio_mem_align{uf.m_dio_mem_align}, m_dio_offset_align{uf.m_dio_offset_align},
       m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)},
-      m_is_regular_file{(uf.stx.stx_mask & STATX_TYPE) && S_ISREG(uf.stx.stx_mode)}
+      m_is_regular_file{(uf.stx.stx_mask & STATX_TYPE) && S_ISREG(uf.stx.stx_mode)},
+      m_on_ext4_ordered{uf.mountinfo && uf.mountinfo->type == FilesystemType::ext4 &&
+                        uf.mountinfo->options.ext4.journaling_mode == ExtJournalingMode::ordered}
 {
 }
 
@@ -134,6 +136,12 @@ bool
 File::isRegularFile() const noexcept
 {
     return m_is_regular_file;
+}
+
+bool
+File::onExt4Ordered() const noexcept
+{
+    return m_on_ext4_ordered;
 }
 
 shared_ptr<IFile>

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -74,7 +74,8 @@ File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
     : client_fd{std::move(uf.client_fd)}, buffered_fd{std::move(uf.buffered_fd)},
       unbuffered_fd{std::move(uf.unbuffered_fd)}, stx{uf.stx}, status_flags{uf.flags},
       mountinfo{uf.mountinfo}, m_dio_mem_align{uf.m_dio_mem_align}, m_dio_offset_align{uf.m_dio_offset_align},
-      m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)}
+      m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)},
+      m_is_regular_file{(uf.stx.stx_mask & STATX_TYPE) && S_ISREG(uf.stx.stx_mode)}
 {
 }
 
@@ -133,6 +134,12 @@ bool
 File::isBlockDevice() const noexcept
 {
     return m_is_block_device;
+}
+
+bool
+File::isRegularFile() const noexcept
+{
+    return m_is_regular_file;
 }
 
 shared_ptr<IFile>

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -65,7 +65,7 @@ UnregisteredFile::UnregisteredFile(int fd)
 }
 
 hipFileHandle_t
-IFile::getHandle() const
+IFile::getHandle() const noexcept
 {
     return reinterpret_cast<hipFileHandle_t>(const_cast<IFile *>(this));
 }

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -72,7 +72,7 @@ IFile::getHandle() const
 
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
     : client_fd{std::move(uf.client_fd)}, buffered_fd{std::move(uf.buffered_fd)},
-      unbuffered_fd{std::move(uf.unbuffered_fd)}, status_flags{uf.flags}, m_dio_mem_align{uf.m_dio_mem_align},
+      unbuffered_fd{std::move(uf.unbuffered_fd)}, m_dio_mem_align{uf.m_dio_mem_align},
       m_dio_offset_align{uf.m_dio_offset_align},
       m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)},
       m_is_regular_file{(uf.stx.stx_mask & STATX_TYPE) && S_ISREG(uf.stx.stx_mode)},
@@ -101,12 +101,6 @@ File::getUnbufferedFd() const
         return unbuffered_fd.value().get();
     }
     return nullopt;
-}
-
-int
-File::getStatusFlags() const
-{
-    return status_flags;
 }
 
 uint32_t

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -95,7 +95,7 @@ File::getBufferedFd() const
 }
 
 optional<int>
-File::getUnbufferedFd() const
+File::getUnbufferedFd() const noexcept
 {
     if (m_unbuffered_fd) {
         return m_unbuffered_fd.value().get();

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -72,8 +72,8 @@ IFile::getHandle() const
 
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
     : client_fd{std::move(uf.client_fd)}, buffered_fd{std::move(uf.buffered_fd)},
-      unbuffered_fd{std::move(uf.unbuffered_fd)}, status_flags{uf.flags}, mountinfo{uf.mountinfo},
-      m_dio_mem_align{uf.m_dio_mem_align}, m_dio_offset_align{uf.m_dio_offset_align},
+      unbuffered_fd{std::move(uf.unbuffered_fd)}, status_flags{uf.flags}, m_dio_mem_align{uf.m_dio_mem_align},
+      m_dio_offset_align{uf.m_dio_offset_align},
       m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)},
       m_is_regular_file{(uf.stx.stx_mask & STATX_TYPE) && S_ISREG(uf.stx.stx_mode)},
       m_on_ext4_ordered{uf.mountinfo && uf.mountinfo->type == FilesystemType::ext4 &&
@@ -107,12 +107,6 @@ int
 File::getStatusFlags() const
 {
     return status_flags;
-}
-
-optional<MountInfo>
-File::getMountInfo() const
-{
-    return mountinfo;
 }
 
 uint32_t

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -77,7 +77,8 @@ File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
       m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)},
       m_is_regular_file{(uf.stx.stx_mask & STATX_TYPE) && S_ISREG(uf.stx.stx_mode)},
       m_on_ext4_ordered{uf.mountinfo && uf.mountinfo->type == FilesystemType::ext4 &&
-                        uf.mountinfo->options.ext4.journaling_mode == ExtJournalingMode::ordered}
+                        uf.mountinfo->options.ext4.journaling_mode == ExtJournalingMode::ordered},
+      m_on_xfs{uf.mountinfo && uf.mountinfo->type == FilesystemType::xfs}
 {
 }
 
@@ -142,6 +143,12 @@ bool
 File::onExt4Ordered() const noexcept
 {
     return m_on_ext4_ordered;
+}
+
+bool
+File::onXfs() const noexcept
+{
+    return m_on_xfs;
 }
 
 shared_ptr<IFile>

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -71,7 +71,7 @@ IFile::getHandle() const
 }
 
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
-    : client_fd{std::move(uf.client_fd)}, buffered_fd{std::move(uf.buffered_fd)},
+    : client_fd{std::move(uf.client_fd)}, m_buffered_fd{std::move(uf.buffered_fd)},
       m_unbuffered_fd{std::move(uf.unbuffered_fd)}, m_dio_mem_align{uf.m_dio_mem_align},
       m_dio_offset_align{uf.m_dio_offset_align},
       m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)},
@@ -91,7 +91,7 @@ File::getClientFd() const
 int
 File::getBufferedFd() const
 {
-    return buffered_fd.get();
+    return m_buffered_fd.get();
 }
 
 optional<int>

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -16,6 +16,7 @@
 #include <sys/sysmacros.h>
 #include <syslog.h>
 #include <system_error>
+#include <unistd.h>
 
 using namespace std;
 
@@ -31,7 +32,12 @@ UnregisteredFile::UnregisteredFile(int fd)
 #endif
                                      )},
       flags{Context<Sys>::get()->fcntl(fd, F_GETFL, 0)},
-      mountinfo{Context<LibMountHelper>::get()->getMountInfo(makedev(stx.stx_dev_major, stx.stx_dev_minor))}
+      mountinfo{Context<LibMountHelper>::get()->getMountInfo(makedev(stx.stx_dev_major, stx.stx_dev_minor))},
+#if defined(STATX_DIOALIGN)
+      m_dio_mem_align{stx.stx_mask & STATX_DIOALIGN ? stx.stx_dio_mem_align : 4096}
+#else
+      m_dio_mem_align{4096}
+#endif
 {
     std::string path = "/proc/self/fd/" + std::to_string(fd);
 
@@ -50,7 +56,8 @@ UnregisteredFile::UnregisteredFile(int fd)
             if (e.code().value() != EINVAL) {
                 throw;
             }
-            unbuffered_fd = nullopt;
+            unbuffered_fd   = nullopt;
+            m_dio_mem_align = 0;
         }
     }
 }
@@ -63,7 +70,8 @@ IFile::getHandle() const
 
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
     : client_fd{std::move(uf.client_fd)}, buffered_fd{std::move(uf.buffered_fd)},
-      unbuffered_fd{std::move(uf.unbuffered_fd)}, stx{uf.stx}, status_flags{uf.flags}, mountinfo{uf.mountinfo}
+      unbuffered_fd{std::move(uf.unbuffered_fd)}, stx{uf.stx}, status_flags{uf.flags},
+      mountinfo{uf.mountinfo}, m_dio_mem_align{uf.m_dio_mem_align}
 {
 }
 
@@ -104,6 +112,12 @@ optional<MountInfo>
 File::getMountInfo() const
 {
     return mountinfo;
+}
+
+uint32_t
+File::dioMemAlign() const noexcept
+{
+    return m_dio_mem_align;
 }
 
 shared_ptr<IFile>

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -89,7 +89,7 @@ File::getClientFd() const
 }
 
 int
-File::getBufferedFd() const
+File::getBufferedFd() const noexcept
 {
     return m_buffered_fd.get();
 }

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -65,7 +65,7 @@ UnregisteredFile::UnregisteredFile(int fd)
 }
 
 hipFileHandle_t
-IFile::getHandle() const noexcept
+IFile::handle() const noexcept
 {
     return reinterpret_cast<hipFileHandle_t>(const_cast<IFile *>(this));
 }
@@ -157,11 +157,11 @@ FileMap::registerFile(UnregisteredFile &&uf)
         throw FileAlreadyRegistered();
     }
 
-    auto file                  = std::shared_ptr<IFile>(new File(std::move(uf), PassKey<FileMap>{}));
-    from_fd[file->clientFd()]  = file;
-    from_fh[file->getHandle()] = file;
+    auto file                 = std::shared_ptr<IFile>(new File(std::move(uf), PassKey<FileMap>{}));
+    from_fd[file->clientFd()] = file;
+    from_fh[file->handle()]   = file;
 
-    return file->getHandle();
+    return file->handle();
 }
 
 void

--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -72,7 +72,7 @@ IFile::getHandle() const
 
 File::File(UnregisteredFile &&uf, const PassKey<FileMap> &)
     : client_fd{std::move(uf.client_fd)}, buffered_fd{std::move(uf.buffered_fd)},
-      unbuffered_fd{std::move(uf.unbuffered_fd)}, m_dio_mem_align{uf.m_dio_mem_align},
+      m_unbuffered_fd{std::move(uf.unbuffered_fd)}, m_dio_mem_align{uf.m_dio_mem_align},
       m_dio_offset_align{uf.m_dio_offset_align},
       m_is_block_device{(uf.stx.stx_mask & STATX_TYPE) && S_ISBLK(uf.stx.stx_mode)},
       m_is_regular_file{(uf.stx.stx_mask & STATX_TYPE) && S_ISREG(uf.stx.stx_mode)},
@@ -97,8 +97,8 @@ File::getBufferedFd() const
 optional<int>
 File::getUnbufferedFd() const
 {
-    if (unbuffered_fd) {
-        return unbuffered_fd.value().get();
+    if (m_unbuffered_fd) {
+        return m_unbuffered_fd.value().get();
     }
     return nullopt;
 }

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -86,7 +86,7 @@ public:
     /// @return The handle for this file
     virtual hipFileHandle_t getHandle() const;
 
-    virtual int                getClientFd() const noexcept    = 0;
+    virtual int                clientFd() const noexcept       = 0;
     virtual int                bufferedFd() const noexcept     = 0;
     virtual std::optional<int> unbufferedFd() const noexcept   = 0;
     virtual uint32_t           dioMemAlign() const noexcept    = 0;
@@ -112,7 +112,7 @@ public:
     File(File &&)            = delete;
     File &operator=(File &&) = delete;
 
-    virtual int getClientFd() const noexcept override;
+    virtual int clientFd() const noexcept override;
 
     /// @brief Get the buffered file descriptor (!O_DIRECT)
     /// @return The buffered file descriptor

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -95,6 +95,7 @@ public:
     virtual uint32_t                 dioMemAlign() const noexcept    = 0;
     virtual uint32_t                 dioOffsetAlign() const noexcept = 0;
     virtual bool                     isBlockDevice() const noexcept  = 0;
+    virtual bool                     isRegularFile() const noexcept  = 0;
 };
 
 class FileMap;
@@ -135,6 +136,11 @@ public:
     /// @return True if the file is a block device, false otherwise
     virtual bool isBlockDevice() const noexcept override;
 
+    /// @brief Whether this file is a regular file. If statx did not return type information, this will return
+    /// false.
+    /// @return True if the file is a regular file, false otherwise
+    virtual bool isRegularFile() const noexcept override;
+
     /// @brief Construct a registered file
     /// @param uf An unregistered file
     /// @param k  Key class instance (see passkey.h)
@@ -171,6 +177,9 @@ private:
 
     /// @brief Whether statx reported that the file is a block device
     bool m_is_block_device;
+
+    /// @brief Whether statx reported that the file is a regular file
+    bool m_is_regular_file;
 };
 
 class FileMap {

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -86,15 +86,15 @@ public:
     /// @return The handle for this file
     virtual hipFileHandle_t getHandle() const;
 
-    virtual int                getClientFd() const             = 0;
-    virtual int                getBufferedFd() const           = 0;
-    virtual std::optional<int> getUnbufferedFd() const         = 0;
-    virtual uint32_t           dioMemAlign() const noexcept    = 0;
-    virtual uint32_t           dioOffsetAlign() const noexcept = 0;
-    virtual bool               isBlockDevice() const noexcept  = 0;
-    virtual bool               isRegularFile() const noexcept  = 0;
-    virtual bool               onExt4Ordered() const noexcept  = 0;
-    virtual bool               onXfs() const noexcept          = 0;
+    virtual int                getClientFd() const              = 0;
+    virtual int                getBufferedFd() const            = 0;
+    virtual std::optional<int> getUnbufferedFd() const noexcept = 0;
+    virtual uint32_t           dioMemAlign() const noexcept     = 0;
+    virtual uint32_t           dioOffsetAlign() const noexcept  = 0;
+    virtual bool               isBlockDevice() const noexcept   = 0;
+    virtual bool               isRegularFile() const noexcept   = 0;
+    virtual bool               onExt4Ordered() const noexcept   = 0;
+    virtual bool               onXfs() const noexcept           = 0;
 };
 
 class FileMap;
@@ -114,7 +114,7 @@ public:
 
     virtual int                getClientFd() const override;
     virtual int                getBufferedFd() const override;
-    virtual std::optional<int> getUnbufferedFd() const override;
+    virtual std::optional<int> getUnbufferedFd() const noexcept override;
 
     /// @brief Get the memory (in bytes) alignment requirement for direct IO on this file. If the file does
     /// not support direct IO, this will return 0.

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -95,6 +95,7 @@ public:
     virtual uint32_t                 dioOffsetAlign() const noexcept = 0;
     virtual bool                     isBlockDevice() const noexcept  = 0;
     virtual bool                     isRegularFile() const noexcept  = 0;
+    virtual bool                     onExt4Ordered() const noexcept  = 0;
 };
 
 class FileMap;
@@ -139,6 +140,11 @@ public:
     /// @return True if the file is a regular file, false otherwise
     virtual bool isRegularFile() const noexcept override;
 
+    /// @brief Whether this file is on an ext4 filesystem with ordered journaling mode. If mountinfo is not
+    /// available, this will return false.
+    /// @return True if the file is on an ext4 filesystem with ordered journaling mode, false otherwise
+    virtual bool onExt4Ordered() const noexcept override;
+
     /// @brief Construct a registered file
     /// @param uf An unregistered file
     /// @param k  Key class instance (see passkey.h)
@@ -175,6 +181,9 @@ private:
 
     /// @brief Whether statx reported that the file is a regular file
     bool m_is_regular_file;
+
+    /// @brief Whether the file is on an ext4 filesystem with ordered journaling mode
+    bool m_on_ext4_ordered;
 };
 
 class FileMap {

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -84,7 +84,7 @@ public:
 
     /// @brief Get the handle for this file
     /// @return The handle for this file
-    virtual hipFileHandle_t getHandle() const;
+    virtual hipFileHandle_t getHandle() const noexcept;
 
     virtual int                clientFd() const noexcept       = 0;
     virtual int                bufferedFd() const noexcept     = 0;

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -86,7 +86,7 @@ public:
     /// @return The handle for this file
     virtual hipFileHandle_t getHandle() const;
 
-    virtual int                getClientFd() const             = 0;
+    virtual int                getClientFd() const noexcept    = 0;
     virtual int                bufferedFd() const noexcept     = 0;
     virtual std::optional<int> unbufferedFd() const noexcept   = 0;
     virtual uint32_t           dioMemAlign() const noexcept    = 0;
@@ -112,7 +112,7 @@ public:
     File(File &&)            = delete;
     File &operator=(File &&) = delete;
 
-    virtual int getClientFd() const override;
+    virtual int getClientFd() const noexcept override;
 
     /// @brief Get the buffered file descriptor (!O_DIRECT)
     /// @return The buffered file descriptor

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -96,6 +96,7 @@ public:
     virtual bool                     isBlockDevice() const noexcept  = 0;
     virtual bool                     isRegularFile() const noexcept  = 0;
     virtual bool                     onExt4Ordered() const noexcept  = 0;
+    virtual bool                     onXfs() const noexcept          = 0;
 };
 
 class FileMap;
@@ -145,6 +146,11 @@ public:
     /// @return True if the file is on an ext4 filesystem with ordered journaling mode, false otherwise
     virtual bool onExt4Ordered() const noexcept override;
 
+    /// @brief Whether this file is on an xfs filesystem. If mountinfo is not available, this will return
+    /// false.
+    /// @return True if the file is on an xfs filesystem, false otherwise
+    virtual bool onXfs() const noexcept override;
+
     /// @brief Construct a registered file
     /// @param uf An unregistered file
     /// @param k  Key class instance (see passkey.h)
@@ -184,6 +190,9 @@ private:
 
     /// @brief Whether the file is on an ext4 filesystem with ordered journaling mode
     bool m_on_ext4_ordered;
+
+    /// @brief Whether the file is on an xfs filesystem
+    bool m_on_xfs;
 };
 
 class FileMap {

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -94,6 +94,7 @@ public:
     virtual std::optional<MountInfo> getMountInfo() const            = 0;
     virtual uint32_t                 dioMemAlign() const noexcept    = 0;
     virtual uint32_t                 dioOffsetAlign() const noexcept = 0;
+    virtual bool                     isBlockDevice() const noexcept  = 0;
 };
 
 class FileMap;
@@ -129,6 +130,11 @@ public:
     /// if direct I/O is not supported
     virtual uint32_t dioOffsetAlign() const noexcept override;
 
+    /// @brief Whether this file is a block device. If statx did not return type information, this will return
+    /// false.
+    /// @return True if the file is a block device, false otherwise
+    virtual bool isBlockDevice() const noexcept override;
+
     /// @brief Construct a registered file
     /// @param uf An unregistered file
     /// @param k  Key class instance (see passkey.h)
@@ -162,6 +168,9 @@ private:
     /// @brief Alignment (in bytes) required for file offsets and I/O segment lengths for direct I/O
     /// (O_DIRECT).
     uint32_t m_dio_offset_align;
+
+    /// @brief Whether statx reported that the file is a block device
+    bool m_is_block_device;
 };
 
 class FileMap {

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -89,7 +89,6 @@ public:
     virtual int                      getClientFd() const             = 0;
     virtual int                      getBufferedFd() const           = 0;
     virtual std::optional<int>       getUnbufferedFd() const         = 0;
-    virtual const struct statx      &getStatx() const noexcept       = 0;
     virtual int                      getStatusFlags() const          = 0;
     virtual std::optional<MountInfo> getMountInfo() const            = 0;
     virtual uint32_t                 dioMemAlign() const noexcept    = 0;
@@ -116,7 +115,6 @@ public:
     virtual int                      getClientFd() const override;
     virtual int                      getBufferedFd() const override;
     virtual std::optional<int>       getUnbufferedFd() const override;
-    virtual const struct statx      &getStatx() const noexcept override;
     virtual int                      getStatusFlags() const override;
     virtual std::optional<MountInfo> getMountInfo() const override;
 
@@ -155,9 +153,6 @@ private:
 
     /// @brief Unbuffered file descriptor (O_DIRECT)
     std::optional<FileDescriptor> unbuffered_fd;
-
-    /// @brief File status information obtained from statx (2)
-    struct statx stx;
 
     /// @brief The file's status flags. See fcntl(2)
     ///

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -84,7 +84,7 @@ public:
 
     /// @brief Get the handle for this file
     /// @return The handle for this file
-    virtual hipFileHandle_t getHandle() const noexcept;
+    virtual hipFileHandle_t handle() const noexcept;
 
     virtual int                clientFd() const noexcept       = 0;
     virtual int                bufferedFd() const noexcept     = 0;

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -161,7 +161,7 @@ private:
     FileDescriptor client_fd;
 
     /// @brief Buffered file descriptor (!O_DIRECT)
-    FileDescriptor buffered_fd;
+    FileDescriptor m_buffered_fd;
 
     /// @brief Unbuffered file descriptor (O_DIRECT)
     std::optional<FileDescriptor> m_unbuffered_fd;

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -160,7 +160,7 @@ private:
     FileDescriptor buffered_fd;
 
     /// @brief Unbuffered file descriptor (O_DIRECT)
-    std::optional<FileDescriptor> unbuffered_fd;
+    std::optional<FileDescriptor> m_unbuffered_fd;
 
     /// @brief Memory alignment (in bytes) requirement for direct IO. If the file does not support direct IO,
     /// this will be 0.

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -89,7 +89,6 @@ public:
     virtual int                getClientFd() const             = 0;
     virtual int                getBufferedFd() const           = 0;
     virtual std::optional<int> getUnbufferedFd() const         = 0;
-    virtual int                getStatusFlags() const          = 0;
     virtual uint32_t           dioMemAlign() const noexcept    = 0;
     virtual uint32_t           dioOffsetAlign() const noexcept = 0;
     virtual bool               isBlockDevice() const noexcept  = 0;
@@ -116,7 +115,6 @@ public:
     virtual int                getClientFd() const override;
     virtual int                getBufferedFd() const override;
     virtual std::optional<int> getUnbufferedFd() const override;
-    virtual int                getStatusFlags() const override;
 
     /// @brief Get the memory (in bytes) alignment requirement for direct IO on this file. If the file does
     /// not support direct IO, this will return 0.
@@ -163,11 +161,6 @@ private:
 
     /// @brief Unbuffered file descriptor (O_DIRECT)
     std::optional<FileDescriptor> unbuffered_fd;
-
-    /// @brief The file's status flags. See fcntl(2)
-    ///
-    /// Used to determine if the O_DIRECT flag is set
-    int status_flags;
 
     /// @brief Memory alignment (in bytes) requirement for direct IO. If the file does not support direct IO,
     /// this will be 0.

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -86,15 +86,15 @@ public:
     /// @return The handle for this file
     virtual hipFileHandle_t getHandle() const;
 
-    virtual int                getClientFd() const              = 0;
-    virtual int                getBufferedFd() const            = 0;
-    virtual std::optional<int> getUnbufferedFd() const noexcept = 0;
-    virtual uint32_t           dioMemAlign() const noexcept     = 0;
-    virtual uint32_t           dioOffsetAlign() const noexcept  = 0;
-    virtual bool               isBlockDevice() const noexcept   = 0;
-    virtual bool               isRegularFile() const noexcept   = 0;
-    virtual bool               onExt4Ordered() const noexcept   = 0;
-    virtual bool               onXfs() const noexcept           = 0;
+    virtual int                getClientFd() const             = 0;
+    virtual int                getBufferedFd() const           = 0;
+    virtual std::optional<int> unbufferedFd() const noexcept   = 0;
+    virtual uint32_t           dioMemAlign() const noexcept    = 0;
+    virtual uint32_t           dioOffsetAlign() const noexcept = 0;
+    virtual bool               isBlockDevice() const noexcept  = 0;
+    virtual bool               isRegularFile() const noexcept  = 0;
+    virtual bool               onExt4Ordered() const noexcept  = 0;
+    virtual bool               onXfs() const noexcept          = 0;
 };
 
 class FileMap;
@@ -112,9 +112,13 @@ public:
     File(File &&)            = delete;
     File &operator=(File &&) = delete;
 
-    virtual int                getClientFd() const override;
-    virtual int                getBufferedFd() const override;
-    virtual std::optional<int> getUnbufferedFd() const noexcept override;
+    virtual int getClientFd() const override;
+    virtual int getBufferedFd() const override;
+
+    /// @brief Get the unbuffered file descriptor for this file. Returns nullopt if the file does not support
+    /// direct IO or if there was an error obtaining the unbuffered fd.
+    /// @return The unbuffered file descriptor, or nullopt if not available
+    virtual std::optional<int> unbufferedFd() const noexcept override;
 
     /// @brief Get the memory (in bytes) alignment requirement for direct IO on this file. If the file does
     /// not support direct IO, this will return 0.

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -71,6 +71,11 @@ public:
     /// @brief Memory alignment (in bytes) requirement for direct IO. If the file does not support direct IO,
     /// this will be 0. If alignment information is not available from statx, this will be set to 4096.
     uint32_t m_dio_mem_align;
+
+    /// @brief Alignment (in bytes) required for file offsets and IO segment lengths for direct IO. If the
+    /// file does not support direct IO, this will be 0. If alignment information is not available from statx,
+    /// this will be set to 4096.
+    uint32_t m_dio_offset_align;
 };
 
 class IFile {
@@ -81,13 +86,14 @@ public:
     /// @return The handle for this file
     virtual hipFileHandle_t getHandle() const;
 
-    virtual int                      getClientFd() const          = 0;
-    virtual int                      getBufferedFd() const        = 0;
-    virtual std::optional<int>       getUnbufferedFd() const      = 0;
-    virtual const struct statx      &getStatx() const noexcept    = 0;
-    virtual int                      getStatusFlags() const       = 0;
-    virtual std::optional<MountInfo> getMountInfo() const         = 0;
-    virtual uint32_t                 dioMemAlign() const noexcept = 0;
+    virtual int                      getClientFd() const             = 0;
+    virtual int                      getBufferedFd() const           = 0;
+    virtual std::optional<int>       getUnbufferedFd() const         = 0;
+    virtual const struct statx      &getStatx() const noexcept       = 0;
+    virtual int                      getStatusFlags() const          = 0;
+    virtual std::optional<MountInfo> getMountInfo() const            = 0;
+    virtual uint32_t                 dioMemAlign() const noexcept    = 0;
+    virtual uint32_t                 dioOffsetAlign() const noexcept = 0;
 };
 
 class FileMap;
@@ -116,6 +122,12 @@ public:
     /// not support direct IO, this will return 0.
     /// @return The memory alignment (in bytes) requirement for direct IO, 0 if direct IO is not supported
     virtual uint32_t dioMemAlign() const noexcept override;
+
+    /// @brief The alignment (in bytes) required for file offsets and I/O segment lengths for direct I/O
+    /// (O_DIRECT) on this file, or 0 if direct I/O is not supported on this file
+    /// @return The alignment (in bytes) required for file offsets and I/O segment lengths for direct I/O, 0
+    /// if direct I/O is not supported
+    virtual uint32_t dioOffsetAlign() const noexcept override;
 
     /// @brief Construct a registered file
     /// @param uf An unregistered file
@@ -146,6 +158,10 @@ private:
     /// @brief Memory alignment (in bytes) requirement for direct IO. If the file does not support direct IO,
     /// this will be 0.
     uint32_t m_dio_mem_align;
+
+    /// @brief Alignment (in bytes) required for file offsets and I/O segment lengths for direct I/O
+    /// (O_DIRECT).
+    uint32_t m_dio_offset_align;
 };
 
 class FileMap {

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -87,7 +87,7 @@ public:
     virtual hipFileHandle_t getHandle() const;
 
     virtual int                getClientFd() const             = 0;
-    virtual int                getBufferedFd() const noexcept  = 0;
+    virtual int                bufferedFd() const noexcept     = 0;
     virtual std::optional<int> unbufferedFd() const noexcept   = 0;
     virtual uint32_t           dioMemAlign() const noexcept    = 0;
     virtual uint32_t           dioOffsetAlign() const noexcept = 0;
@@ -113,7 +113,10 @@ public:
     File &operator=(File &&) = delete;
 
     virtual int getClientFd() const override;
-    virtual int getBufferedFd() const noexcept override;
+
+    /// @brief Get the buffered file descriptor (!O_DIRECT)
+    /// @return The buffered file descriptor
+    virtual int bufferedFd() const noexcept override;
 
     /// @brief Get the unbuffered file descriptor for this file. Returns nullopt if the file does not support
     /// direct IO or if there was an error obtaining the unbuffered fd.

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -86,17 +86,16 @@ public:
     /// @return The handle for this file
     virtual hipFileHandle_t getHandle() const;
 
-    virtual int                      getClientFd() const             = 0;
-    virtual int                      getBufferedFd() const           = 0;
-    virtual std::optional<int>       getUnbufferedFd() const         = 0;
-    virtual int                      getStatusFlags() const          = 0;
-    virtual std::optional<MountInfo> getMountInfo() const            = 0;
-    virtual uint32_t                 dioMemAlign() const noexcept    = 0;
-    virtual uint32_t                 dioOffsetAlign() const noexcept = 0;
-    virtual bool                     isBlockDevice() const noexcept  = 0;
-    virtual bool                     isRegularFile() const noexcept  = 0;
-    virtual bool                     onExt4Ordered() const noexcept  = 0;
-    virtual bool                     onXfs() const noexcept          = 0;
+    virtual int                getClientFd() const             = 0;
+    virtual int                getBufferedFd() const           = 0;
+    virtual std::optional<int> getUnbufferedFd() const         = 0;
+    virtual int                getStatusFlags() const          = 0;
+    virtual uint32_t           dioMemAlign() const noexcept    = 0;
+    virtual uint32_t           dioOffsetAlign() const noexcept = 0;
+    virtual bool               isBlockDevice() const noexcept  = 0;
+    virtual bool               isRegularFile() const noexcept  = 0;
+    virtual bool               onExt4Ordered() const noexcept  = 0;
+    virtual bool               onXfs() const noexcept          = 0;
 };
 
 class FileMap;
@@ -114,11 +113,10 @@ public:
     File(File &&)            = delete;
     File &operator=(File &&) = delete;
 
-    virtual int                      getClientFd() const override;
-    virtual int                      getBufferedFd() const override;
-    virtual std::optional<int>       getUnbufferedFd() const override;
-    virtual int                      getStatusFlags() const override;
-    virtual std::optional<MountInfo> getMountInfo() const override;
+    virtual int                getClientFd() const override;
+    virtual int                getBufferedFd() const override;
+    virtual std::optional<int> getUnbufferedFd() const override;
+    virtual int                getStatusFlags() const override;
 
     /// @brief Get the memory (in bytes) alignment requirement for direct IO on this file. If the file does
     /// not support direct IO, this will return 0.
@@ -170,9 +168,6 @@ private:
     ///
     /// Used to determine if the O_DIRECT flag is set
     int status_flags;
-
-    /// @brief Mount information for the filesystem backing fd
-    std::optional<MountInfo> mountinfo;
 
     /// @brief Memory alignment (in bytes) requirement for direct IO. If the file does not support direct IO,
     /// this will be 0.

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -87,7 +87,7 @@ public:
     virtual hipFileHandle_t getHandle() const;
 
     virtual int                getClientFd() const             = 0;
-    virtual int                getBufferedFd() const           = 0;
+    virtual int                getBufferedFd() const noexcept  = 0;
     virtual std::optional<int> unbufferedFd() const noexcept   = 0;
     virtual uint32_t           dioMemAlign() const noexcept    = 0;
     virtual uint32_t           dioOffsetAlign() const noexcept = 0;
@@ -113,7 +113,7 @@ public:
     File &operator=(File &&) = delete;
 
     virtual int getClientFd() const override;
-    virtual int getBufferedFd() const override;
+    virtual int getBufferedFd() const noexcept override;
 
     /// @brief Get the unbuffered file descriptor for this file. Returns nullopt if the file does not support
     /// direct IO or if there was an error obtaining the unbuffered fd.

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -161,7 +161,7 @@ public:
 
 private:
     /// @brief The file descriptor provided by the client
-    FileDescriptor client_fd;
+    FileDescriptor m_client_fd;
 
     /// @brief Buffered file descriptor (!O_DIRECT)
     FileDescriptor m_buffered_fd;

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -67,6 +67,10 @@ public:
 
     /// @brief Information obtained from /proc/self/mountinfo
     std::optional<MountInfo> mountinfo;
+
+    /// @brief Memory alignment (in bytes) requirement for direct IO. If the file does not support direct IO,
+    /// this will be 0. If alignment information is not available from statx, this will be set to 4096.
+    uint32_t m_dio_mem_align;
 };
 
 class IFile {
@@ -77,12 +81,13 @@ public:
     /// @return The handle for this file
     virtual hipFileHandle_t getHandle() const;
 
-    virtual int                      getClientFd() const       = 0;
-    virtual int                      getBufferedFd() const     = 0;
-    virtual std::optional<int>       getUnbufferedFd() const   = 0;
-    virtual const struct statx      &getStatx() const noexcept = 0;
-    virtual int                      getStatusFlags() const    = 0;
-    virtual std::optional<MountInfo> getMountInfo() const      = 0;
+    virtual int                      getClientFd() const          = 0;
+    virtual int                      getBufferedFd() const        = 0;
+    virtual std::optional<int>       getUnbufferedFd() const      = 0;
+    virtual const struct statx      &getStatx() const noexcept    = 0;
+    virtual int                      getStatusFlags() const       = 0;
+    virtual std::optional<MountInfo> getMountInfo() const         = 0;
+    virtual uint32_t                 dioMemAlign() const noexcept = 0;
 };
 
 class FileMap;
@@ -106,6 +111,11 @@ public:
     virtual const struct statx      &getStatx() const noexcept override;
     virtual int                      getStatusFlags() const override;
     virtual std::optional<MountInfo> getMountInfo() const override;
+
+    /// @brief Get the memory (in bytes) alignment requirement for direct IO on this file. If the file does
+    /// not support direct IO, this will return 0.
+    /// @return The memory alignment (in bytes) requirement for direct IO, 0 if direct IO is not supported
+    virtual uint32_t dioMemAlign() const noexcept override;
 
     /// @brief Construct a registered file
     /// @param uf An unregistered file
@@ -132,6 +142,10 @@ private:
 
     /// @brief Mount information for the filesystem backing fd
     std::optional<MountInfo> mountinfo;
+
+    /// @brief Memory alignment (in bytes) requirement for direct IO. If the file does not support direct IO,
+    /// this will be 0.
+    uint32_t m_dio_mem_align;
 };
 
 class FileMap {

--- a/test/amd_detail/async.cpp
+++ b/test/amd_detail/async.cpp
@@ -665,7 +665,7 @@ TEST_P(AsyncIoOpWithParams, cpuIOReturnsFullSize)
     else {
         EXPECT_CALL(msys, pwrite).WillOnce(Return(size));
     }
-    EXPECT_CALL(*mfile, getBufferedFd);
+    EXPECT_CALL(*mfile, bufferedFd);
     async_io_cpu_copy(op.get());
     ASSERT_EQ(op->bytes_transferred_internal, size);
 }
@@ -678,7 +678,7 @@ TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteErrorReturnsError)
     else {
         EXPECT_CALL(msys, pwrite).WillOnce(Throw(std::system_error(3, std::generic_category())));
     }
-    EXPECT_CALL(*mfile, getBufferedFd);
+    EXPECT_CALL(*mfile, bufferedFd);
     async_io_cpu_copy(op.get());
     ASSERT_EQ(op->bytes_transferred_internal, -1);
 }
@@ -695,7 +695,7 @@ TEST_P(AsyncIoOpWithParams, cpuCopyReadPreadPwriteRetriesOnEINTR)
             .WillOnce(Throw(std::system_error(EINTR, std::generic_category())))
             .WillOnce(Return(size));
     }
-    EXPECT_CALL(*mfile, getBufferedFd).Times(2);
+    EXPECT_CALL(*mfile, bufferedFd).Times(2);
     async_io_cpu_copy(op.get());
 
     ASSERT_EQ(op->bytes_transferred_internal, size);

--- a/test/amd_detail/batch/batch.cpp
+++ b/test/amd_detail/batch/batch.cpp
@@ -47,7 +47,7 @@ struct HipFileBatch : public HipFileUnopened {
         EXPECT_CALL(*default_mock_buffer, getLength).WillRepeatedly(Return(1));
 
         default_mock_file = std::make_shared<StrictMock<MFile>>();
-        EXPECT_CALL(*default_mock_file, getHandle).WillRepeatedly(Return(file_handle));
+        EXPECT_CALL(*default_mock_file, handle).WillRepeatedly(Return(file_handle));
 
         io_params                      = std::make_unique<hipFileIOParams_t>();
         io_params->u.batch.devPtr_base = const_cast<void *>(buffer_pointer);
@@ -86,8 +86,7 @@ TEST_F(HipFileBatch, CreateOperationBadBuffer)
 
 TEST_F(HipFileBatch, CreateOperationBadFileHandle)
 {
-    EXPECT_CALL(*default_mock_file, getHandle)
-        .WillOnce(Return(reinterpret_cast<hipFileHandle_t>(0xFACEFEED)));
+    EXPECT_CALL(*default_mock_file, handle).WillOnce(Return(reinterpret_cast<hipFileHandle_t>(0xFACEFEED)));
     EXPECT_THROW(BatchOperation(std::move(io_params), default_mock_buffer, default_mock_file),
                  std::invalid_argument);
 }
@@ -242,13 +241,13 @@ struct HipFileBatchContext : public HipFileUnopened {
         EXPECT_CALL(*default_mock_buffer, getLength).WillRepeatedly(Return(default_mock_buffer_length));
 
         default_mock_file = std::make_shared<StrictMock<MFile>>();
-        EXPECT_CALL(*default_mock_file, getHandle).WillRepeatedly(Return(default_mock_file.get()));
+        EXPECT_CALL(*default_mock_file, handle).WillRepeatedly(Return(default_mock_file.get()));
 
         file_buffer_pair default_fb_pair = {default_mock_file, default_mock_buffer};
 
         io_params.u.batch.devPtr_base = default_mock_buffer->getBuffer();
         io_params.u.batch.size        = 1;
-        io_params.fh                  = default_mock_file->getHandle();
+        io_params.fh                  = default_mock_file->handle();
         io_params.mode                = hipFileBatch;
         io_params.opcode              = hipFileBatchRead;
 

--- a/test/amd_detail/configuration.cpp
+++ b/test/amd_detail/configuration.cpp
@@ -48,6 +48,12 @@ struct HipFileConfiguration : public Test {
         EXPECT_CALL(msys, getenv(StrEq(hipFile::Environment::STATS_LEVEL)))
             .WillOnce(Return(const_cast<char *>(hipfile_stats_level)));
     }
+
+    void expect_configuration_unsupported_file_systems(const char *hipfile_unsupported_file_systems)
+    {
+        EXPECT_CALL(msys, getenv(StrEq(hipFile::Environment::UNSUPPORTED_FILE_SYSTEMS)))
+            .WillOnce(Return(const_cast<char *>(hipfile_unsupported_file_systems)));
+    }
 };
 
 TEST_F(HipFileConfiguration, FastpathEnabledIfForceCompatModeEnvironmentVariableIsNotSet)
@@ -192,6 +198,30 @@ TEST_F(HipFileConfiguration, StatsLevelEnvironmentVariableIsSet)
 {
     expect_configuration_statslevel("1");
     ASSERT_EQ(1, Configuration().statsLevel());
+}
+
+TEST_F(HipFileConfiguration, UnsupportedFilesystemsDisabledIfEnvironmentVariableIsNotSet)
+{
+    expect_configuration_unsupported_file_systems(nullptr);
+    ASSERT_FALSE(Configuration().unsupportedFileSystems());
+}
+
+TEST_F(HipFileConfiguration, UnsupportedFilesystemsDisabledIfEnvironmentVariableIsInvalid)
+{
+    expect_configuration_unsupported_file_systems("not-a-bool");
+    ASSERT_FALSE(Configuration().unsupportedFileSystems());
+}
+
+TEST_F(HipFileConfiguration, UnsupportedFilesystemsEnabledIfEnvironmentVariableIsTrue)
+{
+    expect_configuration_unsupported_file_systems("true");
+    ASSERT_TRUE(Configuration().unsupportedFileSystems());
+}
+
+TEST_F(HipFileConfiguration, UnsupportedFilesystemsDisabledIfEnvironmentVariableIsFalse)
+{
+    expect_configuration_unsupported_file_systems("false");
+    ASSERT_FALSE(Configuration().unsupportedFileSystems());
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -42,11 +42,11 @@ static int       SCORE_ACCEPT{100};
 static const int SCORE_REJECT{-1};
 
 #if defined(STATX_DIOALIGN)
-static uint32_t DEFAULT_MEM_ALIGN{4};
-static uint32_t DEFAULT_OFFSET_ALIGN{512};
+static const uint32_t DEFAULT_MEM_ALIGN{4};
+static const uint32_t DEFAULT_OFFSET_ALIGN{512};
 #else
-static uint32_t DEFAULT_MEM_ALIGN{4096};
-static uint32_t DEFAULT_OFFSET_ALIGN{4096};
+static const uint32_t DEFAULT_MEM_ALIGN{4096};
+static const uint32_t DEFAULT_OFFSET_ALIGN{4096};
 #endif
 
 namespace hipFile {
@@ -58,26 +58,17 @@ operator==(const hipAmdFileHandle_t &lhs, const hipAmdFileHandle_t &rhs)
 }
 
 // Provide default values for variables used in fastpath tests
-struct FastpathTestBase {
-    const bool          DEFAULT_ENABLE{true};
-    const size_t        DEFAULT_IO_SIZE{1024 * 1024};
-    void *const         DEFAULT_BUFFER_ADDR{reinterpret_cast<void *>(0xABAD'CAFE'0000'0000)};
-    const off_t         DEFAULT_BUFFER_OFFSET{DEFAULT_MEM_ALIGN};
-    const size_t        DEFAULT_BUFFER_LENGTH{DEFAULT_IO_SIZE + static_cast<size_t>(DEFAULT_BUFFER_OFFSET)};
-    const hipMemoryType DEFAULT_BUFFER_TYPE{hipMemoryTypeDevice};
-    const optional<int> DEFAULT_UNBUFFERED_FD{7};
-    const off_t         DEFAULT_FILE_OFFSET{8192};
-    const struct statx  DEFAULT_STATX {
-        []() {
-            struct statx stx {};
-#if defined(STATX_DIOALIGN)
-            stx.stx_mask             = STATX_DIOALIGN;
-            stx.stx_dio_mem_align    = DEFAULT_MEM_ALIGN;
-            stx.stx_dio_offset_align = DEFAULT_OFFSET_ALIGN;
-#endif
-            return stx;
-        }()
-    };
+class FastpathTestBase {
+public:
+    static constexpr bool          DEFAULT_ENABLE{true};
+    static constexpr size_t        DEFAULT_IO_SIZE{1024 * 1024};
+    static constexpr uintptr_t     DEFAULT_BUFFER_ADDR{0xABAD'CAFE'0000'0000};
+    static constexpr off_t         DEFAULT_BUFFER_OFFSET{DEFAULT_MEM_ALIGN};
+    static constexpr size_t        DEFAULT_BUFFER_LENGTH{DEFAULT_IO_SIZE +
+                                                  static_cast<size_t>(DEFAULT_BUFFER_OFFSET)};
+    static constexpr hipMemoryType DEFAULT_BUFFER_TYPE{hipMemoryTypeDevice};
+    static constexpr optional<int> DEFAULT_UNBUFFERED_FD{7};
+    static constexpr off_t         DEFAULT_FILE_OFFSET{8192};
 
     // Buffer and file mocks used to setup expectations
     shared_ptr<StrictMock<MFile>>   mfile{make_shared<StrictMock<MFile>>()};
@@ -85,6 +76,76 @@ struct FastpathTestBase {
 
     StrictMock<MConfiguration> mcfg{};
 };
+
+class FastpathScoreExpectations;
+
+class FastpathScoreExpectationsBuilder {
+public:
+    StrictMock<MConfiguration>     &m_mcfg;
+    shared_ptr<StrictMock<MFile>>   m_mfile;
+    shared_ptr<StrictMock<MBuffer>> m_mbuffer;
+
+    optional<bool>          m_fastpath_enabled;
+    optional<void *>        m_buffer_addr;
+    optional<hipMemoryType> m_buffer_type;
+    optional<optional<int>> m_unbuffered_fd;
+
+    FastpathScoreExpectationsBuilder(StrictMock<MConfiguration> &mcfg, shared_ptr<StrictMock<MFile>> mfile,
+                                     shared_ptr<StrictMock<MBuffer>> mbuffer)
+        : m_mcfg(mcfg), m_mfile(mfile), m_mbuffer(mbuffer)
+    {
+    }
+
+    FastpathScoreExpectationsBuilder &fastpathEnabled(bool enabled)
+    {
+        m_fastpath_enabled = enabled;
+        return *this;
+    }
+
+    FastpathScoreExpectationsBuilder &bufferAddr(void *addr)
+    {
+        m_buffer_addr = addr;
+        return *this;
+    }
+
+    FastpathScoreExpectationsBuilder &bufferType(hipMemoryType type)
+    {
+        m_buffer_type = type;
+        return *this;
+    }
+
+    FastpathScoreExpectationsBuilder &unbufferedFd(optional<int> fd)
+    {
+        m_unbuffered_fd = fd;
+        return *this;
+    }
+
+    FastpathScoreExpectations build();
+};
+
+class FastpathScoreExpectations {
+public:
+    FastpathScoreExpectations(const FastpathScoreExpectationsBuilder &builder)
+    {
+        EXPECT_CALL(builder.m_mcfg, fastpath())
+            .WillOnce(Return(builder.m_fastpath_enabled.value_or(FastpathTestBase::DEFAULT_ENABLE)));
+        EXPECT_CALL(*builder.m_mfile, unbufferedFd)
+            .WillOnce(Return(builder.m_unbuffered_fd.value_or(FastpathTestBase::DEFAULT_UNBUFFERED_FD)));
+        EXPECT_CALL(*builder.m_mbuffer, getType)
+            .WillOnce(Return(builder.m_buffer_type.value_or(FastpathTestBase::DEFAULT_BUFFER_TYPE)));
+        EXPECT_CALL(*builder.m_mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
+        EXPECT_CALL(*builder.m_mbuffer, getBuffer)
+            .WillOnce(Return(builder.m_buffer_addr.value_or(
+                reinterpret_cast<void *>(FastpathTestBase::DEFAULT_BUFFER_ADDR))));
+        EXPECT_CALL(*builder.m_mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    }
+};
+
+FastpathScoreExpectations
+FastpathScoreExpectationsBuilder::build()
+{
+    return FastpathScoreExpectations(*this);
+}
 
 struct FastpathTest : public FastpathTestBase, public Test {};
 
@@ -95,7 +156,7 @@ TEST_F(FastpathTest, TestDefaults)
     ASSERT_TRUE(DEFAULT_MEM_ALIGN > 1);
     ASSERT_FALSE((DEFAULT_OFFSET_ALIGN & (DEFAULT_OFFSET_ALIGN - 1)));
     ASSERT_TRUE(DEFAULT_OFFSET_ALIGN > 1);
-    ASSERT_FALSE((reinterpret_cast<uintptr_t>(DEFAULT_BUFFER_ADDR) & (DEFAULT_MEM_ALIGN - 1)));
+    ASSERT_FALSE((DEFAULT_BUFFER_ADDR & (DEFAULT_MEM_ALIGN - 1)));
     ASSERT_FALSE((DEFAULT_BUFFER_OFFSET & (DEFAULT_MEM_ALIGN - 1)));
     ASSERT_FALSE((DEFAULT_IO_SIZE & (DEFAULT_OFFSET_ALIGN - 1)));
     ASSERT_FALSE((DEFAULT_FILE_OFFSET & (DEFAULT_OFFSET_ALIGN - 1)));
@@ -103,12 +164,7 @@ TEST_F(FastpathTest, TestDefaults)
 
 TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -116,12 +172,7 @@ TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
 
 TEST_F(FastpathTest, ScoreRejectsIoIfFastpathIsDisabled)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(false));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).fastpathEnabled(false).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -129,12 +180,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfFastpathIsDisabled)
 
 TEST_F(FastpathTest, ScoreRejectsIoIfUnbufferedFdNotAvailable)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(nullopt));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).unbufferedFd(nullopt).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -142,12 +188,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfUnbufferedFdNotAvailable)
 
 TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedFileOffset)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, -static_cast<hoff_t>(DEFAULT_OFFSET_ALIGN),
                                DEFAULT_BUFFER_OFFSET),
@@ -156,12 +197,7 @@ TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedFileOffset)
 
 TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedBufferOffset)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET,
                                -static_cast<hoff_t>(DEFAULT_MEM_ALIGN)),
@@ -170,16 +206,11 @@ TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedBufferOffset)
 
 TEST_F(FastpathTest, ScoreRejectsIoIfBufferAddressPlusBufferOffsetIsUnaligned)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     // The DEFAULT_BUFFER_ADDR is DEFAULT_MEM_ALIGN aligned. Ensure that this
     // test's buffer is not DEFAULT_MEM_ALIGN aligned.
-    EXPECT_CALL(*mbuffer, getBuffer)
-        .WillOnce(Return(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(DEFAULT_BUFFER_ADDR) +
-                                                  (DEFAULT_MEM_ALIGN >> 1))));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer)
+        .bufferAddr(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR + (DEFAULT_MEM_ALIGN >> 1)))
+        .build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET,
                                static_cast<hoff_t>(DEFAULT_MEM_ALIGN)),
@@ -190,12 +221,7 @@ struct FastpathSupportedHipMemoryParam : public FastpathTestBase, public TestWit
 
 TEST_P(FastpathSupportedHipMemoryParam, Score)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(GetParam()));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).bufferType(GetParam()).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -207,12 +233,7 @@ struct FastpathUnsupportedHipMemoryParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathUnsupportedHipMemoryParam, Score)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(GetParam()));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).bufferType(GetParam()).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -225,12 +246,7 @@ struct FastpathAlignedIoSizesParam : public FastpathTestBase, public TestWithPar
 
 TEST_P(FastpathAlignedIoSizesParam, Score)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, GetParam(), DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -244,12 +260,7 @@ struct FastpathUnalignedIoSizesParam : public FastpathTestBase, public TestWithP
 
 TEST_P(FastpathUnalignedIoSizesParam, Score)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, GetParam(), DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -263,12 +274,7 @@ struct FastpathAlignedFileOffsetsParam : public FastpathTestBase, public TestWit
 
 TEST_P(FastpathAlignedFileOffsetsParam, Score)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, GetParam(), DEFAULT_BUFFER_OFFSET),
               GetParam() >= 0 ? SCORE_ACCEPT : SCORE_REJECT);
@@ -284,12 +290,7 @@ struct FastpathUnalignedFileOffsetsParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathUnalignedFileOffsetsParam, Score)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, GetParam(), DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -307,12 +308,7 @@ struct FastpathAlignedBufferOffsetsParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathAlignedBufferOffsetsParam, Score)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, GetParam()),
               GetParam() >= 0 ? SCORE_ACCEPT : SCORE_REJECT);
@@ -329,12 +325,7 @@ struct FastpathUnalignedBufferOffsetsParam : public FastpathTestBase, public Tes
 
 TEST_P(FastpathUnalignedBufferOffsetsParam, Score)
 {
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
-    EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
-    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, GetParam()),
               SCORE_REJECT);
@@ -356,7 +347,7 @@ struct FastpathIoParam : public FastpathTestBase, public TestWithParam<IoType> {
     void expect_validate()
     {
         EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-        EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+        EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
         EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     }
@@ -573,7 +564,7 @@ TEST_P(FastpathIoParam, IoSizeIsTruncatedToMaxRWCount)
     const size_t buffer_size{SIZE_MAX};
     const size_t io_size{SIZE_MAX};
 
-    expect_io(DEFAULT_UNBUFFERED_FD, DEFAULT_BUFFER_ADDR, buffer_size);
+    expect_io(DEFAULT_UNBUFFERED_FD, reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR), buffer_size);
     switch (GetParam()) {
         case IoType::Read:
             EXPECT_CALL(mhip, hipAmdFileRead(_, _, MAX_RW_COUNT, _)).WillOnce(Return(MAX_RW_COUNT));
@@ -598,7 +589,7 @@ TEST_P(FastpathIoParam, IoWithFallbackThrowsAFallbackIneligibleException)
 
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(true));
     EXPECT_CALL(mhip, hipInit).WillRepeatedly(Return());
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
 
@@ -627,7 +618,7 @@ TEST_P(FastpathIoParam, IoWithFallbackThrowsHipRuntimeException)
 
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(true));
     EXPECT_CALL(mhip, hipInit).WillOnce(Return());
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
 
@@ -654,7 +645,7 @@ TEST_P(FastpathIoParam, IoThrowsAFallbackEligibleENODEV)
     backend->register_fallback_backend(m_fallback);
 
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(true));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(mhip, hipInit).WillOnce(Return());
     EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
@@ -685,7 +676,7 @@ TEST_P(FastpathIoParam, IoThrowsAFallbackEligibleEREMOTEIO)
     backend->register_fallback_backend(m_fallback);
 
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(true));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(mhip, hipInit).WillOnce(Return());
     EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
@@ -723,7 +714,7 @@ TEST_P(FastpathIoParam, FallbackRejectsIoRequest)
 
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(true));
     EXPECT_CALL(mhip, hipInit).WillRepeatedly(Return());
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*m_fallback, score).WillOnce(Return(SCORE_REJECT));

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -69,6 +69,7 @@ public:
     static constexpr hipMemoryType DEFAULT_BUFFER_TYPE{hipMemoryTypeDevice};
     static constexpr optional<int> DEFAULT_UNBUFFERED_FD{7};
     static constexpr off_t         DEFAULT_FILE_OFFSET{8192};
+    static constexpr bool          DEFAULT_IS_REGULAR_FILE{true};
 
     // Buffer and file mocks used to setup expectations
     shared_ptr<StrictMock<MFile>>   mfile{make_shared<StrictMock<MFile>>()};
@@ -89,6 +90,7 @@ public:
     optional<void *>        m_buffer_addr;
     optional<hipMemoryType> m_buffer_type;
     optional<optional<int>> m_unbuffered_fd;
+    optional<bool>          m_is_regular_file;
 
     FastpathScoreExpectationsBuilder(StrictMock<MConfiguration> &mcfg, shared_ptr<StrictMock<MFile>> mfile,
                                      shared_ptr<StrictMock<MBuffer>> mbuffer)
@@ -120,6 +122,12 @@ public:
         return *this;
     }
 
+    FastpathScoreExpectationsBuilder &isRegularFile(bool is_regular_file)
+    {
+        m_is_regular_file = is_regular_file;
+        return *this;
+    }
+
     FastpathScoreExpectations build();
 };
 
@@ -133,6 +141,8 @@ public:
             .WillOnce(Return(builder.m_unbuffered_fd.value_or(FastpathTestBase::DEFAULT_UNBUFFERED_FD)));
         EXPECT_CALL(*builder.m_mbuffer, getType)
             .WillOnce(Return(builder.m_buffer_type.value_or(FastpathTestBase::DEFAULT_BUFFER_TYPE)));
+        EXPECT_CALL(*builder.m_mfile, isRegularFile)
+            .WillOnce(Return(builder.m_is_regular_file.value_or(FastpathTestBase::DEFAULT_IS_REGULAR_FILE)));
         EXPECT_CALL(*builder.m_mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
         EXPECT_CALL(*builder.m_mbuffer, getBuffer)
             .WillOnce(Return(builder.m_buffer_addr.value_or(
@@ -160,6 +170,7 @@ TEST_F(FastpathTest, TestDefaults)
     ASSERT_FALSE((DEFAULT_BUFFER_OFFSET & (DEFAULT_MEM_ALIGN - 1)));
     ASSERT_FALSE((DEFAULT_IO_SIZE & (DEFAULT_OFFSET_ALIGN - 1)));
     ASSERT_FALSE((DEFAULT_FILE_OFFSET & (DEFAULT_OFFSET_ALIGN - 1)));
+    ASSERT_TRUE(DEFAULT_IS_REGULAR_FILE);
 }
 
 TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
@@ -214,6 +225,22 @@ TEST_F(FastpathTest, ScoreRejectsIoIfBufferAddressPlusBufferOffsetIsUnaligned)
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET,
                                static_cast<hoff_t>(DEFAULT_MEM_ALIGN)),
+              SCORE_REJECT);
+}
+
+TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularFile)
+{
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(true).build();
+
+    ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
+              SCORE_ACCEPT);
+}
+
+TEST_F(FastpathTest, ScoreRejectsIoIfFileIsNotRegularFile)
+{
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(false).build();
+
+    ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
 }
 

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -73,6 +73,7 @@ public:
     static constexpr bool          DEFAULT_IS_BLOCK_DEVICE{false};
     static constexpr bool          DEFAULT_ON_EXT4_ORDERED{true};
     static constexpr bool          DEFAULT_ON_XFS{false};
+    static constexpr bool          DEFAULT_UNSUPPORTED_FILE_SYSTEMS{false};
 
     // Buffer and file mocks used to setup expectations
     shared_ptr<StrictMock<MFile>>   mfile{make_shared<StrictMock<MFile>>()};
@@ -97,6 +98,7 @@ public:
     optional<bool>          m_is_block_device;
     optional<bool>          m_on_ext4_ordered;
     optional<bool>          m_on_xfs;
+    optional<bool>          m_unsupported_file_systems;
 
     FastpathScoreExpectationsBuilder(StrictMock<MConfiguration> &mcfg, shared_ptr<StrictMock<MFile>> mfile,
                                      shared_ptr<StrictMock<MBuffer>> mbuffer)
@@ -152,6 +154,12 @@ public:
         return *this;
     }
 
+    FastpathScoreExpectationsBuilder &unsupportedFileSystems(bool unsupported_file_systems)
+    {
+        m_unsupported_file_systems = unsupported_file_systems;
+        return *this;
+    }
+
     FastpathScoreExpectations build();
 };
 
@@ -171,6 +179,9 @@ public:
             .WillOnce(Return(builder.m_on_ext4_ordered.value_or(FastpathTestBase::DEFAULT_ON_EXT4_ORDERED)));
         EXPECT_CALL(*builder.m_mfile, onXfs)
             .WillOnce(Return(builder.m_on_xfs.value_or(FastpathTestBase::DEFAULT_ON_XFS)));
+        EXPECT_CALL(builder.m_mcfg, unsupportedFileSystems)
+            .WillOnce(Return(builder.m_unsupported_file_systems.value_or(
+                FastpathTestBase::DEFAULT_UNSUPPORTED_FILE_SYSTEMS)));
         EXPECT_CALL(*builder.m_mfile, isBlockDevice)
             .WillOnce(Return(builder.m_is_block_device.value_or(FastpathTestBase::DEFAULT_IS_BLOCK_DEVICE)));
         EXPECT_CALL(*builder.m_mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
@@ -287,6 +298,19 @@ TEST_F(FastpathTest, ScoreRejectsIoIfFileIsRegularAndNotOnExt4OrderedNorXfs)
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
+}
+
+TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularNotOnExt4OrderedNorXfsIfUnsupportedFileSystemsIsTrue)
+{
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer)
+        .isRegularFile(true)
+        .onExt4Ordered(false)
+        .onXfs(false)
+        .unsupportedFileSystems(true)
+        .build();
+
+    ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
+              SCORE_ACCEPT);
 }
 
 TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsBlockDevice)

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -70,6 +70,7 @@ public:
     static constexpr optional<int> DEFAULT_UNBUFFERED_FD{7};
     static constexpr off_t         DEFAULT_FILE_OFFSET{8192};
     static constexpr bool          DEFAULT_IS_REGULAR_FILE{true};
+    static constexpr bool          DEFAULT_IS_BLOCK_DEVICE{false};
 
     // Buffer and file mocks used to setup expectations
     shared_ptr<StrictMock<MFile>>   mfile{make_shared<StrictMock<MFile>>()};
@@ -91,6 +92,7 @@ public:
     optional<hipMemoryType> m_buffer_type;
     optional<optional<int>> m_unbuffered_fd;
     optional<bool>          m_is_regular_file;
+    optional<bool>          m_is_block_device;
 
     FastpathScoreExpectationsBuilder(StrictMock<MConfiguration> &mcfg, shared_ptr<StrictMock<MFile>> mfile,
                                      shared_ptr<StrictMock<MBuffer>> mbuffer)
@@ -128,6 +130,12 @@ public:
         return *this;
     }
 
+    FastpathScoreExpectationsBuilder &isBlockDevice(bool is_block_device)
+    {
+        m_is_block_device = is_block_device;
+        return *this;
+    }
+
     FastpathScoreExpectations build();
 };
 
@@ -143,6 +151,8 @@ public:
             .WillOnce(Return(builder.m_buffer_type.value_or(FastpathTestBase::DEFAULT_BUFFER_TYPE)));
         EXPECT_CALL(*builder.m_mfile, isRegularFile)
             .WillOnce(Return(builder.m_is_regular_file.value_or(FastpathTestBase::DEFAULT_IS_REGULAR_FILE)));
+        EXPECT_CALL(*builder.m_mfile, isBlockDevice)
+            .WillOnce(Return(builder.m_is_block_device.value_or(FastpathTestBase::DEFAULT_IS_BLOCK_DEVICE)));
         EXPECT_CALL(*builder.m_mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
         EXPECT_CALL(*builder.m_mbuffer, getBuffer)
             .WillOnce(Return(builder.m_buffer_addr.value_or(
@@ -171,6 +181,7 @@ TEST_F(FastpathTest, TestDefaults)
     ASSERT_FALSE((DEFAULT_IO_SIZE & (DEFAULT_OFFSET_ALIGN - 1)));
     ASSERT_FALSE((DEFAULT_FILE_OFFSET & (DEFAULT_OFFSET_ALIGN - 1)));
     ASSERT_TRUE(DEFAULT_IS_REGULAR_FILE);
+    ASSERT_FALSE(DEFAULT_IS_BLOCK_DEVICE);
 }
 
 TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
@@ -230,15 +241,23 @@ TEST_F(FastpathTest, ScoreRejectsIoIfBufferAddressPlusBufferOffsetIsUnaligned)
 
 TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularFile)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(true).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(true).isBlockDevice(false).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
 }
 
-TEST_F(FastpathTest, ScoreRejectsIoIfFileIsNotRegularFile)
+TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsBlockDevice)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(false).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(false).isBlockDevice(true).build();
+
+    ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
+              SCORE_ACCEPT);
+}
+
+TEST_F(FastpathTest, ScoreRejectsIoIfFileIsNotRegularFileOrBlockDevice)
+{
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(false).isBlockDevice(false).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -106,9 +106,7 @@ TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -121,9 +119,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfFastpathIsDisabled)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(false));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -136,9 +132,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfUnbufferedFdNotAvailable)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(nullopt));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -151,9 +145,7 @@ TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedFileOffset)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -167,9 +159,7 @@ TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedBufferOffset)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -183,9 +173,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfBufferAddressPlusBufferOffsetIsUnaligned)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     // The DEFAULT_BUFFER_ADDR is DEFAULT_MEM_ALIGN aligned. Ensure that this
     // test's buffer is not DEFAULT_MEM_ALIGN aligned.
     EXPECT_CALL(*mbuffer, getBuffer)
@@ -205,9 +193,7 @@ TEST_P(FastpathSupportedHipMemoryParam, Score)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(GetParam()));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -224,9 +210,7 @@ TEST_P(FastpathUnsupportedHipMemoryParam, Score)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(GetParam()));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -244,9 +228,7 @@ TEST_P(FastpathAlignedIoSizesParam, Score)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -265,9 +247,7 @@ TEST_P(FastpathUnalignedIoSizesParam, Score)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -286,9 +266,7 @@ TEST_P(FastpathAlignedFileOffsetsParam, Score)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -309,9 +287,7 @@ TEST_P(FastpathUnalignedFileOffsetsParam, Score)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -334,9 +310,7 @@ TEST_P(FastpathAlignedBufferOffsetsParam, Score)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
@@ -358,9 +332,7 @@ TEST_P(FastpathUnalignedBufferOffsetsParam, Score)
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
     EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
-#if defined(STATX_DIOALIGN)
-    EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
-#endif
+    EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -104,7 +104,7 @@ TEST_F(FastpathTest, TestDefaults)
 TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -117,7 +117,7 @@ TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
 TEST_F(FastpathTest, ScoreRejectsIoIfFastpathIsDisabled)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(false));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -130,7 +130,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfFastpathIsDisabled)
 TEST_F(FastpathTest, ScoreRejectsIoIfUnbufferedFdNotAvailable)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(nullopt));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(nullopt));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -143,7 +143,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfUnbufferedFdNotAvailable)
 TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedFileOffset)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -157,7 +157,7 @@ TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedFileOffset)
 TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedBufferOffset)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -171,7 +171,7 @@ TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedBufferOffset)
 TEST_F(FastpathTest, ScoreRejectsIoIfBufferAddressPlusBufferOffsetIsUnaligned)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     // The DEFAULT_BUFFER_ADDR is DEFAULT_MEM_ALIGN aligned. Ensure that this
@@ -191,7 +191,7 @@ struct FastpathSupportedHipMemoryParam : public FastpathTestBase, public TestWit
 TEST_P(FastpathSupportedHipMemoryParam, Score)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(GetParam()));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -208,7 +208,7 @@ struct FastpathUnsupportedHipMemoryParam : public FastpathTestBase, public TestW
 TEST_P(FastpathUnsupportedHipMemoryParam, Score)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(GetParam()));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -226,7 +226,7 @@ struct FastpathAlignedIoSizesParam : public FastpathTestBase, public TestWithPar
 TEST_P(FastpathAlignedIoSizesParam, Score)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -245,7 +245,7 @@ struct FastpathUnalignedIoSizesParam : public FastpathTestBase, public TestWithP
 TEST_P(FastpathUnalignedIoSizesParam, Score)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -264,7 +264,7 @@ struct FastpathAlignedFileOffsetsParam : public FastpathTestBase, public TestWit
 TEST_P(FastpathAlignedFileOffsetsParam, Score)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -285,7 +285,7 @@ struct FastpathUnalignedFileOffsetsParam : public FastpathTestBase, public TestW
 TEST_P(FastpathUnalignedFileOffsetsParam, Score)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -308,7 +308,7 @@ struct FastpathAlignedBufferOffsetsParam : public FastpathTestBase, public TestW
 TEST_P(FastpathAlignedBufferOffsetsParam, Score)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -330,7 +330,7 @@ struct FastpathUnalignedBufferOffsetsParam : public FastpathTestBase, public Tes
 TEST_P(FastpathUnalignedBufferOffsetsParam, Score)
 {
     EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*mbuffer, getType).WillOnce(Return(DEFAULT_BUFFER_TYPE));
     EXPECT_CALL(*mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
@@ -358,7 +358,7 @@ struct FastpathIoParam : public FastpathTestBase, public TestWithParam<IoType> {
         EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
         EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-        EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+        EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     }
 
     // Setup expectations on the mocks called to validate IO arguments and
@@ -375,7 +375,7 @@ struct FastpathIoParam : public FastpathTestBase, public TestWithParam<IoType> {
         EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(DEFAULT_ENABLE));
         EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(bufptr));
         EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(buflen));
-        EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(fd));
+        EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(fd));
     }
 
     // Setup expectations on the mocks called to validate IO arguments and
@@ -600,7 +600,7 @@ TEST_P(FastpathIoParam, IoWithFallbackThrowsAFallbackIneligibleException)
     EXPECT_CALL(mhip, hipInit).WillRepeatedly(Return());
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
 
     switch (GetParam()) {
         case IoType::Read:
@@ -629,7 +629,7 @@ TEST_P(FastpathIoParam, IoWithFallbackThrowsHipRuntimeException)
     EXPECT_CALL(mhip, hipInit).WillOnce(Return());
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
 
     switch (GetParam()) {
         case IoType::Read:
@@ -657,7 +657,7 @@ TEST_P(FastpathIoParam, IoThrowsAFallbackEligibleENODEV)
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(mhip, hipInit).WillOnce(Return());
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
 
     switch (GetParam()) {
         case IoType::Read:
@@ -688,7 +688,7 @@ TEST_P(FastpathIoParam, IoThrowsAFallbackEligibleEREMOTEIO)
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(mhip, hipInit).WillOnce(Return());
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
 
     switch (GetParam()) {
         case IoType::Read:
@@ -725,7 +725,7 @@ TEST_P(FastpathIoParam, FallbackRejectsIoRequest)
     EXPECT_CALL(mhip, hipInit).WillRepeatedly(Return());
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-    EXPECT_CALL(*mfile, getUnbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*m_fallback, score).WillOnce(Return(SCORE_REJECT));
 
     switch (GetParam()) {

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -110,6 +110,7 @@ TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -124,6 +125,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfFastpathIsDisabled)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -138,6 +140,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfUnbufferedFdNotAvailable)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -152,6 +155,7 @@ TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedFileOffset)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, -static_cast<hoff_t>(DEFAULT_OFFSET_ALIGN),
                                DEFAULT_BUFFER_OFFSET),
@@ -167,6 +171,7 @@ TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedBufferOffset)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET,
                                -static_cast<hoff_t>(DEFAULT_MEM_ALIGN)),
@@ -186,6 +191,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfBufferAddressPlusBufferOffsetIsUnaligned)
     EXPECT_CALL(*mbuffer, getBuffer)
         .WillOnce(Return(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(DEFAULT_BUFFER_ADDR) +
                                                   (DEFAULT_MEM_ALIGN >> 1))));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET,
                                static_cast<hoff_t>(DEFAULT_MEM_ALIGN)),
@@ -203,6 +209,7 @@ TEST_P(FastpathSupportedHipMemoryParam, Score)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -221,6 +228,7 @@ TEST_P(FastpathUnsupportedHipMemoryParam, Score)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -240,6 +248,7 @@ TEST_P(FastpathAlignedIoSizesParam, Score)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, GetParam(), DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -260,6 +269,7 @@ TEST_P(FastpathUnalignedIoSizesParam, Score)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, GetParam(), DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -280,6 +290,7 @@ TEST_P(FastpathAlignedFileOffsetsParam, Score)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, GetParam(), DEFAULT_BUFFER_OFFSET),
               GetParam() >= 0 ? SCORE_ACCEPT : SCORE_REJECT);
@@ -302,6 +313,7 @@ TEST_P(FastpathUnalignedFileOffsetsParam, Score)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, GetParam(), DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -326,6 +338,7 @@ TEST_P(FastpathAlignedBufferOffsetsParam, Score)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, GetParam()),
               GetParam() >= 0 ? SCORE_ACCEPT : SCORE_REJECT);
@@ -349,6 +362,7 @@ TEST_P(FastpathUnalignedBufferOffsetsParam, Score)
     EXPECT_CALL(*mfile, getStatx).WillOnce(ReturnRef(DEFAULT_STATX));
 #endif
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(DEFAULT_BUFFER_ADDR));
+    EXPECT_CALL(*mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, GetParam()),
               SCORE_REJECT);

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -71,6 +71,7 @@ public:
     static constexpr off_t         DEFAULT_FILE_OFFSET{8192};
     static constexpr bool          DEFAULT_IS_REGULAR_FILE{true};
     static constexpr bool          DEFAULT_IS_BLOCK_DEVICE{false};
+    static constexpr bool          DEFAULT_ON_EXT4_ORDERED{true};
 
     // Buffer and file mocks used to setup expectations
     shared_ptr<StrictMock<MFile>>   mfile{make_shared<StrictMock<MFile>>()};
@@ -93,6 +94,7 @@ public:
     optional<optional<int>> m_unbuffered_fd;
     optional<bool>          m_is_regular_file;
     optional<bool>          m_is_block_device;
+    optional<bool>          m_on_ext4_ordered;
 
     FastpathScoreExpectationsBuilder(StrictMock<MConfiguration> &mcfg, shared_ptr<StrictMock<MFile>> mfile,
                                      shared_ptr<StrictMock<MBuffer>> mbuffer)
@@ -136,6 +138,12 @@ public:
         return *this;
     }
 
+    FastpathScoreExpectationsBuilder &onExt4Ordered(bool on_ext4_ordered)
+    {
+        m_on_ext4_ordered = on_ext4_ordered;
+        return *this;
+    }
+
     FastpathScoreExpectations build();
 };
 
@@ -151,6 +159,8 @@ public:
             .WillOnce(Return(builder.m_buffer_type.value_or(FastpathTestBase::DEFAULT_BUFFER_TYPE)));
         EXPECT_CALL(*builder.m_mfile, isRegularFile)
             .WillOnce(Return(builder.m_is_regular_file.value_or(FastpathTestBase::DEFAULT_IS_REGULAR_FILE)));
+        EXPECT_CALL(*builder.m_mfile, onExt4Ordered)
+            .WillOnce(Return(builder.m_on_ext4_ordered.value_or(FastpathTestBase::DEFAULT_ON_EXT4_ORDERED)));
         EXPECT_CALL(*builder.m_mfile, isBlockDevice)
             .WillOnce(Return(builder.m_is_block_device.value_or(FastpathTestBase::DEFAULT_IS_BLOCK_DEVICE)));
         EXPECT_CALL(*builder.m_mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
@@ -182,6 +192,7 @@ TEST_F(FastpathTest, TestDefaults)
     ASSERT_FALSE((DEFAULT_FILE_OFFSET & (DEFAULT_OFFSET_ALIGN - 1)));
     ASSERT_TRUE(DEFAULT_IS_REGULAR_FILE);
     ASSERT_FALSE(DEFAULT_IS_BLOCK_DEVICE);
+    ASSERT_TRUE(DEFAULT_ON_EXT4_ORDERED);
 }
 
 TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
@@ -239,12 +250,20 @@ TEST_F(FastpathTest, ScoreRejectsIoIfBufferAddressPlusBufferOffsetIsUnaligned)
               SCORE_REJECT);
 }
 
-TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularFile)
+TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularAndOnExt4Ordered)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(true).isBlockDevice(false).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(true).onExt4Ordered(true).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
+}
+
+TEST_F(FastpathTest, ScoreRejectsIoIfFileIsRegularAndNotOnExt4Ordered)
+{
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(true).onExt4Ordered(false).build();
+
+    ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
+              SCORE_REJECT);
 }
 
 TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsBlockDevice)

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -72,6 +72,7 @@ public:
     static constexpr bool          DEFAULT_IS_REGULAR_FILE{true};
     static constexpr bool          DEFAULT_IS_BLOCK_DEVICE{false};
     static constexpr bool          DEFAULT_ON_EXT4_ORDERED{true};
+    static constexpr bool          DEFAULT_ON_XFS{false};
 
     // Buffer and file mocks used to setup expectations
     shared_ptr<StrictMock<MFile>>   mfile{make_shared<StrictMock<MFile>>()};
@@ -95,6 +96,7 @@ public:
     optional<bool>          m_is_regular_file;
     optional<bool>          m_is_block_device;
     optional<bool>          m_on_ext4_ordered;
+    optional<bool>          m_on_xfs;
 
     FastpathScoreExpectationsBuilder(StrictMock<MConfiguration> &mcfg, shared_ptr<StrictMock<MFile>> mfile,
                                      shared_ptr<StrictMock<MBuffer>> mbuffer)
@@ -144,6 +146,12 @@ public:
         return *this;
     }
 
+    FastpathScoreExpectationsBuilder &onXfs(bool on_xfs)
+    {
+        m_on_xfs = on_xfs;
+        return *this;
+    }
+
     FastpathScoreExpectations build();
 };
 
@@ -161,6 +169,8 @@ public:
             .WillOnce(Return(builder.m_is_regular_file.value_or(FastpathTestBase::DEFAULT_IS_REGULAR_FILE)));
         EXPECT_CALL(*builder.m_mfile, onExt4Ordered)
             .WillOnce(Return(builder.m_on_ext4_ordered.value_or(FastpathTestBase::DEFAULT_ON_EXT4_ORDERED)));
+        EXPECT_CALL(*builder.m_mfile, onXfs)
+            .WillOnce(Return(builder.m_on_xfs.value_or(FastpathTestBase::DEFAULT_ON_XFS)));
         EXPECT_CALL(*builder.m_mfile, isBlockDevice)
             .WillOnce(Return(builder.m_is_block_device.value_or(FastpathTestBase::DEFAULT_IS_BLOCK_DEVICE)));
         EXPECT_CALL(*builder.m_mfile, dioOffsetAlign).WillOnce(Return(DEFAULT_OFFSET_ALIGN));
@@ -193,6 +203,7 @@ TEST_F(FastpathTest, TestDefaults)
     ASSERT_TRUE(DEFAULT_IS_REGULAR_FILE);
     ASSERT_FALSE(DEFAULT_IS_BLOCK_DEVICE);
     ASSERT_TRUE(DEFAULT_ON_EXT4_ORDERED);
+    ASSERT_FALSE(DEFAULT_ON_XFS);
 }
 
 TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
@@ -258,9 +269,21 @@ TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularAndOnExt4Ordered)
               SCORE_ACCEPT);
 }
 
-TEST_F(FastpathTest, ScoreRejectsIoIfFileIsRegularAndNotOnExt4Ordered)
+TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularAndOnXfs)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(true).onExt4Ordered(false).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(true).onXfs(true).build();
+
+    ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
+              SCORE_ACCEPT);
+}
+
+TEST_F(FastpathTest, ScoreRejectsIoIfFileIsRegularAndNotOnExt4OrderedNorXfs)
+{
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer)
+        .isRegularFile(true)
+        .onExt4Ordered(false)
+        .onXfs(false)
+        .build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -215,6 +215,7 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_EQ(file->dioOffsetAlign(), 4096);
 #endif
     EXPECT_FALSE(file->isBlockDevice());
+    EXPECT_TRUE(file->isRegularFile());
 }
 
 TEST_F(HipFileHandle, register_handle_internal_linux_fd_already_registered)
@@ -611,6 +612,75 @@ TEST_F(HipFileHandle, IsBlockDeviceReturnsFalseWhenStatxTypeNotAvailable)
     auto file{Context<DriverState>::get()->getFile(fh)};
 
     EXPECT_FALSE(file->isBlockDevice());
+}
+
+TEST_F(HipFileHandle, IsRegularFileReturnsTrueForRegularFile)
+{
+    int          fd{0xBADF00D};
+    struct statx stxbuf {};
+    stxbuf.stx_mask = STATX_TYPE;
+    stxbuf.stx_mode = S_IFREG;
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .statx(stxbuf)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_TRUE(file->isRegularFile());
+}
+
+TEST_F(HipFileHandle, IsRegularFileReturnsFalseForBlockDevice)
+{
+    int          fd{0xBADF00D};
+    struct statx stxbuf {};
+    stxbuf.stx_mask = STATX_TYPE;
+    stxbuf.stx_mode = S_IFBLK;
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .statx(stxbuf)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_FALSE(file->isRegularFile());
+}
+
+TEST_F(HipFileHandle, IsRegularFileReturnsFalseWhenStatxTypeNotAvailable)
+{
+    int          fd{0xBADF00D};
+    struct statx stxbuf {};
+    stxbuf.stx_mask = 0;
+    stxbuf.stx_mode = S_IFBLK;
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .statx(stxbuf)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_FALSE(file->isRegularFile());
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -214,6 +214,7 @@ TEST_F(HipFileHandle, file_initialization)
 #endif
     EXPECT_FALSE(file->isBlockDevice());
     EXPECT_TRUE(file->isRegularFile());
+    EXPECT_TRUE(file->onExt4Ordered());
 }
 
 TEST_F(HipFileHandle, register_handle_internal_linux_fd_already_registered)
@@ -681,4 +682,74 @@ TEST_F(HipFileHandle, IsRegularFileReturnsFalseWhenStatxTypeNotAvailable)
     EXPECT_FALSE(file->isRegularFile());
 }
 
+TEST_F(HipFileHandle, OnExt4OrderedReturnsTrueForExt4Ordered)
+{
+    int fd{0xBADF00D};
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    MountInfo mountinfo;
+    mountinfo.type                         = FilesystemType::ext4;
+    mountinfo.options.ext4.journaling_mode = ExtJournalingMode::ordered;
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .mountinfo(mountinfo)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_TRUE(file->onExt4Ordered());
+}
+
+TEST_F(HipFileHandle, OnExt4OrderedReturnsFalseForExt4Journal)
+{
+    int fd{0xBADF00D};
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    MountInfo mountinfo;
+    mountinfo.type                         = FilesystemType::ext4;
+    mountinfo.options.ext4.journaling_mode = ExtJournalingMode::journal;
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .mountinfo(mountinfo)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_FALSE(file->onExt4Ordered());
+}
+
+TEST_F(HipFileHandle, OnExt4OrderedReturnsFalseForOtherFileSystem)
+{
+    int fd{0xBADF00D};
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    MountInfo mountinfo;
+    mountinfo.type = FilesystemType::other;
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .mountinfo(mountinfo)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_FALSE(file->onExt4Ordered());
+}
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -198,7 +198,7 @@ TEST_F(HipFileHandle, file_initialization)
     auto file{Context<DriverState>::get()->getFile(fh)};
 
     EXPECT_EQ(fh, file->getHandle());
-    EXPECT_EQ(fd, file->getClientFd());
+    EXPECT_EQ(fd, file->clientFd());
     EXPECT_EQ(fd, file->bufferedFd());
     EXPECT_EQ(open_fd, file->unbufferedFd());
 #if defined(STATX_DIOALIGN)

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -176,6 +176,7 @@ TEST_F(HipFileHandle, file_initialization)
 #else
     stxbuf.stx_mask = STATX_TYPE | STATX_MODE;
 #endif
+    stxbuf.stx_mode = S_IFREG;
 
     // In this test, the registered file is destroyed _after_ the mocks are
     // destroyed. Use an eventfd so that when FileDescriptor calls close, it
@@ -213,6 +214,7 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_EQ(file->dioMemAlign(), 4096);
     EXPECT_EQ(file->dioOffsetAlign(), 4096);
 #endif
+    EXPECT_FALSE(file->isBlockDevice());
 }
 
 TEST_F(HipFileHandle, register_handle_internal_linux_fd_already_registered)
@@ -540,6 +542,75 @@ TEST_F(HipFileHandle, UnregisteredFileDioOffsetAlignIsZeroIfUnableToOpenUnbuffer
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).fd_flags(~O_DIRECT).open_throws(EINVAL).build();
     UnregisteredFile uf{777777};
     ASSERT_EQ(uf.m_dio_offset_align, 0);
+}
+
+TEST_F(HipFileHandle, IsBlockDeviceReturnsTrueForBlockDevice)
+{
+    int          fd{0xBADF00D};
+    struct statx stxbuf {};
+    stxbuf.stx_mask = STATX_TYPE;
+    stxbuf.stx_mode = S_IFBLK;
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .statx(stxbuf)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_TRUE(file->isBlockDevice());
+}
+
+TEST_F(HipFileHandle, IsBlockDeviceReturnsFalseForRegularFile)
+{
+    int          fd{0xBADF00D};
+    struct statx stxbuf {};
+    stxbuf.stx_mask = STATX_TYPE;
+    stxbuf.stx_mode = S_IFREG;
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .statx(stxbuf)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_FALSE(file->isBlockDevice());
+}
+
+TEST_F(HipFileHandle, IsBlockDeviceReturnsFalseWhenStatxTypeNotAvailable)
+{
+    int          fd{0xBADF00D};
+    struct statx stxbuf {};
+    stxbuf.stx_mask = 0;
+    stxbuf.stx_mode = S_IFBLK;
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .statx(stxbuf)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_FALSE(file->isBlockDevice());
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -201,7 +201,6 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_EQ(fd, file->getClientFd());
     EXPECT_EQ(fd, file->getBufferedFd());
     EXPECT_EQ(open_fd, file->getUnbufferedFd());
-    EXPECT_EQ(fd_flags, file->getStatusFlags());
 #if defined(STATX_DIOALIGN)
     EXPECT_EQ(file->dioMemAlign(), stxbuf.stx_dio_mem_align);
     EXPECT_EQ(file->dioOffsetAlign(), stxbuf.stx_dio_offset_align);

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -202,9 +202,6 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_EQ(fd, file->getBufferedFd());
     EXPECT_EQ(open_fd, file->getUnbufferedFd());
     EXPECT_EQ(fd_flags, file->getStatusFlags());
-    EXPECT_EQ(mountinfo.type, file->getMountInfo().value().type);
-    EXPECT_EQ(mountinfo.options.ext4.journaling_mode,
-              file->getMountInfo().value().options.ext4.journaling_mode);
 #if defined(STATX_DIOALIGN)
     EXPECT_EQ(file->dioMemAlign(), stxbuf.stx_dio_mem_align);
     EXPECT_EQ(file->dioOffsetAlign(), stxbuf.stx_dio_offset_align);

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -199,7 +199,7 @@ TEST_F(HipFileHandle, file_initialization)
 
     EXPECT_EQ(fh, file->getHandle());
     EXPECT_EQ(fd, file->getClientFd());
-    EXPECT_EQ(fd, file->getBufferedFd());
+    EXPECT_EQ(fd, file->bufferedFd());
     EXPECT_EQ(open_fd, file->unbufferedFd());
 #if defined(STATX_DIOALIGN)
     EXPECT_EQ(file->dioMemAlign(), stxbuf.stx_dio_mem_align);

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -208,8 +208,10 @@ TEST_F(HipFileHandle, file_initialization)
               file->getMountInfo().value().options.ext4.journaling_mode);
 #if defined(STATX_DIOALIGN)
     EXPECT_EQ(file->dioMemAlign(), stxbuf.stx_dio_mem_align);
+    EXPECT_EQ(file->dioOffsetAlign(), stxbuf.stx_dio_offset_align);
 #else
     EXPECT_EQ(file->dioMemAlign(), 4096);
+    EXPECT_EQ(file->dioOffsetAlign(), 4096);
 #endif
 }
 
@@ -475,6 +477,25 @@ TEST_F(HipFileHandle, UnregisteredFileDioMemAlignMatchesStatxDioMemAlign)
 }
 #endif
 
+#if defined(STATX_DIOALIGN)
+TEST_F(HipFileHandle, UnregisteredFileDioOffsetAlignMatchesStatxDioOffsetAlign)
+{
+    int          open_fd{888888};
+    struct statx stxbuf {};
+    stxbuf.stx_mask             = STATX_TYPE | STATX_MODE | STATX_DIOALIGN;
+    stxbuf.stx_dio_offset_align = 1234;
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .open_fd(open_fd)
+        .statx(stxbuf)
+        .build();
+    UnregisteredFile uf{777777};
+    ASSERT_EQ(uf.m_dio_offset_align, 1234);
+
+    EXPECT_CALL(msys, close(open_fd));
+}
+#endif
+
 TEST_F(HipFileHandle, UnregisteredFileDioMemAlignIsPageSizeIfStatxDoesntHaveDioAlign)
 {
     int          open_fd{888888};
@@ -491,11 +512,34 @@ TEST_F(HipFileHandle, UnregisteredFileDioMemAlignIsPageSizeIfStatxDoesntHaveDioA
     EXPECT_CALL(msys, close(open_fd));
 }
 
+TEST_F(HipFileHandle, UnregisteredFileDioOffsetAlignIsPageSizeIfStatxDoesntHaveDioAlign)
+{
+    int          open_fd{888888};
+    struct statx stxbuf {};
+    stxbuf.stx_mask = STATX_TYPE | STATX_MODE;
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .open_fd(open_fd)
+        .statx(stxbuf)
+        .build();
+    UnregisteredFile uf{777777};
+    ASSERT_EQ(uf.m_dio_offset_align, 4096);
+
+    EXPECT_CALL(msys, close(open_fd));
+}
+
 TEST_F(HipFileHandle, UnregisteredFileDioMemAlignIsZeroIfUnableToOpenUnbufferedFd)
 {
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).fd_flags(~O_DIRECT).open_throws(EINVAL).build();
     UnregisteredFile uf{777777};
     ASSERT_EQ(uf.m_dio_mem_align, 0);
+}
+
+TEST_F(HipFileHandle, UnregisteredFileDioOffsetAlignIsZeroIfUnableToOpenUnbufferedFd)
+{
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).fd_flags(~O_DIRECT).open_throws(EINVAL).build();
+    UnregisteredFile uf{777777};
+    ASSERT_EQ(uf.m_dio_offset_align, 0);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -201,8 +201,6 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_EQ(fd, file->getClientFd());
     EXPECT_EQ(fd, file->getBufferedFd());
     EXPECT_EQ(open_fd, file->getUnbufferedFd());
-    auto file_stx{file->getStatx()};
-    EXPECT_EQ(0, memcmp(&file_stx, &stxbuf, sizeof(stxbuf)));
     EXPECT_EQ(fd_flags, file->getStatusFlags());
     EXPECT_EQ(mountinfo.type, file->getMountInfo().value().type);
     EXPECT_EQ(mountinfo.options.ext4.journaling_mode,

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -168,8 +168,14 @@ TEST_F(HipFileHandle, file_initialization)
 {
     int          fd{0x12345678};
     int          fd_flags{~O_DIRECT}; // All flags, except O_DIRECT, set
-    struct statx stxbuf;
-    memset(&stxbuf, 0xA5, sizeof(stxbuf));
+    struct statx stxbuf {};
+#if defined(STATX_DIOALIGN)
+    stxbuf.stx_mask             = STATX_TYPE | STATX_MODE | STATX_DIOALIGN;
+    stxbuf.stx_dio_mem_align    = 4;
+    stxbuf.stx_dio_offset_align = 512;
+#else
+    stxbuf.stx_mask = STATX_TYPE | STATX_MODE;
+#endif
 
     // In this test, the registered file is destroyed _after_ the mocks are
     // destroyed. Use an eventfd so that when FileDescriptor calls close, it
@@ -200,6 +206,11 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_EQ(mountinfo.type, file->getMountInfo().value().type);
     EXPECT_EQ(mountinfo.options.ext4.journaling_mode,
               file->getMountInfo().value().options.ext4.journaling_mode);
+#if defined(STATX_DIOALIGN)
+    EXPECT_EQ(file->dioMemAlign(), stxbuf.stx_dio_mem_align);
+#else
+    EXPECT_EQ(file->dioMemAlign(), 4096);
+#endif
 }
 
 TEST_F(HipFileHandle, register_handle_internal_linux_fd_already_registered)
@@ -443,6 +454,48 @@ TEST_F(HipFileHandle, UnregisteredFileConstructorThrowsOnErrOtherThanEinval)
 {
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).fd_flags(~O_DIRECT).open_throws(EPERM).build();
     ASSERT_THROW(UnregisteredFile{777777}, std::system_error);
+}
+
+#if defined(STATX_DIOALIGN)
+TEST_F(HipFileHandle, UnregisteredFileDioMemAlignMatchesStatxDioMemAlign)
+{
+    int          open_fd{888888};
+    struct statx stxbuf {};
+    stxbuf.stx_mask          = STATX_TYPE | STATX_MODE | STATX_DIOALIGN;
+    stxbuf.stx_dio_mem_align = 1234;
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .open_fd(open_fd)
+        .statx(stxbuf)
+        .build();
+    UnregisteredFile uf{777777};
+    ASSERT_EQ(uf.m_dio_mem_align, 1234);
+
+    EXPECT_CALL(msys, close(open_fd));
+}
+#endif
+
+TEST_F(HipFileHandle, UnregisteredFileDioMemAlignIsPageSizeIfStatxDoesntHaveDioAlign)
+{
+    int          open_fd{888888};
+    struct statx stxbuf {};
+    stxbuf.stx_mask = STATX_TYPE | STATX_MODE;
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .open_fd(open_fd)
+        .statx(stxbuf)
+        .build();
+    UnregisteredFile uf{777777};
+    ASSERT_EQ(uf.m_dio_mem_align, 4096);
+
+    EXPECT_CALL(msys, close(open_fd));
+}
+
+TEST_F(HipFileHandle, UnregisteredFileDioMemAlignIsZeroIfUnableToOpenUnbufferedFd)
+{
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper).fd_flags(~O_DIRECT).open_throws(EINVAL).build();
+    UnregisteredFile uf{777777};
+    ASSERT_EQ(uf.m_dio_mem_align, 0);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -200,7 +200,7 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_EQ(fh, file->getHandle());
     EXPECT_EQ(fd, file->getClientFd());
     EXPECT_EQ(fd, file->getBufferedFd());
-    EXPECT_EQ(open_fd, file->getUnbufferedFd());
+    EXPECT_EQ(open_fd, file->unbufferedFd());
 #if defined(STATX_DIOALIGN)
     EXPECT_EQ(file->dioMemAlign(), stxbuf.stx_dio_mem_align);
     EXPECT_EQ(file->dioOffsetAlign(), stxbuf.stx_dio_offset_align);

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -215,6 +215,7 @@ TEST_F(HipFileHandle, file_initialization)
     EXPECT_FALSE(file->isBlockDevice());
     EXPECT_TRUE(file->isRegularFile());
     EXPECT_TRUE(file->onExt4Ordered());
+    EXPECT_FALSE(file->onXfs());
 }
 
 TEST_F(HipFileHandle, register_handle_internal_linux_fd_already_registered)
@@ -752,4 +753,51 @@ TEST_F(HipFileHandle, OnExt4OrderedReturnsFalseForOtherFileSystem)
 
     EXPECT_FALSE(file->onExt4Ordered());
 }
+
+TEST_F(HipFileHandle, OnXfsReturnsTrueForXfs)
+{
+    int fd{0xBADF00D};
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    MountInfo mountinfo;
+    mountinfo.type = FilesystemType::xfs;
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .mountinfo(mountinfo)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_TRUE(file->onXfs());
+}
+
+TEST_F(HipFileHandle, OnXfsReturnsFalseForOtherFileSystem)
+{
+    int fd{0xBADF00D};
+
+    // Return an eventfd as the file descriptor for the bufferd fd open so that when
+    // FileDescriptor calls close, it has a valid file descriptor to close.
+    int open_fd{eventfd(0, 0)};
+    ASSERT_NE(open_fd, -1);
+
+    MountInfo mountinfo;
+    mountinfo.type = FilesystemType::other;
+
+    ExpectUnregisteredFileBuilder(msys, mlibmounthelper)
+        .fd_flags(O_DIRECT)
+        .mountinfo(mountinfo)
+        .open_fd(open_fd)
+        .build();
+    auto fh{Context<DriverState>::get()->registerFile(fd)};
+    auto file{Context<DriverState>::get()->getFile(fh)};
+
+    EXPECT_FALSE(file->onXfs());
+}
+
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/test/amd_detail/handle.cpp
+++ b/test/amd_detail/handle.cpp
@@ -197,7 +197,7 @@ TEST_F(HipFileHandle, file_initialization)
     auto fh{Context<DriverState>::get()->registerFile(fd)};
     auto file{Context<DriverState>::get()->getFile(fh)};
 
-    EXPECT_EQ(fh, file->getHandle());
+    EXPECT_EQ(fh, file->handle());
     EXPECT_EQ(fd, file->clientFd());
     EXPECT_EQ(fd, file->bufferedFd());
     EXPECT_EQ(open_fd, file->unbufferedFd());

--- a/test/amd_detail/mconfiguration.h
+++ b/test/amd_detail/mconfiguration.h
@@ -22,6 +22,7 @@ struct MConfiguration : Configuration {
     MOCK_METHOD(bool, fallback, (), (const, noexcept, override));
     MOCK_METHOD(void, fallback, (bool), (noexcept, override));
     MOCK_METHOD(unsigned int, statsLevel, (), (const, noexcept, override));
+    MOCK_METHOD(bool, unsupportedFileSystems, (), (const, noexcept, override));
 };
 
 }

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -25,6 +25,7 @@ public:
     MOCK_METHOD(const struct statx &, getStatx, (), (const, noexcept, override));
     MOCK_METHOD(int, getStatusFlags, (), (const, override));
     MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));
+    MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));
 };
 
 class MFileMap : public FileMap {

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -19,7 +19,7 @@ namespace hipFile {
 class MFile : public IFile {
 public:
     MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
-    MOCK_METHOD(int, getClientFd, (), (const, override));
+    MOCK_METHOD(int, getClientFd, (), (const, noexcept, override));
     MOCK_METHOD(int, bufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(std::optional<int>, unbufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -20,7 +20,7 @@ class MFile : public IFile {
 public:
     MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
     MOCK_METHOD(int, getClientFd, (), (const, override));
-    MOCK_METHOD(int, getBufferedFd, (), (const, override));
+    MOCK_METHOD(int, getBufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(std::optional<int>, unbufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioOffsetAlign, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -28,6 +28,7 @@ public:
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioOffsetAlign, (), (const, noexcept, override));
     MOCK_METHOD(bool, isBlockDevice, (), (const, noexcept, override));
+    MOCK_METHOD(bool, isRegularFile, (), (const, noexcept, override));
 };
 
 class MFileMap : public FileMap {

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -22,7 +22,6 @@ public:
     MOCK_METHOD(int, getClientFd, (), (const, override));
     MOCK_METHOD(int, getBufferedFd, (), (const, override));
     MOCK_METHOD(std::optional<int>, getUnbufferedFd, (), (const, override));
-    MOCK_METHOD(int, getStatusFlags, (), (const, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioOffsetAlign, (), (const, noexcept, override));
     MOCK_METHOD(bool, isBlockDevice, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -28,6 +28,7 @@ public:
     MOCK_METHOD(uint32_t, dioOffsetAlign, (), (const, noexcept, override));
     MOCK_METHOD(bool, isBlockDevice, (), (const, noexcept, override));
     MOCK_METHOD(bool, isRegularFile, (), (const, noexcept, override));
+    MOCK_METHOD(bool, onExt4Ordered, (), (const, noexcept, override));
 };
 
 class MFileMap : public FileMap {

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -19,7 +19,7 @@ namespace hipFile {
 class MFile : public IFile {
 public:
     MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
-    MOCK_METHOD(int, getClientFd, (), (const, noexcept, override));
+    MOCK_METHOD(int, clientFd, (), (const, noexcept, override));
     MOCK_METHOD(int, bufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(std::optional<int>, unbufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -22,7 +22,6 @@ public:
     MOCK_METHOD(int, getClientFd, (), (const, override));
     MOCK_METHOD(int, getBufferedFd, (), (const, override));
     MOCK_METHOD(std::optional<int>, getUnbufferedFd, (), (const, override));
-    MOCK_METHOD(const struct statx &, getStatx, (), (const, noexcept, override));
     MOCK_METHOD(int, getStatusFlags, (), (const, override));
     MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -18,7 +18,7 @@ namespace hipFile {
 
 class MFile : public IFile {
 public:
-    MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
+    MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, noexcept, override));
     MOCK_METHOD(int, clientFd, (), (const, noexcept, override));
     MOCK_METHOD(int, bufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(std::optional<int>, unbufferedFd, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -18,7 +18,7 @@ namespace hipFile {
 
 class MFile : public IFile {
 public:
-    MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, noexcept, override));
+    MOCK_METHOD(hipFileHandle_t, handle, (), (const, noexcept, override));
     MOCK_METHOD(int, clientFd, (), (const, noexcept, override));
     MOCK_METHOD(int, bufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(std::optional<int>, unbufferedFd, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -26,6 +26,7 @@ public:
     MOCK_METHOD(int, getStatusFlags, (), (const, override));
     MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));
+    MOCK_METHOD(uint32_t, dioOffsetAlign, (), (const, noexcept, override));
 };
 
 class MFileMap : public FileMap {

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -23,7 +23,6 @@ public:
     MOCK_METHOD(int, getBufferedFd, (), (const, override));
     MOCK_METHOD(std::optional<int>, getUnbufferedFd, (), (const, override));
     MOCK_METHOD(int, getStatusFlags, (), (const, override));
-    MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioOffsetAlign, (), (const, noexcept, override));
     MOCK_METHOD(bool, isBlockDevice, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -27,6 +27,7 @@ public:
     MOCK_METHOD(std::optional<MountInfo>, getMountInfo, (), (const, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioOffsetAlign, (), (const, noexcept, override));
+    MOCK_METHOD(bool, isBlockDevice, (), (const, noexcept, override));
 };
 
 class MFileMap : public FileMap {

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -21,7 +21,7 @@ public:
     MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
     MOCK_METHOD(int, getClientFd, (), (const, override));
     MOCK_METHOD(int, getBufferedFd, (), (const, override));
-    MOCK_METHOD(std::optional<int>, getUnbufferedFd, (), (const, override));
+    MOCK_METHOD(std::optional<int>, getUnbufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioOffsetAlign, (), (const, noexcept, override));
     MOCK_METHOD(bool, isBlockDevice, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -21,7 +21,7 @@ public:
     MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
     MOCK_METHOD(int, getClientFd, (), (const, override));
     MOCK_METHOD(int, getBufferedFd, (), (const, override));
-    MOCK_METHOD(std::optional<int>, getUnbufferedFd, (), (const, noexcept, override));
+    MOCK_METHOD(std::optional<int>, unbufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioOffsetAlign, (), (const, noexcept, override));
     MOCK_METHOD(bool, isBlockDevice, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -20,7 +20,7 @@ class MFile : public IFile {
 public:
     MOCK_METHOD(hipFileHandle_t, getHandle, (), (const, override));
     MOCK_METHOD(int, getClientFd, (), (const, override));
-    MOCK_METHOD(int, getBufferedFd, (), (const, noexcept, override));
+    MOCK_METHOD(int, bufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(std::optional<int>, unbufferedFd, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioMemAlign, (), (const, noexcept, override));
     MOCK_METHOD(uint32_t, dioOffsetAlign, (), (const, noexcept, override));

--- a/test/amd_detail/mfile.h
+++ b/test/amd_detail/mfile.h
@@ -29,6 +29,7 @@ public:
     MOCK_METHOD(bool, isBlockDevice, (), (const, noexcept, override));
     MOCK_METHOD(bool, isRegularFile, (), (const, noexcept, override));
     MOCK_METHOD(bool, onExt4Ordered, (), (const, noexcept, override));
+    MOCK_METHOD(bool, onXfs, (), (const, noexcept, override));
 };
 
 class MFileMap : public FileMap {


### PR DESCRIPTION
## Motivation

Currently, hipFile has only been tested with block devices and regular files on ext4(ordered) or xfs file systems. This change updates `Fastpath::score()` to accept IO operations that target block devices or files backed by ext4(ordered) or xfs.

## Technical Details

When a file is registered, hipFile will cache file type and mount information. `Fastpath::score()` will use the cached information to determine if it will accept an IO. 

If `HIPFILE_UNSUPPORTED_FILE_SYSTEMS=true` is set in the environment, then `Fastpath::score` will allow IO to regular files on unsupported filesystems.

AIHIPFILE-114
