### PR TITLE
Coverity: Move instead of copy things that can be moved

### DIFF
--- a/src/amd_detail/async.cpp
+++ b/src/amd_detail/async.cpp
@@ -94,7 +94,7 @@ AsyncMonitor::completion_thread()
 AsyncOp::AsyncOp(IoType _io_type, std::shared_ptr<IFile> _file, std::shared_ptr<IBuffer> _buffer,
                  std::shared_ptr<IStream> _stream, size_t *_size, hoff_t *_file_offset,
                  hoff_t *_buffer_offset, ssize_t *_bytes_transferred)
-    : io_type{_io_type}, file{_file}, buffer{_buffer}, stream{_stream},
+    : io_type{_io_type}, file{std::move(_file)}, buffer{std::move(_buffer)}, stream{std::move(_stream)},
 
       size{stream->fixedIOSize() ? std::variant<size_t, size_t *>{*_size}
                                  : std::variant<size_t, size_t *>{_size}},

--- a/src/amd_detail/backend/asyncop-fallback.cpp
+++ b/src/amd_detail/backend/asyncop-fallback.cpp
@@ -42,7 +42,8 @@ AsyncOpFallback::AsyncOpFallback(IoType _io_type, std::shared_ptr<IFile> _file,
                                  std::shared_ptr<IBuffer> _buffer, std::shared_ptr<IStream> _stream,
                                  size_t *_size, hoff_t *_file_offset, hoff_t *_buffer_offset,
                                  ssize_t *_bytes_transferred)
-    : AsyncOp{_io_type, _file, _buffer, _stream, _size, _file_offset, _buffer_offset, _bytes_transferred},
+    : AsyncOp{_io_type, std::move(_file), std::move(_buffer), std::move(_stream),
+              _size,    _file_offset,     _buffer_offset,     _bytes_transferred},
       submitted_size{std::min(*_size, hipFile::getMaxRwCount())}, bytes_transferred_internal{0},
       gpu_buffer{buffer->getBuffer()}, bounce_buffer_dev_ptr{nullptr},
       bounce_buffer{nullptr, [](void *addr) { (void)addr; }}

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -56,8 +56,7 @@ ssize_t
 Fallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
              hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size)
 {
-    return _io_impl(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset,
-                    chunk_size);
+    return _io_impl(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset, chunk_size);
 }
 
 ssize_t

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -56,7 +56,8 @@ ssize_t
 Fallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
              hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size)
 {
-    return _io_impl(type, file, buffer, size, file_offset, buffer_offset, chunk_size);
+    return _io_impl(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset,
+                    chunk_size);
 }
 
 ssize_t
@@ -164,7 +165,7 @@ Fallback::async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBu
     }
 
     auto op = std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback(
-        type, file, buffer, stream, size_p, file_offset_p, buffer_offset_p, bytes_transferred_p));
+        type, std::move(file), buffer, stream, size_p, file_offset_p, buffer_offset_p, bytes_transferred_p));
     Context<AsyncMonitor>::get()->addOp(op);
     auto  op_dev_ptr     = op->devPtr();
     void *kernel_args[1] = {&op_dev_ptr};

--- a/src/amd_detail/buffer.cpp
+++ b/src/amd_detail/buffer.cpp
@@ -128,7 +128,7 @@ BufferMap::registerBuffer(const void *buf, size_t length, int flags)
     }
 
     auto buffer   = std::shared_ptr<IBuffer>(new Buffer(buf, length, flags, PassKey<BufferMap>{}));
-    from_ptr[buf] = buffer;
+    from_ptr[buf] = std::move(buffer);
 }
 
 void

--- a/test/amd_detail/fallback.cpp
+++ b/test/amd_detail/fallback.cpp
@@ -287,7 +287,7 @@ TEST_P(FallbackParam, FallbackIoTruncatesSizeToMAX_RW_COUNT)
 
     EXPECT_CALL(msys, munmap);
     ASSERT_EQ(hipFile::getMaxRwCount(),
-              Fallback().io(io_type, file, big_buffer, SIZE_MAX, 0, 0, 16 * 1024 * 1024));
+              Fallback().io(io_type, file, std::move(big_buffer), SIZE_MAX, 0, 0, 16 * 1024 * 1024));
 }
 
 TEST_P(FallbackParam, FallbackIoThrowsOnBounceBufferAllocationFailure)

--- a/test/amd_detail/hipfile-api.cpp
+++ b/test/amd_detail/hipfile-api.cpp
@@ -243,7 +243,7 @@ TEST_P(HipFileIoBackendSelectionParam, HipFileIoThrowsIfThereAreNoBackends)
     auto backends{std::vector<std::shared_ptr<Backend>>()};
 
     EXPECT_CALL(mds, getFileAndBuffer(handle, buffer)).WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
-    EXPECT_CALL(mds, getBackends).WillOnce(Return(backends));
+    EXPECT_CALL(mds, getBackends).WillOnce(Return(std::move(backends)));
 
     switch (io_type) {
         case IoType::Read:
@@ -264,7 +264,7 @@ TEST_P(HipFileIoBackendSelectionParam, HipFileIoThrowsIfAllBackendsRejectTheIO)
     std::vector<std::shared_ptr<Backend>> backends{mbe1, mbe2, mbe3};
 
     EXPECT_CALL(mds, getFileAndBuffer(handle, buffer)).WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
-    EXPECT_CALL(mds, getBackends).WillOnce(Return(backends));
+    EXPECT_CALL(mds, getBackends).WillOnce(Return(std::move(backends)));
     EXPECT_CALL(*mbe1, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
         .WillOnce(Return(-1));
     EXPECT_CALL(*mbe2, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
@@ -291,7 +291,7 @@ TEST_P(HipFileIoBackendSelectionParam, HipFileIoIssuesIoToHighestScoringBackend)
     std::vector<std::shared_ptr<Backend>> backends{mbe1, mbe2, mbe3};
 
     EXPECT_CALL(mds, getFileAndBuffer(handle, buffer)).WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
-    EXPECT_CALL(mds, getBackends).WillOnce(Return(backends));
+    EXPECT_CALL(mds, getBackends).WillOnce(Return(std::move(backends)));
     EXPECT_CALL(*mbe1, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
         .WillOnce(Return(0));
     EXPECT_CALL(*mbe2, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))

--- a/test/common/test-common.h
+++ b/test/common/test-common.h
@@ -65,7 +65,7 @@ struct Tmpfile {
      * \warning The constructor is NOT thread-safe and can result in
      *          interleaved calls to `umask()`
      */
-    Tmpfile(std::string directory) : path{directory}
+    Tmpfile(std::string directory) : path{std::move(directory)}
     {
         // Security analyzers will be sad if you don't set umask 0077
         // before creating temporary files


### PR DESCRIPTION
Mainly shared pointers. Lower priority issues noted by Coverity.

Part of AIHIPFILE-161