### PR TITLE
Coverity: Set umask 0077 before creating tmp files

### DIFF
--- a/test/amd_detail/state_mt.cpp
+++ b/test/amd_detail/state_mt.cpp
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <utility>
 #include <sys/resource.h>
+#include <sys/stat.h>
 #include <vector>
 
 using namespace hipFile;

--- a/test/amd_detail/state_mt.cpp
+++ b/test/amd_detail/state_mt.cpp
@@ -49,6 +49,10 @@ static atomic<bool> run_flag{true};
 static int
 make_temp_file()
 {
+    // Security analyzers will be sad if you don't set umask 0077
+    // before creating temporary files
+    mode_t old_umask = umask(S_IRWXG | S_IRWXO);
+
     // Create a unique temporary file
     char pathname[]{"state_mt_tmp.XXXXXX"};
     int  fd{mkstemp(pathname)};
@@ -56,6 +60,8 @@ make_temp_file()
         cerr << "mkstemp() failed! " << strerror(errno) << endl;
         exit(EXIT_FAILURE);
     }
+
+    umask(old_umask);
 
     // Ensure the file is deleted when fd is closed
     if (-1 == unlink(pathname)) {

--- a/test/amd_detail/state_mt.cpp
+++ b/test/amd_detail/state_mt.cpp
@@ -50,10 +50,6 @@ static atomic<bool> run_flag{true};
 static int
 make_temp_file()
 {
-    // Security analyzers will be sad if you don't set umask 0077
-    // before creating temporary files
-    mode_t old_umask = umask(S_IRWXG | S_IRWXO);
-
     // Create a unique temporary file
     char pathname[]{"state_mt_tmp.XXXXXX"};
     int  fd{mkstemp(pathname)};
@@ -61,8 +57,6 @@ make_temp_file()
         cerr << "mkstemp() failed! " << strerror(errno) << endl;
         exit(EXIT_FAILURE);
     }
-
-    umask(old_umask);
 
     // Ensure the file is deleted when fd is closed
     if (-1 == unlink(pathname)) {
@@ -376,6 +370,15 @@ thread_function(int id)
 int
 main()
 {
+    // Security analyzers will be sad if you don't set umask 0077
+    // before creating temporary files
+    //
+    // Doing this here to avoid inadvertently synchronizing files if we
+    // added a mutex in the temp file function
+    //
+    // Ignoring return type since we never switch it back
+    (void)umask(S_IRWXG | S_IRWXO);
+
     struct rlimit nofile;
     if (-1 == getrlimit(RLIMIT_NOFILE, &nofile)) {
         cerr << "getrlimit() failed! " << strerror(errno) << endl;

--- a/test/common/test-common.h
+++ b/test/common/test-common.h
@@ -69,6 +69,7 @@ struct Tmpfile {
 
         path += "/hipFile.XXXXXX";
         if ((fd = mkstemp(path.data())) == -1) {
+            umask(old_umask);
             throw std::runtime_error("Could not create temporary file");
         }
 

--- a/test/common/test-common.h
+++ b/test/common/test-common.h
@@ -61,6 +61,10 @@ struct Tmpfile {
     {
     }
 
+    /*!
+     * \warning The constructor is NOT thread-safe and can result in
+     *          interleaved calls to `umask()`
+     */
     Tmpfile(std::string directory) : path{directory}
     {
         // Security analyzers will be sad if you don't set umask 0077

--- a/test/common/test-common.h
+++ b/test/common/test-common.h
@@ -81,6 +81,7 @@ struct Tmpfile {
 
 #ifdef __HIP_PLATFORM_AMD__
         if (unlink(path.c_str()) == -1) {
+            close(fd);
             throw std::runtime_error("Could not unlink temporary file");
         }
 #endif

--- a/test/common/test-common.h
+++ b/test/common/test-common.h
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <random>
 #include <stdexcept>
+#include <sys/stat.h>
 #include <unistd.h>
 
 constexpr hipFileError_t
@@ -62,10 +63,16 @@ struct Tmpfile {
 
     Tmpfile(std::string directory) : path{directory}
     {
+        // Security analyzers will be sad if you don't set umask 0077
+        // before creating temporary files
+        mode_t old_umask = umask(S_IRWXG | S_IRWXO);
+
         path += "/hipFile.XXXXXX";
         if ((fd = mkstemp(path.data())) == -1) {
             throw std::runtime_error("Could not create temporary file");
         }
+
+        umask(old_umask);
 
 #ifdef __HIP_PLATFORM_AMD__
         if (unlink(path.c_str()) == -1) {


### PR DESCRIPTION
Coverity points out that it's a potential security problem if you create tmp files with group and world permissions.

Adds umask calls to state_mt and the common test header.

Part of AIHIPFILE-161