### PR TITLE
Add ais_add_test_executable() to CMake

### DIFF
--- a/cmake/AISAddExecutable.cmake
+++ b/cmake/AISAddExecutable.cmake
@@ -87,14 +87,18 @@ endfunction()
 #       always have assert() available.
 function(ais_add_test_executable)
 
-    ais_add_executable(${ARGV})
-
     # Parse arguments
     set(options) # None at this time
-    set(oneValueArgs NAME PLATFORM)
+    set(oneValueArgs NAME)
     set(multiValueArgs SRCS DEPS SYSINCLS)
     cmake_parse_arguments(arg "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
+    ais_add_executable(
+        NAME     ${arg_NAME}
+        DEPS     ${arg_DEPS}
+        SRCS     ${arg_SRCS}
+        SYSINCLS ${arg_SYSINCLS}
+    )
     target_compile_options(${arg_NAME} PRIVATE -UNDEBUG)
 
 endfunction()

--- a/cmake/AISAddExecutable.cmake
+++ b/cmake/AISAddExecutable.cmake
@@ -74,3 +74,27 @@ function(ais_add_executable)
 
     target_include_directories(${arg_NAME} PRIVATE "${HIPFILE_ROOT_PATH}/shared")
 endfunction()
+
+# Add an executable test program using AIS build conventions
+#
+# Parameters:
+#   NAME     <name>                             The name of the executable program to create
+#   DEPS     [dependency1 [dependency2 ...]]    List of AIS target library dependencies
+#   SRCS     [src1 [src2 ...]]                  The source files
+#   SYSINCLS [path1 [path2 ...]]                Paths to include dirs
+#
+# NOTE: Simply a pass-through to add -UNDEBUG to test programs so they
+#       always have assert() available.
+function(ais_add_test_executable)
+
+    ais_add_executable(${ARGV})
+
+    # Parse arguments
+    set(options) # None at this time
+    set(oneValueArgs NAME PLATFORM)
+    set(multiValueArgs SRCS DEPS SYSINCLS)
+    cmake_parse_arguments(arg "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    target_compile_options(${arg_NAME} PRIVATE -UNDEBUG)
+
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,14 +41,11 @@ else()
     list(APPEND TEST_SYSINCLS ${HIPFILE_AMD_SOURCE_PATH})
 endif()
 
-ais_add_executable(
+ais_add_test_executable(
     NAME hipfile_tests
     DEPS hipfile
     SRCS ${UNIT_TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
     SYSINCLS ${TEST_SYSINCLS}
-)
-target_compile_options(hipfile_tests
-    PRIVATE -UNDEBUG -Wno-unused-function
 )
 target_link_libraries(hipfile_tests PRIVATE GTest::gtest)
 target_link_libraries(hipfile_tests PRIVATE GTest::gtest_main)
@@ -59,13 +56,12 @@ ais_gtest_discover_tests(
     TEST_LIST hipfile_unit_tests
 )
 
-ais_add_executable(
+ais_add_test_executable(
     NAME hipfile_system_tests
     DEPS hipfile
     SRCS ${SYSTEM_TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
     SYSINCLS ${TEST_SYSINCLS}
 )
-target_compile_options(hipfile_system_tests PRIVATE -UNDEBUG)
 target_link_libraries(hipfile_system_tests PRIVATE GTest::gtest)
 target_link_libraries(hipfile_system_tests PRIVATE Boost::program_options)
 
@@ -79,12 +75,12 @@ ais_gtest_discover_tests(
 # Temporary Test Files
 # Can be deleted once proper testing added
 # ----------------------------------------
-ais_add_executable(
+ais_add_test_executable(
     NAME test_hipfile_basic
     SRCS legacy/test-hipfile.cpp
     DEPS hipfile
 )
-ais_add_executable(
+ais_add_test_executable(
     NAME test_hipfile_batch
     SRCS legacy/test-hipfile-batch.cpp
     DEPS hipfile

--- a/test/amd_detail/CMakeLists.txt
+++ b/test/amd_detail/CMakeLists.txt
@@ -38,13 +38,12 @@ set(TEST_SYSINCLS
     ${HIPFILE_AMD_TEST_PATH}
 )
 
-ais_add_executable(
+ais_add_test_executable(
     NAME internal_tests
     DEPS hipfile
     SRCS ${TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
     SYSINCLS ${TEST_SYSINCLS}
 )
-target_compile_options(internal_tests PRIVATE -UNDEBUG)
 
 # Add gtest
 target_link_libraries(internal_tests PRIVATE GTest::gmock)
@@ -63,7 +62,7 @@ ais_gtest_discover_tests(
 # so test failures may not be due to the commit in which you
 # observe the failure.
 
-ais_add_executable(
+ais_add_test_executable(
     NAME state_mt
     DEPS hipfile
     SRCS "state_mt.cpp"
@@ -73,10 +72,9 @@ add_test(
     NAME state_mt_test
     COMMAND gdb --batch --quiet -ex run -ex "thread apply all bt full" --return-child-result --args $<TARGET_FILE:state_mt>
 )
-target_compile_options(state_mt PRIVATE -UNDEBUG)
 set_tests_properties(state_mt_test PROPERTIES LABELS "stress;internal")
 
-ais_add_executable(
+ais_add_test_executable(
     NAME batch_mt
     DEPS hipfile
     SRCS "batch/batch_mt.cpp"
@@ -86,5 +84,4 @@ add_test(
     NAME batch_mt_test
     COMMAND gdb --batch --quiet -ex run -ex "thread apply all bt full" --return-child-result --args $<TARGET_FILE:batch_mt>
 )
-target_compile_options(batch_mt PRIVATE -UNDEBUG)
 set_tests_properties(batch_mt_test PROPERTIES LABELS "stress;internal")


### PR DESCRIPTION
Adds -UNDEBUG all test executables, ensuring assert() exists, and avoiding duplicate target_compile_options() statements.