### PR TITLE
Coverity: Don't use noexcept with unbufferedFd

### DIFF
--- a/src/amd_detail/file.cpp
+++ b/src/amd_detail/file.cpp
@@ -95,7 +95,7 @@ File::bufferedFd() const noexcept
 }
 
 optional<int>
-File::unbufferedFd() const noexcept
+File::unbufferedFd() const
 {
     if (m_unbuffered_fd) {
         return m_unbuffered_fd.value().get();

--- a/src/amd_detail/file.h
+++ b/src/amd_detail/file.h
@@ -88,7 +88,7 @@ public:
 
     virtual int                clientFd() const noexcept       = 0;
     virtual int                bufferedFd() const noexcept     = 0;
-    virtual std::optional<int> unbufferedFd() const noexcept   = 0;
+    virtual std::optional<int> unbufferedFd() const            = 0;
     virtual uint32_t           dioMemAlign() const noexcept    = 0;
     virtual uint32_t           dioOffsetAlign() const noexcept = 0;
     virtual bool               isBlockDevice() const noexcept  = 0;
@@ -121,7 +121,7 @@ public:
     /// @brief Get the unbuffered file descriptor for this file. Returns nullopt if the file does not support
     /// direct IO or if there was an error obtaining the unbuffered fd.
     /// @return The unbuffered file descriptor, or nullopt if not available
-    virtual std::optional<int> unbufferedFd() const noexcept override;
+    virtual std::optional<int> unbufferedFd() const override;
 
     /// @brief Get the memory (in bytes) alignment requirement for direct IO on this file. If the file does
     /// not support direct IO, this will return 0.


### PR DESCRIPTION
This uses optional and can throw std::bad_optional_access

Part of AIHIPFILE-161