### PR TITLE
Coverity: Init IoType class members

### DIFF
--- a/test/amd_detail/async.cpp
+++ b/test/amd_detail/async.cpp
@@ -397,8 +397,8 @@ INSTANTIATE_TEST_SUITE_P(HipFileAsyncSuite, HipFileReadWriteAsync, ::testing::Va
 struct FallbackAsyncIO : public HipFileOpened, public ::testing::WithParamInterface<IoType> {
     FallbackAsyncIO()
         : mfile{std::make_shared<StrictMock<MFile>>()}, mbuffer{std::make_shared<StrictMock<MBuffer>>()},
-          mstream{std::make_shared<StrictMock<MStream>>()}, size{1024 * 1024}, file_offset{0},
-          buffer_offset{0}, bytes_written{0}
+          mstream{std::make_shared<StrictMock<MStream>>()}, io_type{IoType::Read}, size{1024 * 1024},
+          file_offset{0}, buffer_offset{0}, bytes_written{0}
     {
     }
     void SetUp() override

--- a/test/amd_detail/backend.cpp
+++ b/test/amd_detail/backend.cpp
@@ -36,8 +36,8 @@ struct HipFileBackendWithFallback : public HipFileUnopened, ::testing::WithParam
     std::shared_ptr<StrictMock<DummyBackendWithFallback>> default_backend;
     std::shared_ptr<StrictMock<DummyFallbackBackend>>     fallback_backend;
 
-    IoType  io_type;
-    ssize_t successful_io_size = 0x1234;
+    IoType  io_type{IoType::Read};
+    ssize_t successful_io_size{0x1234};
 
     void SetUp() override
     {

--- a/test/amd_detail/fallback.cpp
+++ b/test/amd_detail/fallback.cpp
@@ -217,7 +217,7 @@ protected:
         io_type = GetParam();
     }
 
-    IoType io_type;
+    IoType io_type{IoType::Read};
 };
 
 TEST_P(FallbackParam, FallbackIoRejectedIfBackendIsDisabled)


### PR DESCRIPTION
Set to IoType::Read, which is a little weird but probably better than adding an IoType::Undefined value to the enum.

Part of AIHIPFILE-161