### PR TITLE
ASAN: Fix a potential integer overflow in Buffer

### DIFF
--- a/src/amd_detail/buffer.cpp
+++ b/src/amd_detail/buffer.cpp
@@ -26,8 +26,16 @@ isValidBufferRegion(void *ptr, size_t length)
 
     try {
         HipMemAddressRange buffer_range = Context<Hip>::get()->hipMemGetAddressRange(ptr);
-        if (uptr + length < uptr ||
-            uptr + length > reinterpret_cast<uintptr_t>(buffer_range.base) + buffer_range.size) {
+        uintptr_t          base         = reinterpret_cast<uintptr_t>(buffer_range.base);
+
+        // Overflow check
+        // Do this before the addition, so the sanitizers don't complain
+        // about integer overflow
+        if (length > std::numeric_limits<uintptr_t>::max() - uptr) {
+            return false;
+        }
+
+        if (uptr + length > base + buffer_range.size) {
             return false;
         }
     }

--- a/src/amd_detail/buffer.cpp
+++ b/src/amd_detail/buffer.cpp
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 #include <hip/hip_runtime_api.h>
+#include <limits>
 #include <stdexcept>
 #include <syslog.h>
 #include <utility>

--- a/src/amd_detail/buffer.cpp
+++ b/src/amd_detail/buffer.cpp
@@ -36,6 +36,9 @@ isValidBufferRegion(void *ptr, size_t length)
             return false;
         }
 
+        // Don't need to check base + buffer_range.size since
+        // HIP shouldn't give us invalid values
+
         if (uptr + length > base + buffer_range.size) {
             return false;
         }


### PR DESCRIPTION
The integer/undefined behavior sanitizer complains that an unsigned addition can overflow. This PR moves the overflow check to before doing the addition that can overflow.

Part of AIHIPFILE-154