### PR TITLE
Fix high-severity Coverity issues

### DIFF
--- a/src/amd_detail/stats.cpp
+++ b/src/amd_detail/stats.cpp
@@ -146,7 +146,23 @@ StatsServer::threadFn()
     }
     while (true) {
         pollfd pfd[2]{{sock, POLLIN, 0}, {m_efd.get(), POLLIN, 0}};
-        poll(&pfd[0], 2, -1);
+
+        int ret = poll(&pfd[0], 2, -1);
+
+        if (ret == 0) {
+            continue;
+        }
+        else if (ret < 0) {
+            if (errno == EINTR) {
+                // Signal interrupt
+                continue;
+            }
+            else {
+                // Badness
+                break;
+            }
+        }
+
         if (pfd[0].revents & POLLIN) {
             socklen_t addrlen{sizeof(addr)};
             int       conn{accept(sock, reinterpret_cast<sockaddr *>(&addr), &addrlen)};

--- a/src/amd_detail/stats.cpp
+++ b/src/amd_detail/stats.cpp
@@ -134,15 +134,15 @@ StatsServer::threadFn()
     int   sock{socket(AF_UNIX, SOCK_STREAM, 0)};
     pid_t pid{getpid()};
     if (sock == -1) {
-        return;
+        goto out;
     }
     sockaddr_un addr;
     populateSocketAddr(addr, pid);
     if (bind(sock, reinterpret_cast<const sockaddr *>(&addr), sizeof(addr)) == -1) {
-        return;
+        goto out;
     }
     if (listen(sock, 64) == -1) {
-        return;
+        goto out;
     }
     while (true) {
         pollfd pfd[2]{{sock, POLLIN, 0}, {m_efd.get(), POLLIN, 0}};
@@ -160,7 +160,11 @@ StatsServer::threadFn()
             break;
         }
     }
-    close(sock);
+
+out:
+    if (sock != -1) {
+        close(sock);
+    }
 }
 
 StatsClient::StatsClient(pid_t p)

--- a/src/amd_detail/stats.cpp
+++ b/src/amd_detail/stats.cpp
@@ -23,12 +23,12 @@ sendFd(int sock, int fd) noexcept
     int      data{1};
     iovec    iov{&data, sizeof(data)};
     msghdr   msgh{};
-    cmsghdr *cmsgp = nullptr;
+    cmsghdr *cmsgp{};
 
     union {
         char    buff[CMSG_SPACE(sizeof(int))];
         cmsghdr align;
-    } controlMsg;
+    } controlMsg{};
 
     msgh.msg_name       = nullptr;
     msgh.msg_namelen    = 0;
@@ -56,12 +56,12 @@ recvFd(int sockfd) noexcept
     int      data, fd;
     iovec    iov{&data, sizeof(data)};
     msghdr   msgh{};
-    cmsghdr *cmsgp = nullptr;
+    cmsghdr *cmsgp{};
 
     union {
         char    buff[CMSG_SPACE(sizeof(int))];
         cmsghdr align;
-    } controlMsg;
+    } controlMsg{};
 
     msgh.msg_name       = nullptr;
     msgh.msg_namelen    = 0;

