### PR TITLE
Coverity: More std::move() for shared pointers

### DIFF
--- a/src/amd_detail/backend.cpp
+++ b/src/amd_detail/backend.cpp
@@ -22,7 +22,7 @@ ssize_t
 Backend::io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
             hoff_t file_offset, hoff_t buffer_offset)
 {
-    return _io_impl(type, file, buffer, size, file_offset, buffer_offset);
+    return _io_impl(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset);
 }
 
 ssize_t
@@ -42,7 +42,8 @@ BackendWithFallback::io(IoType type, std::shared_ptr<IFile> file, std::shared_pt
         std::exception_ptr e_ptr = std::current_exception();
         if (fallback_backend && is_fallback_eligible(e_ptr, nbytes) &&
             fallback_backend->score(file, buffer, size, file_offset, buffer_offset) >= 0) {
-            nbytes = fallback_backend->io(type, file, buffer, size, file_offset, buffer_offset);
+            nbytes = fallback_backend->io(type, std::move(file), std::move(buffer), size, file_offset,
+                                          buffer_offset);
         }
         else {
             throw;
@@ -61,5 +62,5 @@ BackendWithFallback::register_fallback_backend(std::shared_ptr<Backend> backend)
     else if (backend.get() == this) {
         throw std::invalid_argument("Cannot register a backend as it's own fallback.");
     }
-    fallback_backend = backend;
+    fallback_backend = std::move(backend);
 }

--- a/src/amd_detail/backend.cpp
+++ b/src/amd_detail/backend.cpp
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #include <system_error>
 #include <unistd.h>
+#include <utility>
 
 using namespace hipFile;
 

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -31,6 +31,7 @@
 #include <syslog.h>
 #include <system_error>
 #include <variant>
+#include <utility>
 
 using namespace hipFile;
 

--- a/src/amd_detail/backend/fallback.cpp
+++ b/src/amd_detail/backend/fallback.cpp
@@ -63,7 +63,8 @@ ssize_t
 Fallback::_io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                    hoff_t file_offset, hoff_t buffer_offset)
 {
-    return _io_impl(type, file, buffer, size, file_offset, buffer_offset, DefaultChunkSize);
+    return _io_impl(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset,
+                    DefaultChunkSize);
 }
 
 ssize_t

--- a/src/amd_detail/batch/batch.cpp
+++ b/src/amd_detail/batch/batch.cpp
@@ -126,7 +126,7 @@ BatchContext::submit_operations(const hipFileIOParams_t *params, unsigned num_pa
             Context<DriverState>::get()->getFileAndBuffer(param_copy->fh, param_copy->u.batch.devPtr_base);
         auto op = std::make_shared<BatchOperation>(std::move(param_copy), _buffer, _file);
 
-        pending_ops.push_back(op);
+        pending_ops.push_back(std::move(op));
     }
 
     // All submitted operations look valid at this point. Accept them.
@@ -150,7 +150,7 @@ BatchContextMap::createContext(unsigned capacity)
     // somehow deallocates this handle...
 
     std::unique_lock<std::shared_mutex> ulock{batch_mutex};
-    active_contexts[handle] = context;
+    active_contexts[handle] = std::move(context);
     return handle;
 }
 

--- a/test/amd_detail/batch/batch.cpp
+++ b/test/amd_detail/batch/batch.cpp
@@ -254,7 +254,7 @@ struct HipFileBatchContext : public HipFileUnopened {
         mock_driver_state = std::make_unique<StrictMock<MDriverState>>();
         _context          = batch_map.get(batch_map.createContext(_context_capacity));
         // May be overridden with EXPECT_CALL in the test.
-        EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillRepeatedly(Return(default_fb_pair));
+        EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillRepeatedly(Return(std::move(default_fb_pair)));
     }
 
     void TearDown() override

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -102,7 +102,7 @@ public:
 
     FastpathScoreExpectationsBuilder(StrictMock<MConfiguration> &mcfg, shared_ptr<StrictMock<MFile>> mfile,
                                      shared_ptr<StrictMock<MBuffer>> mbuffer)
-        : m_mcfg(mcfg), m_mfile(mfile), m_mbuffer(mbuffer)
+        : m_mcfg(mcfg), m_mfile(std::move(mfile)), m_mbuffer(std::move(mbuffer))
     {
     }
 

--- a/test/amd_detail/fastpath.cpp
+++ b/test/amd_detail/fastpath.cpp
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <system_error>
 #include <tuple>
+#include <utility>
 
 using namespace hipFile;
 using namespace testing;


### PR DESCRIPTION
Part of AIHIPFILE-161