--- a/src/amd_detail/stats.cpp
+++ b/src/amd_detail/stats.cpp
@@ -131,21 +131,21 @@ StatsServer::statsDeleter(Stats *s)
 void
 StatsServer::threadFn()
 {
-    int   sock{socket(AF_UNIX, SOCK_STREAM, 0)};
-    pid_t pid{getpid()};
-    if (sock == -1) {
-        goto out;
+    FileDescriptor sock{FileDescriptor::make_managed(socket(AF_UNIX, SOCK_STREAM, 0))};
+    pid_t          pid{getpid()};
+    if (sock.get() == -1) {
+        return;
     }
     sockaddr_un addr;
     populateSocketAddr(addr, pid);
-    if (bind(sock, reinterpret_cast<const sockaddr *>(&addr), sizeof(addr)) == -1) {
-        goto out;
+    if (bind(sock.get(), reinterpret_cast<const sockaddr *>(&addr), sizeof(addr)) == -1) {
+        return;
     }
-    if (listen(sock, 64) == -1) {
-        goto out;
+    if (listen(sock.get(), 64) == -1) {
+        return;
     }
     while (true) {
-        pollfd pfd[2]{{sock, POLLIN, 0}, {m_efd.get(), POLLIN, 0}};
+        pollfd pfd[2]{{sock.get(), POLLIN, 0}, {m_efd.get(), POLLIN, 0}};
 
         int ret = poll(&pfd[0], 2, -1);
 
@@ -165,7 +165,7 @@ StatsServer::threadFn()
 
         if (pfd[0].revents & POLLIN) {
             socklen_t addrlen{sizeof(addr)};
-            int       conn{accept(sock, reinterpret_cast<sockaddr *>(&addr), &addrlen)};
+            int       conn{accept(sock.get(), reinterpret_cast<sockaddr *>(&addr), &addrlen)};
             if (conn == -1) {
                 continue;
             }
@@ -175,11 +175,6 @@ StatsServer::threadFn()
         if (pfd[1].revents & (POLLIN | POLLERR | POLLNVAL)) {
             break;
         }
-    }
-
-out:
-    if (sock != -1) {
-        close(sock);
     }
 }
 

--- a/src/amd_detail/stats.cpp
+++ b/src/amd_detail/stats.cpp
@@ -22,8 +22,8 @@ sendFd(int sock, int fd) noexcept
 {
     int      data{1};
     iovec    iov{&data, sizeof(data)};
-    msghdr   msgh;
-    cmsghdr *cmsgp;
+    msghdr   msgh{};
+    cmsghdr *cmsgp = nullptr;
 
     union {
         char    buff[CMSG_SPACE(sizeof(int))];
@@ -36,6 +36,7 @@ sendFd(int sock, int fd) noexcept
     msgh.msg_iovlen     = 1;
     msgh.msg_control    = controlMsg.buff;
     msgh.msg_controllen = sizeof(controlMsg.buff);
+    msgh.msg_flags      = 0;
 
     cmsgp             = CMSG_FIRSTHDR(&msgh);
     cmsgp->cmsg_level = SOL_SOCKET;
@@ -54,8 +55,8 @@ recvFd(int sockfd) noexcept
 {
     int      data, fd;
     iovec    iov{&data, sizeof(data)};
-    msghdr   msgh;
-    cmsghdr *cmsgp;
+    msghdr   msgh{};
+    cmsghdr *cmsgp = nullptr;
 
     union {
         char    buff[CMSG_SPACE(sizeof(int))];
@@ -68,6 +69,7 @@ recvFd(int sockfd) noexcept
     msgh.msg_iovlen     = 1;
     msgh.msg_control    = controlMsg.buff;
     msgh.msg_controllen = sizeof(controlMsg.buff);
+    msgh.msg_flags      = 0;
 
     if (recvmsg(sockfd, &msgh, 0) == -1)
         return -1;

--- a/test/amd_detail/file-descriptor.cpp
+++ b/test/amd_detail/file-descriptor.cpp
@@ -41,6 +41,8 @@ TEST_F(HipFileFileDescriptor, ManagedFileDescriptorMoveCopyConstructor)
 {
     auto fd_a{FileDescriptor::make_managed(42)};
     auto fd_b{std::move(fd_a)};
+
+    // coverity[USE_AFTER_MOVE]
     ASSERT_EQ(fd_a.get(), -1); // NOLINT(clang-analyzer-cplusplus.Move)
     ASSERT_EQ(fd_b.get(), 42);
     EXPECT_CALL(msys, close(42));
@@ -50,6 +52,8 @@ TEST_F(HipFileFileDescriptor, UnmanagedFileDescriptorMoveCopyConstructor)
 {
     auto fd_a{FileDescriptor::make_unmanaged(42)};
     auto fd_b{std::move(fd_a)};
+
+    // coverity[USE_AFTER_MOVE]
     ASSERT_EQ(fd_a.get(), -1); // NOLINT(clang-analyzer-cplusplus.Move)
     ASSERT_EQ(fd_b.get(), 42);
 }
@@ -60,6 +64,8 @@ TEST_F(HipFileFileDescriptor, ManagedFileDescriptorToManagedFileDescriptorMoveAs
     auto fd_b{FileDescriptor::make_managed(12)};
     EXPECT_CALL(msys, close(12));
     fd_b = std::move(fd_a);
+
+    // coverity[USE_AFTER_MOVE]
     ASSERT_EQ(fd_a.get(), -1); // NOLINT(clang-analyzer-cplusplus.Move)
     ASSERT_EQ(fd_b.get(), 42);
     EXPECT_CALL(msys, close(42));
@@ -70,6 +76,8 @@ TEST_F(HipFileFileDescriptor, ManagedFileDescriptorToUnmanagedFileDescriptorMove
     auto fd_a{FileDescriptor::make_managed(42)};
     auto fd_b{FileDescriptor::make_unmanaged(12)};
     fd_b = std::move(fd_a);
+
+    // coverity[USE_AFTER_MOVE]
     ASSERT_EQ(fd_a.get(), -1); // NOLINT(clang-analyzer-cplusplus.Move)
     ASSERT_EQ(fd_b.get(), 42);
     EXPECT_CALL(msys, close(42));
@@ -81,6 +89,8 @@ TEST_F(HipFileFileDescriptor, UnmanagedFileDescriptorToManagedFileDescriptorMove
     auto fd_b{FileDescriptor::make_managed(12)};
     EXPECT_CALL(msys, close(12));
     fd_b = std::move(fd_a);
+
+    // coverity[USE_AFTER_MOVE]
     ASSERT_EQ(fd_a.get(), -1); // NOLINT(clang-analyzer-cplusplus.Move)
     ASSERT_EQ(fd_b.get(), 42);
 }
@@ -90,6 +100,8 @@ TEST_F(HipFileFileDescriptor, UnmanagedFileDescriptorToUnmanagedFileDescriptorMo
     auto fd_a{FileDescriptor::make_unmanaged(42)};
     auto fd_b{FileDescriptor::make_unmanaged(12)};
     fd_b = std::move(fd_a);
+
+    // coverity[USE_AFTER_MOVE]
     ASSERT_EQ(fd_a.get(), -1); // NOLINT(clang-analyzer-cplusplus.Move)
     ASSERT_EQ(fd_b.get(), 42);
 }

--- a/test/amd_detail/stats.cpp
+++ b/test/amd_detail/stats.cpp
@@ -55,7 +55,7 @@ TEST_F(HipFileStats, StatsServerLifetime)
     EXPECT_CALL(msys, ftruncate);
     EXPECT_CALL(msys, mmap).WillOnce(testing::Return(&buff));
     EXPECT_CALL(msys, munmap);
-    EXPECT_CALL(msys, close).Times(2);
+    EXPECT_CALL(msys, close).Times(3);
     EXPECT_CALL(mcfg, statsLevel()).WillOnce(testing::Return(1));
     StatsServer srvr{};
 }


### PR DESCRIPTION
Fixes a couple of high-severity issues identified by Coverity Scan

* Marks use-after-move as intentional in the file descriptor tests
* Fully initialize a struct in the stats code
* Ensure a socket is cleaned up on errors in `StatsServer::threadFn()`
* Check the return value from poll(2) in stats.cpp

Part of AIHIPFILE-161